### PR TITLE
Selection Assignment Edit: Affix conflicting with instructions

### DIFF
--- a/media/js/app/projects/selection_assignment_edit.js
+++ b/media/js/app/projects/selection_assignment_edit.js
@@ -168,6 +168,9 @@
             jQuery('.selected-item div').replaceWith(clone);
 
             delete this.hoverItem;
+
+            // scroll to top of page
+            jQuery('body').scrollTop(0);
         }
     });
 }(jQuery));

--- a/mediathread/templates/projects/selection_assignment_edit.html
+++ b/mediathread/templates/projects/selection_assignment_edit.html
@@ -62,7 +62,7 @@
 <div class="selection-assignment">    
     <div class="row">
         <div class="col-md-3 column-container">
-            <div class="affix affix-top" data-spy="affix">
+            <div>
                 <form name="selection-assignment-edit"
                     {% if form.instance %}
                         action="{% url 'project-save' form.instance.id %}"


### PR DESCRIPTION
Remove the affix area as smaller screens displayed scrolling issues.
To alleviate the need for the affix section -- When selecting from the collection, scroll back to the top of the page.