### PR TITLE
Check that jQuery element exists before cloning - PMT #102478

### DIFF
--- a/media/js/app/projects/selection_assignment_edit.js
+++ b/media/js/app/projects/selection_assignment_edit.js
@@ -155,6 +155,10 @@
             $overlay.addClass('hidden');
         },
         onGalleryItemSelect: function(evt) {
+            if (!this.hoverItem) {
+                return;
+            }
+
             var pk = jQuery(this.hoverItem).attr('data-id');
             jQuery('input[name="item"]').val(pk);
 


### PR DESCRIPTION
This fixes the JS error that occurs when the target element
that switches for the Selection Assignment doesn't exist (like
when the window is too narrow).