### PR TITLE
Enable jsonp response for is_logged_in view

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -763,3 +763,12 @@ class IsLoggedInDataViewTest(MediathreadTestMixin, TestCase):
         self.client.login(username=self.up.user.username, password='test')
         r = self.client.get(reverse('is_logged_in'))
         self.assertEqual(r.status_code, 200)
+
+    def test_get_when_logged_in_jsonp(self):
+        self.client.login(username=self.up.user.username, password='test')
+        r = self.client.get(reverse('is_logged_in'), {'callback': 'test'})
+
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'logged_in')
+        self.assertContains(r, 'course_selected')
+        self.assertContains(r, 'test')

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -480,4 +480,13 @@ class IsLoggedInDataView(View):
             d['youtube_apikey'] = settings.YOUTUBE_BROWSER_APIKEY
             d['flickr_apikey'] = settings.DJANGOSHERD_FLICKR_APIKEY
 
-        return HttpResponse(json.dumps(d), content_type='application/json')
+        json_data = json.dumps(d)
+
+        if 'callback' in request.REQUEST:
+            # JSONP
+            rendered = '{}({});'.format(request.REQUEST['callback'], json_data)
+            return HttpResponse(rendered,
+                                content_type='application/javascript')
+        else:
+            return HttpResponse(json_data,
+                                content_type='application/json')


### PR DESCRIPTION
To get around cross-origin problems with the chrome extension