### PR TITLE
Asset.primary: resolving possible cache misses

### DIFF
--- a/mediathread/assetmgr/models.py
+++ b/mediathread/assetmgr/models.py
@@ -179,9 +179,11 @@ class Asset(models.Model):
     @property
     def primary(self):
         key = "%s:primary" % (self.id)
-        if key not in cache:
-            cache.set(key, self.source_set.get(primary=True))
-        return cache.get(key)
+        the_primary = cache.get(key)
+        if the_primary is None:
+            the_primary = self.source_set.get(primary=True)
+            cache.set(key, the_primary)
+        return the_primary
 
     @property
     def thumb_url(self):


### PR DESCRIPTION
Sentry is reporting some strange-ish errors related to an Asset's primary source. The reported error is "AttributeError: 'NoneType' object has no attribute 'is_audio'" at Ln 216. But it appears primary was valid at Ln. 214. None a few lines before. I reordered the code to prevent any odd cache miss/race condition situations.

<img width="405" alt="screen shot 2015-09-17 at 1 52 07 pm" src="https://cloud.githubusercontent.com/assets/141369/9943720/253eef44-5d51-11e5-9977-d12f9a2284ad.png">