### PR TITLE
add pbr 1.2.0 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ linecache2==1.0.0  # traceback2
 argparse==1.3.0  # testtools
 traceback2==1.4.0  # testtools
 testtools==1.7.1  # python-subunit
+pbr>=0.11
 testscenarios==0.5.0  # python-subunit
 python-subunit==1.1.0  # lettuce
 lettuce==0.2.20


### PR DESCRIPTION
testscenarios 0.5.0 requires pbr>=0.11
the testscenarios 0.5.0 upgrade (https://github.com/ccnmtl/mediathread/pull/184) broke the jenkins build as it uses our pypi mirror.