### PR TITLE
Resolving what appears to be a very old bug. When a user deletes an anno...

### DIFF
--- a/media/js/app/assetmgr/collection.js
+++ b/media/js/app/assetmgr/collection.js
@@ -92,14 +92,14 @@ var CollectionList = function (config) {
         return self.filter();
     });
     
-    jQuery(self.el).find("select.vocabulary").on('change select2-removed', function(evt) {
+    jQuery(self.el).on('change select2-removed', "select.vocabulary", function(evt) {
         var srcElement = evt.srcElement || evt.target || evt.originalTarget;
         var name = jQuery(srcElement).attr("name");
         self.current_records.active_filters[name] = jQuery(srcElement).val();
         return self.filter();
     });
 
-    jQuery(self.el).find("select.course-tags").on('change select2-removed', function() {
+    jQuery(self.el).on('change select2-removed', "select.course-tags", function() {
         var elt = jQuery(self.el).find("select.course-tags");
         self.current_records.active_filters.tag = jQuery(elt).val();
         return self.filter();

--- a/mediathread/djangosherd/models.py
+++ b/mediathread/djangosherd/models.py
@@ -313,7 +313,7 @@ class SherdNote(Annotation):
         return self.asset
 
     def delete(self):
-        Tag.objects.get_for_object(self).delete()
+        Tag.objects.update_tags(self, None)
         return Annotation.delete(self)
 
     def get_absolute_url(self):

--- a/mediathread/djangosherd/tests/test_model.py
+++ b/mediathread/djangosherd/tests/test_model.py
@@ -129,15 +129,28 @@ class SherdNoteTest(TestCase):
 
     def test_add_tag(self):
         ann = SherdNote.objects.get(id=15)
+        ann1 = SherdNote.objects.get(id=14)
+
         ann.add_tag("foo")
         ann.add_tag("bar")
         ann.save()
+
+        ann1.add_tag("foo")
+        ann1.add_tag("bar")
+        ann1.save()
 
         tags = ann.tags_split()
         self.assertEquals(len(tags), 3)
         self.assertEquals(tags[0].name, 'bar')
         self.assertEquals(tags[1].name, 'foo')
         self.assertEquals(tags[2].name, 'test_student_three')
+        ann.delete()
+
+        tags = ann1.tags_split()
+        self.assertEquals(len(tags), 3)
+        self.assertEquals(tags[0].name, 'bar')
+        self.assertEquals(tags[1].name, 'foo')
+        self.assertEquals(tags[2].name, 'tag1')
 
     def test_update_reference_in_string(self):
         text = ('<p><a href="/asset/2/annotations/10/">Nice Tie</a>'


### PR DESCRIPTION
Resolving what appears to be a very old bug...or possibly behavior changed in the Tag library?

When a user deletes an annotation, all the named Tags were deleted as well, not the TaggedItem instances.
