### PR TITLE
add Flickr API keys on upgrade bookmarklet screen

### DIFF
--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -126,6 +126,20 @@ def triple_homepage(request):
     return context
 
 
+@allow_http("GET")
+@login_required
+@rendered_with('assetmgr/upgrade_bookmarklet.html')
+def upgrade_bookmarklet(request):
+    context = {}
+    if getattr(settings, 'DJANGOSHERD_FLICKR_APIKEY', None):
+        # MUST only contain string values for now!!
+        # (see templates/assetmgr/bookmarklet.js to see why or fix)
+        context['bookmarklet_vars'] = {
+            'flickr_apikey': settings.DJANGOSHERD_FLICKR_APIKEY
+        }
+    return context
+
+
 @allow_http("GET", "POST")
 @rendered_with('dashboard/class_manage_sources.html')
 @faculty_only

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -139,8 +139,7 @@ urlpatterns = patterns(
 
     url(r'^taxonomy/', include('mediathread.taxonomy.urls')),
 
-    url(r'^upgrade/', TemplateView.as_view(
-        template_name="assetmgr/upgrade_bookmarklet.html")),
+    url(r'^upgrade/', 'mediathread.main.views.upgrade_bookmarklet'),
 
     ### Public Access ###
     (r'^s/', include('structuredcollaboration.urls')),


### PR DESCRIPTION
Hi,

I noticed a bug that causes the bookmarklet code on the homepage and bookmarklet code on the upgrade bookmarklet screen to be different. It happens because the `bookmarklet_vars` aren't set in the upgrade bookmarklet view (a regular template view) which causes collecting of Flickr images to fail because of the missing API keys. 

I've attached a fix for that bug.
