### PR TITLE
add make targets for jshint and jscs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ media/js/sherdjs/
 media/CACHE
 libpeerconnection.log
 reports
+node_modules

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,5 @@
+{
+    "preset": "google",
+    "validateIndentation": 4,
+    "disallowTrailingWhitespace": true
+}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,18 @@ jenkins: ./ve/bin/python validate test flake8
 ./ve/bin/python: requirements.txt bootstrap.py virtualenv.py
 	./bootstrap.py
 
+jshint: node_modules/jshint/bin/jshint
+	./node_modules/jshint/bin/jshint media/js/app/
+
+jscs: node_modules/jscs/bin/jscs
+	./node_modules/jscs/bin/jscs media/js/app/
+
+node_modules/jshint/bin/jshint:
+	npm install jshint --prefix .
+
+node_modules/jscs/bin/jscs:
+	npm install jscs --prefix .
+
 test: ./ve/bin/python
 	$(MANAGE) jenkins
 

--- a/media/js/app/browserdetect.js
+++ b/media/js/app/browserdetect.js
@@ -8,7 +8,7 @@ function addLoadEvent(func) {
     window.onload = function() {
       oldonload();
       func();
-    }
+    };
   }
 }
 
@@ -16,9 +16,8 @@ function addLoadEvent(func) {
 var BrowserDetect = {
   init: function () {
     this.browser = this.searchString(this.dataBrowser) || "An unknown browser";
-    this.version = this.searchVersion(navigator.userAgent)
-      || this.searchVersion(navigator.appVersion)
-      || "an unknown version";
+    this.version = this.searchVersion(navigator.userAgent) ||
+					this.searchVersion(navigator.appVersion) || "an unknown version";
     this.OS = this.searchString(this.dataOS) || "an unknown OS";
   },
   searchString: function (data) {

--- a/media/js/app/dashboard/class_migrate.js
+++ b/media/js/app/dashboard/class_migrate.js
@@ -3,7 +3,7 @@
 
     var Asset = Backbone.Model.extend({
         initialize: function (attrs) {
-            this.id = attrs['id'];
+            this.id = attrs.id;
         }
     });
 
@@ -12,7 +12,7 @@
         total_sherdnotes: function () {
             var count = 0;
             this.forEach(function (obj) {
-                count += obj.get('annotation_count')
+                count += obj.get('annotation_count');
             });
             return count;
         }
@@ -20,7 +20,7 @@
 
     var Project = Backbone.Model.extend({
         initialize: function (attrs) {
-            this.id = attrs['id'];
+            this.id = attrs.id;
         }
     });
 

--- a/media/js/app/json2.js
+++ b/media/js/app/json2.js
@@ -158,12 +158,12 @@
 
 // Create a JSON object only if one does not already exist. We create the
 // methods in a closure to avoid creating global variables.
-
 if (!this.JSON) {
     this.JSON = {};
 }
 
 (function () {
+		"use strict";
 
     function f(n) {
         // Format integers to have at least two digits.

--- a/media/js/app/projects/projectpanel.js
+++ b/media/js/app/projects/projectpanel.js
@@ -742,7 +742,7 @@ ProjectPanelHandler.prototype.isDirty = function() {
     return self.projectModified ||
         self.tinyMCE.isDirty() ||
         (self.tinyMCE.editorId === tinyMCE.activeEditor.editorId &&
-                tinyMCE.activeEditor.isDirty())
+         tinyMCE.activeEditor.isDirty());
 };
 
 ProjectPanelHandler.prototype.updateRevisions = function() {


### PR DESCRIPTION
they're not integrated into the default target yet, since
they still have a lot of issues, but now you can at least
run 'make jscs' or 'make jshint' and start seeing what
needs to be fixed
