### PR TITLE
Fix icon alignment (see screenshots)

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -2509,7 +2509,6 @@ div.gallery-item h4.asset_title {
 
 .actions {
     float: right;
-    margin: -4px -6px 0 0;
 }
 
 .actions a {


### PR DESCRIPTION
The mis-alignment was probably caused by the bootstrap upgrade.

This fixes the alignment of the question-mark icon on the homepage.

before:
![2015-08-14-151329_605x168_scrot](https://cloud.githubusercontent.com/assets/59292/9281995/4ce604bc-4297-11e5-8ed5-a1e414d6de36.png)

after:
![2015-08-14-151337_588x166_scrot](https://cloud.githubusercontent.com/assets/59292/9281998/51cfdb2e-4297-11e5-951b-540bc528d2bf.png)
