### PR TITLE
:bug: Class references not updating for projects

### DIFF
--- a/mediathread/discussions/utils.py
+++ b/mediathread/discussions/utils.py
@@ -2,7 +2,6 @@ from courseaffils.models import Course
 from django.contrib.contenttypes.models import ContentType
 from threadedcomments.models import ThreadedComment
 
-from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from structuredcollaboration.models import Collaboration
 
 
@@ -51,25 +50,3 @@ def pretty_date(timestamp):
         ago = "(" + str(day_diff) + " days ago)"
 
     return "%s %s" % (timestamp.strftime("%m/%d/%Y %I:%M %p"), ago)
-
-
-def update_class_references(comment):
-    # update class references
-    notes = SherdNote.objects.references_in_string(comment.comment,
-                                                   comment.user)
-    if len(notes) < 1:
-        class NoNote:
-            asset = None
-        notes = [NoNote(), ]
-
-    for note in notes:
-        try:
-            disc, created = DiscussionIndex.objects.get_or_create(
-                participant=comment.user,
-                collaboration=comment.content_object,
-                asset=note.asset)
-            disc.comment = comment
-            disc.save()
-        except:
-            # some things may be deleted. pass
-            pass

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -18,8 +18,9 @@ from threadedcomments.util import annotate_tree_properties, fill_tree
 
 from mediathread.api import UserResource
 from mediathread.assetmgr.api import AssetResource
-from mediathread.discussions.utils import pretty_date, update_class_references
+from mediathread.discussions.utils import pretty_date
 from mediathread.djangosherd.api import SherdNoteResource
+from mediathread.djangosherd.models import DiscussionIndex
 from mediathread.mixins import faculty_only
 from mediathread.taxonomy.api import VocabularyResource
 from mediathread.taxonomy.models import Vocabulary
@@ -88,7 +89,10 @@ def discussion_create(request):
     disc_sc.content_object = new_threaded_comment
     disc_sc.save()
 
