### PR TITLE
SelectionAssignment + Course-level selection visibility

### DIFF
--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -194,6 +194,9 @@ class CourseSettingsView(LoggedInFacultyMixin, TemplateView):
             value = int(request.POST.get(key))
             request.course.add_detail(key, value)
 
+            if value == 0:
+                Project.objects.limit_response_policy(request.course)
+
         key = course_details.ITEM_VISIBILITY_KEY
         if key in request.POST:
             value = int(request.POST.get(key))

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -225,6 +225,12 @@ class ProjectManager(models.Manager):
             except:
                 pass
 
+    def limit_response_policy(self, course):
+        # All selection assignment response policy must be NEVER
+        projects = Project.objects.filter(
+            course=course, project_type=PROJECT_TYPE_SELECTION_ASSIGNMENT)
+        projects.update(response_view_policy=RESPONSE_VIEW_NEVER[0])
+
 
 class Project(models.Model):
     DEFAULT_TITLE = 'Untitled'
@@ -452,7 +458,7 @@ class Project(models.Model):
 
         # assignment response?
         parent = collaboration.get_parent()
-        if parent is None:
+        if parent is None or parent.content_object is None:
             return True
 
         # the author & faculty can always view a submitted response

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -8,7 +8,7 @@ from mediathread.djangosherd.models import SherdNote
 from mediathread.factories import MediathreadTestMixin, \
     AssetFactory, SherdNoteFactory, ProjectFactory
 from mediathread.projects.models import Project, RESPONSE_VIEW_NEVER, \
-    RESPONSE_VIEW_SUBMITTED
+    RESPONSE_VIEW_SUBMITTED, RESPONSE_VIEW_ALWAYS
 
 
 class ProjectTest(MediathreadTestMixin, TestCase):
@@ -327,6 +327,20 @@ class ProjectTest(MediathreadTestMixin, TestCase):
 
         Project.objects.reset_publish_to_world(self.sample_course)
         self.assertIsNone(public.public_url())
+
+    def test_limit_response_policy(self):
+        self.assertEquals(self.assignment.response_view_policy,
+                          RESPONSE_VIEW_ALWAYS[0])
+        self.assertEquals(self.selection_assignment.response_view_policy,
+                          RESPONSE_VIEW_ALWAYS[0])
+        Project.objects.limit_response_policy(self.sample_course)
+
+        assignment = Project.objects.get(id=self.assignment.id)
+        self.assertEquals(assignment.response_view_policy,
+                          RESPONSE_VIEW_ALWAYS[0])
+        assignment = Project.objects.get(id=self.selection_assignment.id)
+        self.assertEquals(assignment.response_view_policy,
+                          RESPONSE_VIEW_NEVER[0])
 
     def test_collaboration_sync_model(self):
         project = ProjectFactory.create(


### PR DESCRIPTION
If a course's selection visibility is turned off, update all selection assignments to response_view_policy = 'never'