### PR TITLE
Allow auth cookies in CORS

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -285,6 +285,7 @@ ACCOUNT_ACTIVATION_DAYS = 7
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_METHODS = ('GET',)
+CORS_ALLOW_CREDENTIALS = True
 
 
 def default_url_processor(url, label=None, request=None):


### PR DESCRIPTION
This is for the mediathread-collect chrome extension.
The basic auth on mediathread.qa is preventing my xhr
request from the extension from going through, but I
think this option will allow it to work.