### PR TITLE
Fix AttributeError when checking permission

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -447,7 +447,8 @@ class Project(models.Model):
     def can_read(self, course, viewer):
         # has the author published his work?
         collaboration = self.get_collaboration()
-        if not collaboration.permission_to('read', course, viewer):
+        if (collaboration is None) or \
+           (not collaboration.permission_to('read', course, viewer)):
             return False
 
         # assignment response?


### PR DESCRIPTION
After pulling the latest fall2015 changes, I was getting
this error when loading the homepage:

> AttributeError at /api/project/user/ccnmtl/
> 'NoneType' object has no attribute 'permission_to'
>
> 450.         if not collaboration.permission_to('read', course,
> viewer):
>
> (in mediathread/projects/models.py)

This change just checks to see if `collaboration` is `None` before
calling `permission_to` on it.

I'm not sure if this behavior is correct - maybe we should be returning
`True` when `collaboration` is `None`?