### PR TITLE
Update sample_deploy_specific_settings.py

### DIFF
--- a/docs/sample_deploy_specific_settings.py
+++ b/docs/sample_deploy_specific_settings.py
@@ -15,6 +15,17 @@ ADMINS = (
 # developer IPs
 INTERNAL_IPS = ('000.000.000.000',)
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'mediathread',
+        'HOST': 'localhost',
+        'PORT': 5432,  # using standard PostgreSQL installation
+        'USER': 'postgres',
+        'PASSWORD': 'postgres',
+    }
+}
+
 # custom authentication module
 # AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend',)
 


### PR DESCRIPTION
deploy_specific/settings.py will become a requirement, since there is now no default DATABASES defntion (should be stated in the README file)
