### PR TITLE
Fix z-index for jQueryUI dialog to work with openlayers

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4787,3 +4787,8 @@ div#taxonomy div.term-container div.term div.term-display div.actions {
 div#taxonomy div.term-container div.term:hover div.term-display div.actions {
     display: inline-block;
 }
+
+/* Make jquery-ui dialogs work with openlayers */
+.ui-dialog {
+    z-index: 1000 !important;
+}


### PR DESCRIPTION
This fixes a problem where the jQuery UI dialog on the
asset viewer isn't usable. See screenshot attached.

![2015-07-09-162056_666x416_scrot](https://cloud.githubusercontent.com/assets/59292/8605962/acccb680-2656-11e5-8024-96affe53fef7.png)

Also, I've based this change off `master`, should I base it off `fall2015`? I wasn't sure. 