### PR TITLE
Course Settings: Selection Visibility Bug Fix

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -626,6 +626,23 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
         self.assertFalse(all_items_are_visible(self.sample_course))
         self.assertFalse(all_selections_are_visible(self.sample_course))
 
+    def test_post_disabled_selection_visibility(self):
+        self.client.login(username=self.instructor_one.username,
+                          password='test')
+        data = {course_details.ITEM_VISIBILITY_KEY: 0}
+
+        response = self.client.post('/dashboard/settings/', data)
+        self.assertEquals(response.status_code, 302)
+
+        # unchanged from defaults
+        self.assertEquals(course_information_title(self.sample_course),
+                          'From Your Instructor')
+        self.assertFalse(allow_public_compositions(self.sample_course))
+
+        # updated
+        self.assertFalse(all_items_are_visible(self.sample_course))
+        self.assertFalse(all_selections_are_visible(self.sample_course))
+
 
 class CourseManageSourcesViewTest(MediathreadTestMixin, TestCase):
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -166,13 +166,13 @@ class CourseSettingsView(LoggedInFacultyMixin, TemplateView):
         context[key] = int(self.request.course.get_detail(key,
                            course_details.ALLOW_PUBLIC_COMPOSITIONS_DEFAULT))
 
-        key = course_details.SELECTION_VISIBILITY_KEY
-        context[key] = int(self.request.course.get_detail(key,
-                           course_details.SELECTION_VISIBILITY_DEFAULT))
-
         key = course_details.ITEM_VISIBILITY_KEY
         context[key] = int(self.request.course.get_detail(key,
                            course_details.ITEM_VISIBILITY_DEFAULT))
+
+        key = course_details.SELECTION_VISIBILITY_KEY
+        context[key] = int(self.request.course.get_detail(key,
+                           course_details.SELECTION_VISIBILITY_DEFAULT))
 
         key = course_details.COURSE_INFORMATION_TITLE_KEY
         context[key] = self.request.course.get_detail(
@@ -186,18 +186,21 @@ class CourseSettingsView(LoggedInFacultyMixin, TemplateView):
             value = request.POST.get(key)
             request.course.add_detail(key, value)
 
-        key = course_details.SELECTION_VISIBILITY_KEY
-        if key in request.POST:
-            value = int(request.POST.get(key))
-            request.course.add_detail(key, value)
-
-            if value == 0:
-                Project.objects.limit_response_policy(request.course)
-
         key = course_details.ITEM_VISIBILITY_KEY
         if key in request.POST:
             value = int(request.POST.get(key))
             request.course.add_detail(key, value)
+
+            key = course_details.SELECTION_VISIBILITY_KEY
+            if key in request.POST:
+                value = int(request.POST.get(key))
+            else:
+                value = 0
+
+            request.course.add_detail(key, value)
+
+            if value == 0:
+                Project.objects.limit_response_policy(request.course)
 
         key = course_details.ALLOW_PUBLIC_COMPOSITIONS_KEY
         if key in request.POST:

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -233,9 +233,8 @@ class ProjectManager(models.Manager):
                 pass
 
     def limit_response_policy(self, course):
-        # All selection assignment response policy must be NEVER
-        projects = Project.objects.filter(
-            course=course, project_type=PROJECT_TYPE_SELECTION_ASSIGNMENT)
+        # Update response policy to be NEVER
+        projects = Project.objects.filter(course=course)
         projects.update(response_view_policy=RESPONSE_VIEW_NEVER[0])
 
 

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -352,7 +352,7 @@ class ProjectTest(MediathreadTestMixin, TestCase):
 
         assignment = Project.objects.get(id=self.assignment.id)
         self.assertEquals(assignment.response_view_policy,
-                          RESPONSE_VIEW_ALWAYS[0])
+                          RESPONSE_VIEW_NEVER[0])
         assignment = Project.objects.get(id=self.selection_assignment.id)
         self.assertEquals(assignment.response_view_policy,
                           RESPONSE_VIEW_NEVER[0])
@@ -455,12 +455,12 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         self.assertFalse(self.project_class_shared.can_read(
             self.alt_course, self.alt_instructor))
 
-    def test_can_read_selection_assignment(self):
+    def can_read_assignment_response(self, parent):
         # always
         response = ProjectFactory.create(
             course=self.sample_course, author=self.student_one,
             policy='PublicEditorsAreOwners',
-            parent=self.selection_assignment)
+            parent=parent)
 
         self.assertTrue(response.can_read(
             self.sample_course, self.student_one))
@@ -470,9 +470,9 @@ class ProjectTest(MediathreadTestMixin, TestCase):
             self.sample_course, self.instructor_one))
 
         # never
-        self.selection_assignment.response_view_policy = \
+        parent.response_view_policy = \
             RESPONSE_VIEW_NEVER[0]
-        self.selection_assignment.save()
+        parent.save()
 
         self.assertTrue(response.can_read(
             self.sample_course, self.student_one))
@@ -482,9 +482,9 @@ class ProjectTest(MediathreadTestMixin, TestCase):
             self.sample_course, self.instructor_one))
 
         # submitted
-        self.selection_assignment.response_view_policy = \
+        parent.response_view_policy = \
             RESPONSE_VIEW_SUBMITTED[0]
-        self.selection_assignment.save()
+        parent.save()
 
         self.assertTrue(response.can_read(
             self.sample_course, self.student_one))
@@ -496,7 +496,7 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         # student two created a response
         response2 = ProjectFactory.create(
             course=self.sample_course, author=self.student_two,
-            parent=self.selection_assignment)
+            parent=parent)
         self.assertFalse(response.can_read(
             self.sample_course, self.student_two))
 
@@ -506,6 +506,12 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         response2.save()
         self.assertTrue(response.can_read(
             self.sample_course, self.student_two))
+
+    def test_can_read_selection_assignment_response(self):
+        self.can_read_assignment_response(self.selection_assignment)
+
+    def test_can_read_composition_assignment_response(self):
+        self.can_read_assignment_response(self.assignment)
 
     def test_unresponded_assignments(self):
         lst = Project.objects.unresponded_assignments(self.sample_course,


### PR DESCRIPTION
The selection visibility was not being properly set when
item-level visibility was set to False. At issue: selection
visibility is set to "False" and disabled in the interface. On
post, the disabled radio button value is not sent to the server.
Resolved + added tests