### PR TITLE
upgrade Pillow to 2.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ simplejson==3.4.0
 smartypants==1.6.0.2
 uuid==1.30
 psycopg2==2.5.1
-Pillow==1.7.8
+Pillow==2.3.0
 nose==1.3.0
 versiontools==1.9.1
 statsd==2.0.2


### PR DESCRIPTION
1.7.8 doesn't compile on Ubuntu 14.04
