### PR TITLE
Fix upside-down project page text in chrome 48 - PMT #103619

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -1008,7 +1008,6 @@ table#sliding-content-container tr td.panhandle-stripe {
 
 table#sliding-content-container tr td.panhandle-stripe div.label {
     color: #fff;
-    writing-mode:tb-rl;
     -webkit-transform:rotate(90deg);
     -moz-transform:rotate(90deg);
     -o-transform: rotate(90deg);


### PR DESCRIPTION
before:
![2015-10-30-103727_237x243_scrot](https://cloud.githubusercontent.com/assets/59292/10848532/bbbbf6ca-7ef2-11e5-872d-8ed54a30a6b7.png)

after:
![2015-10-30-104123_244x224_scrot](https://cloud.githubusercontent.com/assets/59292/10848537/c712ee0c-7ef2-11e5-938d-454669701d1d.png)
