### PR TITLE
Fix multiline string in help_text

### DIFF
--- a/mediathread/assetmgr/models.py
+++ b/mediathread/assetmgr/models.py
@@ -144,9 +144,9 @@ class Asset(models.Model):
     # make it json or somethin
     metadata_blob = models.TextField(
         blank=True,
-        help_text="""Be careful, this is a JSON blob and NOT a place to enter \
-        the description, etc, and is easy to format incorrectly. \
-        Make sure not to add any "'s.""")
+        help_text="Be careful, this is a JSON blob and NOT a place to enter "
+        "the description, etc, and is easy to format incorrectly. "
+        "Make sure not to add any \"'s.")
 
     # labels which determine the saving of an asset
     # in order of priority for which label is marked primary


### PR DESCRIPTION
When migrating my mediathread db, I was getting the message that told me to
run "makemigrations". When I did that, it created a migration for
Asset.metadata_blob with slightly different spacing in the help text.

Using a different method for making the multi-line string in this commit
prevents the migration prompt from appearing.