-    update_class_references(new_threaded_comment)
+    DiscussionIndex.update_class_references(
+        new_threaded_comment.comment, new_threaded_comment.user,
+        new_threaded_comment, new_threaded_comment.content_object,
+        new_threaded_comment.user)
 
     if not request.is_ajax():
         return HttpResponseRedirect("/discussion/%d/" %
@@ -214,9 +218,11 @@ def comment_save(request, comment_id, next_url=None):
 
     comment.save()
 
-    update_class_references(comment)
+    DiscussionIndex.update_class_references(comment.comment, comment.user,
+                                            comment, comment.content_object,
+                                            comment.user)
 
-    return {'comment': comment, }
+    return {'comment': comment}
 
 
 def threaded_comment_citations(all_comments, viewer):

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -1,4 +1,8 @@
 from datetime import datetime
+import json
+from random import choice
+from string import letters
+
 from django.conf import settings
 from django.contrib import comments
 from django.contrib.comments.models import COMMENT_MAX_LENGTH
@@ -9,20 +13,18 @@ from django.http import HttpResponse, HttpResponseForbidden, \
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
 from djangohelpers.lib import rendered_with, allow_http
+from threadedcomments import ThreadedComment
+from threadedcomments.util import annotate_tree_properties, fill_tree
+
 from mediathread.api import UserResource
 from mediathread.assetmgr.api import AssetResource
-from mediathread.discussions.utils import pretty_date
+from mediathread.discussions.utils import pretty_date, update_class_references
 from mediathread.djangosherd.api import SherdNoteResource
 from mediathread.mixins import faculty_only
 from mediathread.taxonomy.api import VocabularyResource
 from mediathread.taxonomy.models import Vocabulary
-from random import choice
-from string import letters
 from structuredcollaboration.models import Collaboration
 from structuredcollaboration.views import delete_collaboration
-from threadedcomments import ThreadedComment
-from threadedcomments.util import annotate_tree_properties, fill_tree
-import json
 
 
 @allow_http("POST")
@@ -85,6 +87,8 @@ def discussion_create(request):
 
     disc_sc.content_object = new_threaded_comment
     disc_sc.save()
+
+    update_class_references(new_threaded_comment)
 
     if not request.is_ajax():
         return HttpResponseRedirect("/discussion/%d/" %
@@ -209,6 +213,9 @@ def comment_save(request, comment_id, next_url=None):
             disc_sc.save()
 
     comment.save()
+
+    update_class_references(comment)
+
     return {'comment': comment, }
 
 

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models import Q
 from threadedcomments.models import ThreadedComment
 
-from mediathread.djangosherd.models import DiscussionIndex
 from structuredcollaboration.models import Collaboration
 
 
@@ -407,19 +406,6 @@ class Project(models.Model):
         """
         note_model = models.get_model('djangosherd', 'SherdNote')
         return note_model.objects.references_in_string(self.body, self.author)
-
-    def update_class_references(self):
-        note_model = models.get_model('djangosherd', 'SherdNote')
-        notes = note_model.objects.references_in_string(self.body, self.author)
-
-        for note in notes:
-            try:
-                DiscussionIndex.objects.get_or_create(
-                    participant=None,
-                    collaboration=self.get_collaboration(),
-                    asset=note.asset)
-            except:
-                pass  # some things may be deleted?
 
     @property
     def content_object(self):

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.models import Q
 from threadedcomments.models import ThreadedComment
 
+from mediathread.djangosherd.models import DiscussionIndex
 from structuredcollaboration.models import Collaboration
 
 
@@ -406,6 +407,19 @@ class Project(models.Model):
         """
         note_model = models.get_model('djangosherd', 'SherdNote')
         return note_model.objects.references_in_string(self.body, self.author)
+
+    def update_class_references(self):
+        note_model = models.get_model('djangosherd', 'SherdNote')
+        notes = note_model.objects.references_in_string(self.body, self.author)
+
+        for note in notes:
+            try:
+                DiscussionIndex.objects.get_or_create(
+                    participant=None,
+                    collaboration=self.get_collaboration(),
+                    asset=note.asset)
+            except:
+                pass  # some things may be deleted?
 
     @property
     def content_object(self):

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -37,6 +37,7 @@ class ProjectCreateView(LoggedInMixin, JSONResponseMixin, View):
 
         policy_name = request.POST.get('publish', 'PrivateEditorsAreOwners')
         project.create_or_update_collaboration(policy_name)
+        project.update_class_references()
 
         parent = request.POST.get("parent", None)
         if parent is not None:
@@ -98,6 +99,8 @@ def project_save(request, project_id):
         v_num = projectform.instance.get_latest_version()
         is_assignment = projectform.instance.is_assignment(request.course,
                                                            request.user)
+
+        projectform.instance.update_class_references()
 
         return HttpResponse(json.dumps({
             'status': 'success',

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -15,7 +15,7 @@ from djangohelpers.lib import allow_http
 from mediathread.api import CourseResource
 from mediathread.api import UserResource
 from mediathread.discussions.views import threaded_comment_json
-from mediathread.djangosherd.models import SherdNote
+from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from mediathread.mixins import ajax_required, LoggedInMixin, \
     RestrictedMaterialsMixin, AjaxRequiredMixin, JSONResponseMixin, \
     LoggedInFacultyMixin
@@ -36,8 +36,10 @@ class ProjectCreateView(LoggedInMixin, JSONResponseMixin, View):
         project.participants.add(request.user)
 
         policy_name = request.POST.get('publish', 'PrivateEditorsAreOwners')
-        project.create_or_update_collaboration(policy_name)
-        project.update_class_references()
+        collaboration = project.create_or_update_collaboration(policy_name)
+        DiscussionIndex.update_class_references(project.body,
+                                                None, None, collaboration,
+                                                project.author)
 
         parent = request.POST.get("parent", None)
         if parent is not None:
@@ -94,13 +96,16 @@ def project_save(request, project_id):
 
         # update the collaboration
         policy_name = request.POST.get('publish', 'PrivateEditorsAreOwners')
-        projectform.instance.create_or_update_collaboration(policy_name)
+        collaboration = projectform.instance.create_or_update_collaboration(
+            policy_name)
 
         v_num = projectform.instance.get_latest_version()
         is_assignment = projectform.instance.is_assignment(request.course,
                                                            request.user)
 
-        projectform.instance.update_class_references()
+        DiscussionIndex.update_class_references(projectform.instance.body,
+                                                None, None, collaboration,
+                                                projectform.instance.author)
 
         return HttpResponse(json.dumps({
             'status': 'success',


### PR DESCRIPTION
As part of the big collaboration refactoring, the class reference indexer was broken due to a reordering of events.

This fixes the issue by:
1. removing the ancient and rather inelegant universal post_save hook.
2. Calling explicit update_class_reference functions.

Ideally, the whole DiscussionIndex model would be factored out completely. But, one step at a time.

Selenium tests on another branch were added to demonstrate this issue (https://github.com/ccnmtl/mediathread/pull/206)