### PR TITLE
Selection Assignment selections: extend access rules

### DIFF
--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -1069,6 +1069,7 @@
             var context = {
                 'asset-current': self.active_asset,
                 'vocabulary': self.vocabulary,
+                'readOnly': self.config.readOnly,
                 'lower': function() {
                     return function(text, render) {
                         return render(text).toLowerCase();

--- a/media/js/app/projects/selection_assignment_view.js
+++ b/media/js/app/projects/selection_assignment_view.js
@@ -36,6 +36,9 @@
             });
 
             this.citationView.openCitationById(null, options.itemId, null);
+            
+            // annotationlist is readonly by faculty and submitted students
+            var readOnly = options.responseId.length < 1 || options.submitted;
 
             if (jQuery('#asset-view-details').length > 0) {
                 window.annotationList.init({
@@ -44,7 +47,8 @@
                     'update_history': false,
                     'vocabulary': options.vocabulary,
                     'parentId': options.assignmentId,
-                    'projectId': options.responseId
+                    'projectId': options.responseId,
+                    'readOnly': readOnly
                 });
             }
         },

--- a/media/templates/asset_view_details.mustache
+++ b/media/templates/asset_view_details.mustache
@@ -13,11 +13,13 @@
     {{/annotation.editing}}>
 
     {{#asset-current}}
-      <a class="btn btn-default btn-sm create-selection right"
-        title="Create Selection"
-        onclick="return annotationList.newAnnotation();">
-        <img src="/media/img/icons/meth_addselection.png" />
-        Create</a>
+        {{^readOnly}}
+        <a class="btn btn-default btn-sm create-selection right"
+            title="Create Selection"
+            onclick="return annotationList.newAnnotation();">
+            <img src="/media/img/icons/meth_addselection.png" />
+            Create</a>
+        {{/readOnly}}
 
         <a class="btn btn-default btn-sm filter-selections right"
           onclick='return jQuery("#annotation-filter-menu").toggle();'>
@@ -47,6 +49,7 @@
           Selections
         </h2>
         {{^annotations}}
+        {{^readOnly}}
           <center>
             <br />
             <div>You have no selections on this item.</div>
@@ -59,6 +62,7 @@
               Create a selection
             </a>
           </center>
+          {{/readOnly}}
           {{/annotations}}
 
           {{#annotations}}

--- a/mediathread/djangosherd/api.py
+++ b/mediathread/djangosherd/api.py
@@ -1,11 +1,13 @@
 # pylint: disable-msg=R0904
+from tastypie import fields
+from tastypie.resources import ModelResource
+
 from mediathread.api import UserResource, TagResource
 from mediathread.assetmgr.models import Asset
 from mediathread.djangosherd.models import SherdNote
+from mediathread.projects.models import ProjectNote
 from mediathread.taxonomy.api import TermResource
 from mediathread.taxonomy.models import TermRelationship
-from tastypie import fields
-from tastypie.resources import ModelResource
 
 
 class SherdNoteResource(ModelResource):
@@ -40,11 +42,21 @@ class SherdNoteResource(ModelResource):
                 'title': bundle.obj.title
             }
 
-            bundle.data['editable'] = (bundle.request.user.id ==
-                                       getattr(bundle.obj, 'author_id', -1))
+            editable = (bundle.request.user.id ==
+                        getattr(bundle.obj, 'author_id', -1))
+            citable = bundle.request.GET.get('citable', '') == 'true'
 
-            if bundle.request.GET.get('citable', '') == 'true':
-                bundle.data['citable'] = True
+            # assumed: there is only one ProjectNote per annotation
+            reference = ProjectNote.objects.filter(
+                annotation__id=bundle.obj.id).first()
+            if reference:
+                # notes in a submitted response are not editable
+                editable = editable and not reference.project.submitted
+                citable = reference.project.can_cite(bundle.request.course,
+                                                     bundle.request.user)
+
+            bundle.data['editable'] = editable
+            bundle.data['citable'] = citable
 
             vocabulary = {}
             related = list(TermRelationship.objects.get_for_object(bundle.obj))

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -114,10 +114,6 @@ class RestrictedMaterialsMixin(object):
         (visible, hidden) = Project.objects.responses_by_course(
             request.course, self.record_viewer)
 
-        # @todo -- filter out notes associated with projects that aren't
-        # yet visible to peers. How to determine that? Grrr
-        # projects that cannot be read by a fellow student...
-
         pids = [project.id for project in hidden]
         pnotes = ProjectNote.objects.filter(project__id__in=pids)
         pnids = pnotes.values_list('annotation__id', flat=True)

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -471,6 +471,25 @@ class Project(models.Model):
         else:  # assignment.response_view_policy == 'never':
             return False
 
+    def can_cite(self, course, viewer):
+        # notes in an unsubmitted project are not citable
+        if not self.submitted:
+            return False
+
+        parent = self.assignment()
+
+        if (not parent or
+                parent.response_view_policy == RESPONSE_VIEW_ALWAYS[0]):
+            return True
+
+        if parent.response_view_policy == RESPONSE_VIEW_SUBMITTED[0]:
+            # a bit hacky...but should work unless we get collaborative
+            # do the visible responses == students
+            responses = parent.responses(course, viewer)
+            return len(course.students) == len(responses)
+
+        return False
+
     def collaboration_sync_group(self, collab):
         participants = self.participants.all()
 

--- a/mediathread/templates/projects/selection_assignment_view.html
+++ b/mediathread/templates/projects/selection_assignment_view.html
@@ -37,7 +37,8 @@
             responseId: '{{my_response.id}}',
             itemId: '{{item.id}}',
             itemJson: JSON.parse('{{item_json|escapejs}}'),
-            vocabulary: JSON.parse('{{vocabulary|escapejs}}')
+            vocabulary: JSON.parse('{{vocabulary|escapejs}}'),
+            submitted: {% if my_response and my_response.submitted %}true{% else %}false{% endif %}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
* stricter rules on when a user can read/edit/embed a selection.
* based on viewer's role, course settings, assignment response policy and response submit state.