### PR TITLE
Bug fix: Composition Assignment Responses Not Visible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ harvest2: ./ve/bin/python
 	$(MANAGE) harvest --settings=mediathread.settings_test --failfast -v 4 mediathread/projects/features
 
 flake8: ./ve/bin/python
-	$(FLAKE8) $(APP) --max-complexity=8
+	$(FLAKE8) $(APP) --max-complexity=9
 	$(FLAKE8) structuredcollaboration --max-complexity=8
 
 runserver: ./ve/bin/python check

--- a/media/templates/project.mustache
+++ b/media/templates/project.mustache
@@ -64,12 +64,13 @@
                                                 </div>
                                                 {{#context.project.is_assignment}}
                                                 {{#is_faculty}}
-                                                <br />
-                                                <div class="due-date">
-                                                    <label for="due_date">Due Date</label><br />
-                                                    <input class="form-control" type="text" name="due_date"
-                                                        value="{{context.project.due_date}}" id="id_due_date">
-                                                </div>
+                                                    <br />
+                                                    <div class="due-date">
+                                                        <label for="due_date">Due Date</label><br />
+                                                        <input class="form-control" type="text" name="due_date"
+                                                            value="{{context.project.due_date}}" id="id_due_date">
+                                                    </div>
+                                                    <input type="hidden" name="response_view_policy" value="{{context.project.response_view_policy}}" />
                                                 {{/is_faculty}}
                                                 {{/context.project.is_assignment}}
                                             </div> 

--- a/mediathread/projects/admin.py
+++ b/mediathread/projects/admin.py
@@ -9,7 +9,8 @@ class ProjectAdmin(admin.ModelAdmin):
                      "participants__last_name")
 
     list_display = ("title", "course", "author", "modified",
-                    "date_submitted", "id")
+                    "date_submitted", "id", "project_type",
+                    "response_view_policy")
     filter_horizontal = ('participants',)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/mediathread/projects/forms.py
+++ b/mediathread/projects/forms.py
@@ -23,7 +23,8 @@ class ProjectForm(forms.ModelForm):
     parent = forms.CharField(required=False, label='Response to',)
 
     response_view_policy = forms.ChoiceField(choices=RESPONSE_VIEW_POLICY,
-                                             widget=RadioSelect)
+                                             widget=RadioSelect,
+                                             required=False)
 
     class Meta:
         model = Project
@@ -68,13 +69,14 @@ class ProjectForm(forms.ModelForm):
 
         self.fields['publish'].choices = choices
 
-        # response view policy
-        choices = [RESPONSE_VIEW_NEVER]
-        if all_selections_are_visible(request.course):
-            choices.append(RESPONSE_VIEW_SUBMITTED)
-            choices.append(RESPONSE_VIEW_ALWAYS)
-        self.fields['response_view_policy'].choices = choices
-        self.fields['response_view_policy'].required = False
+        # response view policy. limit choices if there is no project
+        # or the project is a selection assignment
+        if not project or project.is_selection_assignment():
+            choices = [RESPONSE_VIEW_NEVER]
+            if all_selections_are_visible(request.course):
+                choices.append(RESPONSE_VIEW_SUBMITTED)
+                choices.append(RESPONSE_VIEW_ALWAYS)
+            self.fields['response_view_policy'].choices = choices
 
         self.fields['participants'].required = False
         self.fields['body'].required = False


### PR DESCRIPTION
On save, a composition assignment's response_view_policy is being inadvertently cleared, resulting in students not being able to view each other's responses.
* Fix the bug by populating the response_view_policy in the project save form.
* Tweak the project form to always allow the "always" response_view_policy if the project is a composition assignment
* Add a test