### PR TITLE
Selection Assignment Feedback UI: swap user name for username

### DIFF
--- a/media/js/app/projects/selection_assignment_view.js
+++ b/media/js/app/projects/selection_assignment_view.js
@@ -96,6 +96,7 @@
                                       .first();
                 if (elt.length) {
                     var username = jQuery(elt).data('username');
+                    ctx.username = username;
                     ctx.responseId = self.feedback[username].responseId;
                     ctx.comment = self.feedback[username].comment;
                     ctx.showFeedback = ctx.responseId === self.myResponse &&

--- a/media/templates/asset_feedback.mustache
+++ b/media/templates/asset_feedback.mustache
@@ -1,17 +1,17 @@
 <h4>
     <div class="color-box" style="background-color:{{color}}"></div>
-    <span class="group-title">{{title}}</span>
+    <span data-username="{{username}}" class="group-title">{{title}}</span>
 
     {{#comment}}
         {{#isFaculty}}
              <a href="javascript:void(0)" class="toggle-feedback small right"
-                data-target="annotation-feedback-{{title}}">
+                data-target="annotation-feedback-{{username}}">
                 <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> edit feedback
              </a>
         {{/isFaculty}}
         {{^isFaculty}}
              <a href="javascript:void(0)" class="toggle-feedback small right"
-                data-target="annotation-feedback-{{title}}">
+                data-target="annotation-feedback-{{username}}">
                 <span class="glyphicon glyphicon-paperclip" aria-hidden="true"></span> read feedback
              </a>
         {{/isFaculty}}
@@ -19,20 +19,20 @@
     {{^comment}}
         {{#isFaculty}}
              <a href="javascript:void(0)" class="toggle-feedback small right"
-                data-target="annotation-feedback-{{title}}">
+                data-target="annotation-feedback-{{username}}">
                 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> add feedback
              </a>
         {{/isFaculty}}
     {{/comment}}
 </h4>
 
-<div id="annotation-feedback-{{title}}" class="annotation-feedback"
+<div id="annotation-feedback-{{username}}" class="annotation-feedback"
     {{^showFeedback}}
     style="display: none"
     {{/showFeedback}}>
     
     {{#isFaculty}}
-    <form method="post" data-username="{{title}}" 
+    <form method="post" data-username="{{username}}" 
         action="{{#comment}}/discussion/comment/{{comment.id}}/{{/comment}}
                 {{^comment}}/discussion/create/{{/comment}}">
     {{/isFaculty}}
@@ -53,12 +53,12 @@
                 {{/comment}}
                 <button class="btn btn-primary btn-sm right save-feedback">Save Feedback</button>
                 <button class="btn btn-default btn-sm right toggle-feedback"
-                    data-target="annotation-feedback-{{title}}">Cancel</button>
+                    data-target="annotation-feedback-{{username}}">Cancel</button>
             {{/isFaculty}}
             
             {{^isFaculty}}
                 <button class="btn btn-default btn-sm right toggle-feedback"
-                    data-target="annotation-feedback-{{title}}">Close</button>
+                    data-target="annotation-feedback-{{username}}">Close</button>
             {{/isFaculty}}            
             <div class="clearfix"></div>
             


### PR DESCRIPTION
Spaces were mucking up the toggle display. (Our testing didn't use users with first name/last name. Grrr.)