### PR TITLE
Fix AnnotationList colorbox display

### DIFF
--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -297,6 +297,11 @@
             self.updateAnnotationList();
         };
 
+        this.rgb = function(color) {
+            return 'rgb(' + parseInt(color.r, 10) + ',' +
+                parseInt(color.g, 10) + ',' + parseInt(color.b, 10) + ')';
+        };
+
         this.updateAnnotationList = function() {
             var frm = document.forms['annotation-list-filter'];
             if (!frm) {
@@ -320,7 +325,8 @@
                     var titles = self.layers[grouping].color_by(ann);
                     for (var j = 0; j < titles.length; j++) {
                         var title = titles[j];
-                        var color = DjangoSherd_Colors.get(title);
+                        var color = self.rgb(DjangoSherd_Colors.get(title));
+
                         /// add the annotation onto the layer w/the right color
                         if (ann.annotation) {
                             self.layers[grouping].add(


### PR DESCRIPTION
A [DjangoSherd_Colors refactoring] (https://github.com/ccnmtl/SherdJS/pull/35/files#diff-3afa41cea26f428c7c0f9eca0e936656) inadvertently resulted in empty colorboxes next to a student's name or a tag.
<img width="348" alt="screen shot 2015-10-06 at 3 26 35 pm" src="https://cloud.githubusercontent.com/assets/141369/10320046/5a5f9e42-6c3f-11e5-99ea-faaf53a591a3.png">

Fixed by readding the code that composes the rgb() style.
 