### PR TITLE
Fix spacing on recommended sources panel

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -758,11 +758,7 @@ div.column-contents {
 }
 
 .recommend_source {
-    display: block;
-    clear: both; 
-    float: left;
-    padding: 5px 0;
-    margin: 5px 0;
+    padding: 10px 0;
     min-height: 24px;
     width: 100%;
     border-bottom: solid 1px #ccc;
@@ -770,11 +766,10 @@ div.column-contents {
 
 .source_thumb {
     float: left;
-    margin: 0 10px 0 0;
 }
 
 .source_title {
-    margin: 0 20px 0 0;
+    margin: 10px;
 }
 
 #coursefilter {

--- a/mediathread/templates/homepage.html
+++ b/mediathread/templates/homepage.html
@@ -339,13 +339,14 @@
                             {% if collection.thumb_url %}
                                 <div class="source_thumb">
                                     <a href="/explore/redirect/{{collection.id}}/">
-                                        <img src="{{collection.thumb_url}}" alt="thumbnail image" class="collection-link" />
+                                        <img src="{{collection.thumb_url}}" class="collection-link" />
                                     </a>
                                 </div>
                             {% endif %}
                             <div class="source_title">
                                 <a href="/explore/redirect/{{collection.id}}/" class="collection-link">{{collection.title}}</a>
                             </div>
+                            <div class="clearfix"></div>
                         </div>
                     {% endfor %}                        
                 </div>


### PR DESCRIPTION
The text was on a different level than the logos here, and
there was different spacing below and above each section.

before:
![2015-10-30-093345_284x396_scrot](https://cloud.githubusercontent.com/assets/59292/10846962/a9d99e70-7ee9-11e5-9569-7d82b9579301.png)

after:
![2015-10-30-093334_286x319_scrot](https://cloud.githubusercontent.com/assets/59292/10846964/af6b3aba-7ee9-11e5-866f-22358917638a.png)
