### PR TITLE
Update wording to install Safari bookmarklet

### DIFF
--- a/mediathread/templates/assetmgr/install_bookmarklet.html
+++ b/mediathread/templates/assetmgr/install_bookmarklet.html
@@ -15,7 +15,7 @@
         <div id="safari" class="browser-instruction"> 
             <strong>Install Bookmarklet in Safari</strong>
             <ol>
-             <li>In the <b>View</b> menu, show the "Bookmarks Bar".</li><br />
+             <li>In the <b>View</b> menu, show the "Favorites Bar".</li><br />
               <li>Drag the link below onto your browser bookmarks toolbar</li>
             </ol>
         </div>


### PR DESCRIPTION
I'm on Safari 8.0.7 on Mac OS 10.10, and it looks like the "Bookmarks Bar" is now called
the "Favorites Bar".

![screen shot 2015-08-24 at 2 42 51 pm](https://cloud.githubusercontent.com/assets/59292/9449146/c0d65ef6-4a6e-11e5-96c7-795385db565b.png)
