### PR TITLE
Fix Makefile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test: ./ve/bin/python
 harvest1: ./ve/bin/python
 	$(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/main/features
 	$(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/assetmgr/features
-    $(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/taxonomy/features
+	$(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/taxonomy/features
 
 harvest2: ./ve/bin/python
 	$(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/projects/features


### PR DESCRIPTION
This fixes this error I get when running `make runserver`:

> Makefile:28: *** missing separator (did you mean TAB instead of 8
> spaces?).  Stop.