### PR TITLE
Consolide Project Views

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -305,6 +305,15 @@ ul#projects li {
     clear: both;
 }
 
+#create-project-menu a {
+    margin-left: 6px;
+}
+
+#create-project-menu .divideLinks {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
 #create-project-menu input {
     font: 1em 'helvetica neue', helvetica, arial, sans-serif;
 	font-weight: bold;

--- a/media/js/app/projects/selectionassignment.js
+++ b/media/js/app/projects/selectionassignment.js
@@ -90,7 +90,7 @@
                     dataType: 'json',
                     data: data,
                     success: function (json) {
-                        window.location = json.project.url;
+                        window.location = json.context.project.url;
                     },
                     error: function() {
                         // do something useful here

--- a/media/templates/homepage.mustache
+++ b/media/templates/homepage.mustache
@@ -59,7 +59,7 @@
             <input type="submit" value="Create Discussion" />
         </form>
         {{/is_faculty}}
-        
+
         {{^is_faculty}}
             {{#assignments}}
                 <a data-id="{{id}}" class="linkRespond">

--- a/media/templates/homepage.mustache
+++ b/media/templates/homepage.mustache
@@ -42,18 +42,12 @@
     <div id="create-project-menu" style="display: none;">
         {{#is_faculty}}
         <form action="/project/create/" method="post">
-            <input type="hidden" name="title" />
             <input type="hidden" name="project_type" value="assignment"/>
-            <input type="submit" value="Create Assignment" />
+            <input type="submit" value="Create Composition Assignment" />
         </form>
-        <form action="/project/create/" method="post">
-            <input type="hidden" name="title" />
-            <input type="hidden" name="project_type" value="selection-assignment"/>
-            <input type="submit" value="Create Selection Assignment" />
-        </form>
+        <a href="/project/create/sa/">Create Selection Assignment</a>
         <hr class="divideLinks" />
         <form action="/project/create/" method="post">
-            <input type="hidden" name="title" />
             <input type="hidden" name="project_type" value="composition"/>
             <input type="submit" value="Create Composition" />
         </form>
@@ -76,7 +70,6 @@
             <hr class="divideLinks" />
     
             <form action="/project/create/" method="post">
-                <input type="hidden" name="title" />
                 <input type="hidden" name="project_type" value="composition"/>
                 <input type="submit" value="Create Composition" />
             </form>

--- a/mediathread/main/features/instructor.feature
+++ b/mediathread/main/features/instructor.feature
@@ -65,7 +65,7 @@ Feature: Instructor Dashboard
         
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         
@@ -88,7 +88,7 @@ Feature: Instructor Dashboard
         
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -185,8 +185,7 @@ class ProjectVisibleMixin(object):
 class ProjectEditableMixin(object):
     def dispatch(self, *args, **kwargs):
         project = get_object_or_404(Project, pk=kwargs.get('project_id', None))
-        if (project and
-                not project.can_edit(self.request.course, self.request.user)):
+        if (not project.can_edit(self.request.course, self.request.user)):
             return HttpResponseForbidden("forbidden")
-
+        self.project = project
         return super(ProjectEditableMixin, self).dispatch(*args, **kwargs)

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -185,7 +185,8 @@ class ProjectVisibleMixin(object):
 class ProjectEditableMixin(object):
     def dispatch(self, *args, **kwargs):
         project = get_object_or_404(Project, pk=kwargs.get('project_id', None))
-        if not project.can_edit(self.request.course, self.request.user):
+        if (project and
+                not project.can_edit(self.request.course, self.request.user)):
             return HttpResponseForbidden("forbidden")
 
         return super(ProjectEditableMixin, self).dispatch(*args, **kwargs)

--- a/mediathread/projects/features/assignment.feature
+++ b/mediathread/projects/features/assignment.feature
@@ -8,11 +8,11 @@ Feature: Assignment
         # Create an assignment from the home page
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         
-        When I click the Create Assignment button  
+        When I click the Create Composition Assignment button  
         
         Then I am at the Untitled page
         There is an open Assignment panel

--- a/mediathread/projects/features/composition.feature
+++ b/mediathread/projects/features/composition.feature
@@ -8,7 +8,7 @@ Feature: Composition
         # Create a project from the home page
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         
@@ -65,7 +65,7 @@ Feature: Composition
         # Create a project from the home page
         There is a Create button
         When I click the Create button
-        Then there is not a Create Assignment button
+        Then there is not a Create Composition Assignment button
         And there is a Create Composition button
         And there is not a Create Discussion button
         
@@ -122,7 +122,7 @@ Feature: Composition
         # Create a project from the home page
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         
@@ -157,7 +157,7 @@ Feature: Composition
         # Create a project from the home page
         There is a Create button
         When I click the Create button
-        Then there is not a Create Assignment button
+        Then there is not a Create Composition Assignment button
         And there is a Create Composition button
         And there is not a Create Discussion button
         

--- a/mediathread/projects/features/publishtoworld.composition.feature
+++ b/mediathread/projects/features/publishtoworld.composition.feature
@@ -10,7 +10,7 @@ Feature: Public Compositions
         Given the home workspace is loaded
             There is a Create button
             When I click the Create button
-            Then there is a Create Assignment button
+            Then there is a Create Composition Assignment button
             And there is a Create Composition button
             And there is a Create Discussion button
             

--- a/mediathread/projects/features/sliding_panels.feature
+++ b/mediathread/projects/features/sliding_panels.feature
@@ -8,7 +8,7 @@ Feature: Sliding Panels
         # Composition Editing
         There is a Create button
         When I click the Create button
-        Then there is a Create Assignment button
+        Then there is a Create Composition Assignment button
         And there is a Create Composition button
         And there is a Create Discussion button
         

--- a/mediathread/projects/forms.py
+++ b/mediathread/projects/forms.py
@@ -35,12 +35,15 @@ class ProjectForm(forms.ModelForm):
             'id': "id_participants_%s" % self.instance.id
         }
 
-        col = kwargs['instance'].get_collaboration()
-        if col:
-            pol = col.policy_record.policy_name
-            if pol not in dict(self.fields['publish'].choices):
-                self.fields['publish'].choices.append((pol, pol))
-            self.initial['publish'] = pol
+        if kwargs['instance']:
+            col = kwargs['instance'].get_collaboration()
+            if col:
+                pol = col.policy_record.policy_name
+                if pol not in dict(self.fields['publish'].choices):
+                    self.fields['publish'].choices.append((pol, pol))
+                self.initial['publish'] = pol
+        else:
+            self.instance = None
 
         if request.course.is_faculty(request.user):
             # Faculty
@@ -49,7 +52,7 @@ class ProjectForm(forms.ModelForm):
                  if choice[0] in PUBLISH_OPTIONS_FACULTY]
         else:
             # Student
-            if kwargs['instance'].assignment():
+            if kwargs['instance'] and kwargs['instance'].assignment():
                 # Assignment response
                 self.fields['publish'].choices = \
                     [choice for choice in self.fields['publish'].choices

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from threadedcomments.models import ThreadedComment
 
 from mediathread.assetmgr.models import Asset
-from mediathread.djangosherd.models import SherdNote, DiscussionIndex
+from mediathread.djangosherd.models import SherdNote
 from structuredcollaboration.models import Collaboration
 
 
@@ -229,13 +229,10 @@ class Project(models.Model):
     # -- at least, the instructor, if not the whole class
     submitted = models.BooleanField(default=False)
 
-    modified = models.DateTimeField('date modified',
-                                    editable=False,
+    modified = models.DateTimeField('date modified', editable=False,
                                     auto_now=True)
 
-    due_date = models.DateTimeField('due date',
-                                    null=True,
-                                    blank=True)
+    due_date = models.DateTimeField('due date', null=True, blank=True)
 
     ordinality = models.IntegerField(default=-1)
 
@@ -482,10 +479,6 @@ class Project(models.Model):
         col.save()
 
         self.collaboration_sync_group(col)
-
-        DiscussionIndex.update_class_references(
-            self.body, None, None, col, self.author)
-
         return col
 
     def create_or_update_item(self, item_id):
@@ -497,12 +490,11 @@ class Project(models.Model):
         except Asset.DoesNotExist:
             pass  # optional parameter
 
-    def create_or_update_parent(self, parent_id):
+    def set_parent(self, parent_id):
         try:
             parent = Project.objects.get(id=parent_id)
             if parent.is_assignment():
-                collaboration = parent.get_collaboration()
-                collaboration.append_child(self)
+                parent.get_collaboration().append_child(self)
         except Project.DoesNotExist:
             pass
 

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -214,18 +214,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(project.versions.count(), 2)
         self.assertIsNotNone(project.submitted_date())
 
-    def test_assignment_response_create_error(self):
-        self.client.login(username=self.student_one.username,
-                          password='test')
-
-        data = {u'participants': [self.student_one.id],
-                u'publish': [u'PrivateEditorsAreOwners'],
-                u'parent': 12345}
-
-        response = self.client.post('/project/create/', data,
-                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEquals(response.status_code, 404)
-
     def test_assignment_response_create(self):
         self.client.login(username=self.student_one.username,
                           password='test')
@@ -457,7 +445,7 @@ class SelectionAssignmenViewTest(MediathreadTestMixin, TestCase):
             project_type='selection-assignment')
 
     def test_view(self):
-        url = reverse('selection-assignment-view', args=[self.project.id])
+        url = reverse('project-workspace', args=[self.project.id])
 
         # anonymous
         response = self.client.get(url, {})

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -481,8 +481,9 @@ class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):
             policy='PrivateEditorsAreOwners',
             project_type='selection-assignment')
 
-    def test_access(self):
-        url = reverse('selection-assignment-edit', args=[self.project.id])
+    def test_get_edit(self):
+        url = reverse('selection-assignment-edit',
+                      args=[self.project.id])
 
         # anonymous
         response = self.client.get(url, {})
@@ -506,7 +507,16 @@ class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 200)
 
-    def test_post(self):
+    def test_get_create(self):
+        url = reverse('selection-assignment-create')
+
+        # faculty
+        self.client.login(username=self.instructor_one.username,
+                          password='test')
+        response = self.client.get(url, {})
+        self.assertEquals(response.status_code, 200)
+
+    def test_save(self):
         asset1 = AssetFactory.create(course=self.sample_course,
                                      primary_source='image')
         asset2 = AssetFactory.create(course=self.sample_course,

--- a/mediathread/projects/urls.py
+++ b/mediathread/projects/urls.py
@@ -11,6 +11,10 @@ urlpatterns = patterns(
     url(r'^create/sa/$', SelectionAssignmentEditView.as_view(), {},
         name='selection-assignment-create'),
 
+    url(r'^edit/sa/(?P<project_id>\d+)/$',
+        SelectionAssignmentEditView.as_view(), {},
+        name='selection-assignment-edit'),
+
     url(r'^create/$', ProjectCreateView.as_view(), {}, "project-create"),
 
     url(r'^view/(?P<project_id>\d+)/$',
@@ -18,10 +22,6 @@ urlpatterns = patterns(
 
     url(r'^view/(?P<project_id>\d+)/(?P<feedback>\w+)/$',
         ProjectWorkspaceView.as_view(), {}, name='project-workspace-feedback'),
-
-    url(r'^edit/sa/(?P<project_id>\d+)/$',
-        SelectionAssignmentEditView.as_view(), {},
-        name='selection-assignment-edit'),
 
     url(r'^save/(?P<project_id>\d+)/$',
         ProjectSaveView.as_view(), {},

--- a/mediathread/projects/urls.py
+++ b/mediathread/projects/urls.py
@@ -1,12 +1,15 @@
 from django.conf.urls import patterns, url
 
-from mediathread.projects.views import ProjectCreateView, ProjectDeleteView, \
-    ProjectSortView, SelectionAssignmentView, \
-    SelectionAssignmentEditView, ProjectSaveView, ProjectWorkspaceView
+from mediathread.projects.views import (
+    ProjectCreateView, ProjectDeleteView, ProjectSortView,
+    SelectionAssignmentEditView, ProjectSaveView, ProjectWorkspaceView)
 
 
 urlpatterns = patterns(
     'mediathread.projects.views',
+
+    url(r'^create/sa/$', SelectionAssignmentEditView.as_view(), {},
+        name='selection-assignment-create'),
 
     url(r'^create/$', ProjectCreateView.as_view(), {}, "project-create"),
 
@@ -16,13 +19,9 @@ urlpatterns = patterns(
     url(r'^view/(?P<project_id>\d+)/(?P<feedback>\w+)/$',
         ProjectWorkspaceView.as_view(), {}, name='project-workspace-feedback'),
 
-    url(r'^view/sa/(?P<project_id>\d+)/$',
-        SelectionAssignmentView.as_view(), {},
-        'selection-assignment-view'),
-
     url(r'^edit/sa/(?P<project_id>\d+)/$',
         SelectionAssignmentEditView.as_view(), {},
-        'selection-assignment-edit'),
+        name='selection-assignment-edit'),
 
     url(r'^save/(?P<project_id>\d+)/$',
         ProjectSaveView.as_view(), {},

--- a/mediathread/templates/projects/selection_assignment_edit.html
+++ b/mediathread/templates/projects/selection_assignment_edit.html
@@ -73,6 +73,7 @@
                     method="post">
                     
                     {% csrf_token %}
+                    <input type="hidden" name="project_type" value="selection-assignment" />
 
                     <h2>Edit Selection Assignment</h2>
                     <div data-page="1">

--- a/mediathread/templates/projects/selection_assignment_edit.html
+++ b/mediathread/templates/projects/selection_assignment_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-    {% if form.instance.title %}{{form.instance.title}}{% else %}New Assignment{% endif %}
+    {% if form.instance %}{{form.instance.title}}{% else %}Create Assignment{% endif %}
 {% endblock %}
 
 {% block css %}
@@ -65,7 +65,11 @@
         <div class="col-md-3 column-container">
             <div class="affix affix-top" data-spy="affix">
                 <form name='selection-assignment-edit'
-                    action="{% url 'project-save' form.instance.id %}"
+                    {% if form.instance %}
+                        action="{% url 'project-save' form.instance.id %}"
+                    {% else %}
+                        action="{% url 'project-create' %}"
+                    {% endif %}
                     method="post">
                     
                     {% csrf_token %}


### PR DESCRIPTION
**ProjectWorkspaceView + SelectionAssignmentView**
Initially, my thought was to separate out the SelectionAssignmentView into its own url/view. This proved to be somewhat problematic as MeTh feels projects (assignments, compositions, responses) live at a certain place. And, hacking out the Project.get_absolute_url function began to get messy. This PR unites the project view via a common CBV.

**SelectionAssignment creation**
SelectionAssignments are not created until valid properties are in place. The creation of empty projects is a MeTh anti-pattern that has caused much confusion.)


