### PR TITLE
Firefox / Flowplayer / mp4 + native HTML5 video

### DIFF
--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -58,10 +58,6 @@ def django_settings(request):
     if request.course:
         context['is_course_faculty'] = request.course.is_faculty(request.user)
 
-    user_agent = request.META.get("HTTP_USER_AGENT")
-    if user_agent is not None and 'firefox' in user_agent.lower():
-        context['settings']['FIREFOX'] = True
-
     return context
 
 

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -12,11 +12,7 @@
         
         <script type="text/javascript" src='{% static "js/mustache/mustache.js" %}'></script>
 
-        {% if settings.FIREFOX %}
-            <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/lib/flowplayer/flowplayer-3.2.13.min.js"></script>
-        {% else %}
-            <script src="http://ccnmtl.columbia.edu/remote/flowplayer-5.5.0/flowplayer.min.js"></script>
-        {% endif %}
+        <script src="http://ccnmtl.columbia.edu/remote/flowplayer-5.5.0/flowplayer.min.js"></script>
 
         <script type="text/javascript" src='{% static "js/sherdjs/lib/OpenLayers-min.js" %}'></script>
         <script type="text/javascript" src="/jsi18n"></script>

--- a/mediathread/templates/djangosherd/annotator_resources.html
+++ b/mediathread/templates/djangosherd/annotator_resources.html
@@ -19,11 +19,7 @@
 <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/videotag.js"></script>
 <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/youtube.js"></script>
 
-{% if settings.FIREFOX %}
-    <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/flowplayer.js"></script>
-{% else %}
-    <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/flowplayer5.js"></script>
-{% endif %}
+<script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/flowplayer5.js"></script>
 
 <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/vimeo.js"></script>
 <script type="text/javascript" src="{{STATIC_URL}}js/sherdjs/src/video/views/kaltura.js"></script>


### PR DESCRIPTION
Pull the manual workaround that instantiated the old pseudostreaming capable Flowplayer when Firefox was detected.