### PR TITLE
Project.save m2m issues

### DIFF
--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -135,6 +135,11 @@ class ProjectFactory(factory.DjangoModelFactory):
             if parent_collab.policy_record.policy_name == 'Assignment':
                 parent_collab.append_child(self)
 
+    @factory.post_generation
+    def participants(self, create, extracted, **kwargs):
+        if create:
+            self.participants.add(self.author)
+
 
 class CollaborationFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Collaboration

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -355,10 +355,6 @@ class Project(models.Model):
 
         return thread
 
-    def save(self, *args, **kwargs):
-        super(Project, self).save(*args, **kwargs)
-        self.participants.add(self.author)
-
     def visibility(self):
         """
         The project's status, one of "draft submitted complete".split()

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -30,6 +30,8 @@ class ProjectCreateView(LoggedInMixin, JSONResponseMixin, View):
                                          course=request.course,
                                          title="Untitled")
 
+        project.participants.add(request.user)
+
         policy_name = request.POST.get('publish', 'PrivateEditorsAreOwners')
         project.create_or_update_collaboration(policy_name)
 
@@ -83,6 +85,8 @@ def project_save(request, project_id):
         # this changes for version-tracking purposes
         projectform.instance.author = request.user
         projectform.save()
+
+        projectform.instance.participants.add(request.user)
 
         # update the collaboration
         policy_name = request.POST.get('publish', 'PrivateEditorsAreOwners')


### PR DESCRIPTION
Attempting to address reported behavior that author is not being added to participants in all cases. (https://pmt.ccnmtl.columbia.edu/item/101195/).

So far, this case is not reproducible. But, the overridden save could be at issue. (If a model is
not completely saved, it's m2m properties cannot be accessed). Switched to adding the author explicitly to participants in create/save views.

note: The author/participant architecture is a bit weird in general and should be revisited.