### PR TITLE
Add link to install chrome extension - PMT #103376

### DIFF
--- a/mediathread/templates/assetmgr/install_bookmarklet.html
+++ b/mediathread/templates/assetmgr/install_bookmarklet.html
@@ -1,26 +1,26 @@
-        <div id="firefox" class="browser-instruction"> 
-            <strong>Install Bookmarklet in Firefox</strong>
+        <div id="firefox-instruction" class="browser-instruction">
+            <strong>How to install the bookmarklet in Firefox</strong>
             <ol>
               <li>In the <b>View</b> menu, show the "Bookmarks"  toolbar.</li><br />
               <li>Drag the link below onto your browser bookmarks toolbar.</li>
             </ol>
         </div>
-        <div id="ie" class="browser-instruction">
-            <strong>Install Bookmarklet in Internet Explorer</strong>
+        <div id="ie-instruction" class="browser-instruction">
+            <strong>How to install the bookmarklet in Internet Explorer</strong>
             <ol>
               <li>Right-click on the blue bookmarklet button below.</li>  
               <li>and choose <b>Add to Favorites</b></li>
             </ol>
         </div>
-        <div id="safari" class="browser-instruction"> 
-            <strong>Install Bookmarklet in Safari</strong>
+        <div id="safari-instruction" class="browser-instruction">
+            <strong>How to install the bookmarklet in Safari</strong>
             <ol>
              <li>In the <b>View</b> menu, show the "Favorites Bar".</li><br />
               <li>Drag the link below onto your browser bookmarks toolbar</li>
             </ol>
         </div>
-        <div id="chrome" class="browser-instruction"> 
-            <strong>Install Bookmarklet in Chrome</strong>
+        <div id="chrome-instruction" class="browser-instruction">
+            <strong>How to install the bookmarklet in Chrome</strong>
             <ol>
               <li>Under the <b>Tools</b> menu (the Wrench), show the "Bookmarks bar".</li><br />
               <li>Drag the link below onto your browser bookmarks toolbar:  <br />Collect w/Mediathread</li>
@@ -31,18 +31,18 @@
             var u = navigator.userAgent;
             if (/Trident/.test(u)) {
                 jQuery('.browser-instruction').hide();
-                jQuery('#ie').show();
+                jQuery('#ie-instruction').show();
             } else if (/Chrome/.test(u)) {
                 jQuery('.browser-instruction').hide();
-                jQuery('#chrome').show();
+                jQuery('#chrome-instruction').show();
             } else if (/Safari/.test(u)) {
                 jQuery('.browser-instruction').hide();
-                jQuery('#safari').show();
+                jQuery('#safari-instruction').show();
             } else if (/MSIE/.test(u)) {
                 jQuery('.browser-instruction').hide();
-                jQuery('#ie').show();
+                jQuery('#ie-instruction').show();
             } else if (/Gecko/.test(u)) {
                 jQuery('.browser-instruction').hide();
-                jQuery('#firefox').show();
+                jQuery('#firefox-instruction').show();
             }
         </script>

--- a/mediathread/templates/assetmgr/install_chrome_extension.html
+++ b/mediathread/templates/assetmgr/install_chrome_extension.html
@@ -1,0 +1,44 @@
+<div id="chrome-install-container" class="hidden">
+    <h4><strong>Install Chrome extension</strong></h4>
+    <p>
+        Use Mediathread's Google Chrome extension to import media
+        from various sites.
+    </p>
+    <button id="chrome-install-button"
+            class="btn btn-primary">
+        + Add to Chrome
+    </button>
+    <hr />
+</div>
+
+<script>
+(function() {
+    var markAsInstalled = function($button) {
+        $button.text('Installed.');
+        $button.removeClass('btn-primary');
+        $button.addClass('btn-default disabled');
+    };
+
+    jQuery(document).ready(function() {
+        var $button = jQuery('#chrome-install-button');
+        $button.on('click', function(e) {
+            if (jQuery(this).hasClass('disabled')) {
+                return;
+            }
+            chrome.webstore.install(
+                'https://chrome.google.com/webstore/detail/gambcgmmppeklfmbahomokogelnaffbi',
+                function() {
+                    // Success handler
+                    markAsInstalled($button);
+                }
+            );
+        });
+
+        // Show the install container on chrome
+        var isChrome = !!(window.chrome && chrome.webstore);
+        if (isChrome) {
+            jQuery('#chrome-install-container').removeClass('hidden');
+        }
+    });
+})();
+</script>

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -28,6 +28,9 @@
 
         {% block uncompressable_css %}
         {% endblock %}
+
+        <link rel="chrome-webstore-item"
+              href="https://chrome.google.com/webstore/detail/gambcgmmppeklfmbahomokogelnaffbi">
     </head>
 
     {% course_role for request.user in course as role_in_course %}

--- a/mediathread/templates/homepage.html
+++ b/mediathread/templates/homepage.html
@@ -272,6 +272,7 @@
                         <div class="arrowIcon left"></div>
                     </a>
                     <div class="arrowContent" id="import_collection" style="display: none">
+                        {% include "assetmgr/install_chrome_extension.html" %}
                         <p>
                             Use the Mediathread Bookmarklet to import images and video from any web page containing Mediathread-friendly items.                                
                             

--- a/terrain.py
+++ b/terrain.py
@@ -334,7 +334,10 @@ def i_cancel_the_action(step):
     dialog = world.browser.find_element_by_id("dialog-confirm").parent
     btns = dialog.find_elements_by_tag_name("button")
     for btn in btns:
-        span = btn.find_element_by_css_selector("span.ui-button-text")
+        try:
+            span = btn.find_element_by_css_selector("span.ui-button-text")
+        except NoSuchElementException:
+            continue
         if span.text == "Cancel":
             btn.click()
             time.sleep(2)
@@ -352,7 +355,10 @@ def i_confirm_the_action(step):
     dialog = world.browser.find_element_by_id("dialog-confirm").parent
     btns = dialog.find_elements_by_tag_name("button")
     for btn in btns:
-        span = btn.find_element_by_css_selector("span.ui-button-text")
+        try:
+            span = btn.find_element_by_css_selector("span.ui-button-text")
+        except NoSuchElementException:
+            continue
         if span.text == "OK":
             btn.click()
             wait = ui.WebDriverWait(world.browser, 5)


### PR DESCRIPTION
I followed these instructions to add a button to mediathread
to install the extension:
https://developer.chrome.com/webstore/inline_installation

Note that because this only works on "Verified domains", you
need to be on a *.ccnmtl.columbia.edu domain to test this.

Because http://ccnmtl.columbia.edu/ happened to be registered
under google webmaster tools as the ccnmtl@gmail.com user,
I was able to connect it up to the chrome extension in the developer
dashboard.

![2015-10-12-101646_317x213_scrot](https://cloud.githubusercontent.com/assets/59292/10430092/501d2fb8-70cb-11e5-9742-c39518a75e10.png)

