### PR TITLE
Allow COMPRESS_ROOT to be overridden in local_settings.py

### DIFF
--- a/mediathread/settings_test.py
+++ b/mediathread/settings_test.py
@@ -31,7 +31,10 @@ LETTUCE_APPS = (
 LETTUCE_DJANGO_APP = ['lettuce.django']
 INSTALLED_APPS = INSTALLED_APPS + LETTUCE_DJANGO_APP
 
-COMPRESS_ROOT = "/Users/sdreher/workspace/mediathread/media/"
+try:
+    from local_settings import COMPRESS_ROOT
+except ImportError:
+    COMPRESS_ROOT = "/Users/sdreher/workspace/mediathread/media/"
 
 
 # Full run


### PR DESCRIPTION
When running the selenium tests like this:

```
./manage.py harvest --settings=mediathread.settings_test mediathread/main/features
```

COMPRESS_ROOT needs to be set correctly.
