### PR TITLE
Add bookmarklet error when scripts fail to load - PMT #103532

### DIFF
--- a/mediathread/templates/assetmgr/bookmarklet.html
+++ b/mediathread/templates/assetmgr/bookmarklet.html
@@ -10,26 +10,63 @@ jQuery(document).ready(function() {
             'var sb = window.SherdBookmarkletOptions;',
             'if (!sb) {',
                 'sb = window.SherdBookmarkletOptions = {};',
-                'sb["action"]="jump";',
+                'sb["action"] = "jump";',
             '}',
+
             'sb["host_url"] = "https://" + host + "/save/?";',
             {% for k,v in bookmarklet_vars.items %}
-                'sb["{{k}}"]="{{v}}";',
+                'sb["{{k}}"] = "{{v}}";',
             {% endfor %}
+
             'var r4 = function() {',
-                'return "&nocache="+Number(new Date());',
+                'return "&nocache=" + Number(new Date());',
             '};',
+
             'if (b) {',
+                /**
+                 * loadError is triggered when any of the scripts that
+                 * the bookmarklet relies on fail to load. This can occur
+                 * if a site has set up its Content-Security-Policy to
+                 * prevent javascript from external domains from being
+                 * loaded, as an attempt to address cross-site scripting
+                 * attacks.
+                 *
+                 * When this error happens, we want to tell users
+                 * what's going on, and let them know they can get
+                 * around this problem by using the Mediathread
+                 * browser extension (currently only available on
+                 * Chrome).
+                 */
+                'var loadError = function(oError) {',
+                    'alert("',
+                        'The bookmarklet encountered a ',
+                        'loading error, probably due to ',
+                        "this website's security policy. ",
+                        "Please try using Mediathread's browser extension ",
+                        'instead."',
+                    ');',
+                    'throw new URIError("The script " + ',
+                        'oError.target.src + " is not accessible.");',
+                '};',
+
+                // Load Mediathread logged-in status
                 'var x = document.createElement("script");',
+                'x.onerror = loadError;',
                 'x.src = "https://" + host + user_url + r4();',
                 'b.appendChild(x);',
+
+                // Load the main bookmarklet code
                 'var z = document.createElement("script");',
-                'z.src = "https://" + host + bookmarklet_url+r4();',
+                'z.onerror = loadError;',
+                'z.src = "https://" + host + bookmarklet_url + r4();',
                 'b.appendChild(z);',
+
+                // Load jQuery
                 'var y = document.createElement("script");',
+                'y.onerror = loadError;',
                 'y.src = "https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js";',
-                'var onload = (/MSIE/.test(navigator.userAgent))?"onreadystatechange":"onload";',
-                'y[onload]=function(){',
+                'var onload = (/MSIE/.test(navigator.userAgent)) ? "onreadystatechange" : "onload";',
+                'y[onload] = function() {',
                     'var jQ = sb.jQuery = jQuery.noConflict(true);',
                     'if (sb && sb.onJQuery) {',
                         'sb.onJQuery(jQ);',


### PR DESCRIPTION
This is my first pass at addressing the content-security-policy failures in the bookmarklet. We will talk about this more in the Mediathread meeting.

In particular, I would like to clarify there how we should direct users to the extension from the error message, and whether or not a simple alert popup is sufficient.