### PR TITLE
faculty_only mixin implies logged in user

### DIFF
--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -38,6 +38,8 @@ def ajax_required(func):
 def faculty_only(func):
 
     def wrap(request, *args, **kwargs):
+        if request.user is None or request.user.is_anonymous():
+            return HttpResponseForbidden("forbidden")
         if not cached_course_is_faculty(request.course, request.user):
             return HttpResponseForbidden("forbidden")
         return func(request, *args, **kwargs)

--- a/mediathread/reports/tests/test_views.py
+++ b/mediathread/reports/tests/test_views.py
@@ -54,6 +54,11 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         self.add_citation(self.project, whole_item_annotation)
         self.add_citation(self.project, real_annotation)
 
+    def test_class_assignments_report_logged_out(self):
+        url = reverse('class-assignment-report', args=[self.assignment1.id])
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 403)
+
     def test_class_assignment_report(self):
         url = reverse('class-assignment-report', args=[self.assignment1.id])
 


### PR DESCRIPTION
see: https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/764/

if an anon hits a view protected only with faculty_only, we get a server error instead of a 403.

this fixes that issue.

arguably, views with @faculty_only probably ought to also have the @login_required
decorator so the user gets sent to the login page rather than a 403, but this ensures
that even if that isn't in place, we get a 403 instead of a 500