### PR TITLE
Always show clipform after inserting it - PMT #102299

### DIFF
--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -784,10 +784,11 @@
                     jQuery('select.vocabulary').select2({});
                     jQuery('#asset-details-annotations-current')
                         .fadeIn(function() {
-                            djangosherd.assetview.clipform.html
-                                .push('clipform-display', {
+                            djangosherd.assetview.clipform.html.push(
+                                'clipform-display', {
                                     asset: {}
                                 });
+                            jQuery('#clipform').show();
                         });
                     jQuery(window).trigger('resize');
                 });
@@ -859,6 +860,7 @@
                                 'clipform-display', {
                                     asset: {}
                                 });
+                            jQuery('#clipform').show();
                         });
                         jQuery(window).trigger('resize');
                     }
@@ -1169,10 +1171,11 @@
 
             var $elt = jQuery('#asset-workspace-panel-container');
             $elt.fadeIn('slow', function() {
-                djangosherd.assetview.clipform.html
-                    .push('clipform-display', {
+                djangosherd.assetview.clipform.html.push(
+                    'clipform-display', {
                         asset: {}
                     });
+                jQuery('#clipform').show();
 
                 if (self.active_annotation) {
                     djangosherd.assetview.clipform


### PR DESCRIPTION
The clipform gets inserted with `display: none;` set. This
causes it to be hidden in at least the case mentioned in the
referenced PMT.

This change calls `.show()` on the element each time it's inserted,
just to be safe.