### PR TITLE
Asset Workspace: Shorten link to original item source

### DIFF
--- a/media/templates/asset_sources.mustache
+++ b/media/templates/asset_sources.mustache
@@ -1,7 +1,7 @@
 <h2>Sources</h2>
 {{#asset-current}}
-  <h4>Item's Original Source:</h4>
-  <a href="{{sources.url.url}}">{{sources.url.url}}</a>
+  <h4><a href="{{sources.url.url}}">Item Permalink</a></h4>
+  
 
   {{#sources.xmeml}}
     <h4 class="metadata-title">Final Cut Pro</h4>
@@ -23,7 +23,7 @@
   {{/sources.xmeml}}
 
   {{#metadata}}
-    <h4>{{key}}</h4>
+    <h4><b>{{key}}</b></h4>
     <div>{{value}}</div>
   {{/metadata}}
 {{/asset-current}}

--- a/mediathread/assetmgr/features/single_asset_view.feature
+++ b/mediathread/assetmgr/features/single_asset_view.feature
@@ -26,8 +26,7 @@ Feature: Single Asset View
         
         # Verify the Sources tab
         When I click the "Source" link
-        Then I see "Item's Original Source"
-        And there is a "http://www.flickr.com/photos/ccnmtl/4049410921/" link
+        And there is an "Item Permalink" link
                         
         Finished using Selenium
         


### PR DESCRIPTION
very long urls broke the display