### PR TITLE
Use html5 doctype

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -1,11 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 {% load cache user_projects coursetags compress static %}
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-
+<!DOCTYPE html>
+<html lang="en">
 {% with request.course as course %}
     <head><!-- {{controller_name}} :: {{template_name}} -->
-    	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    	<title>Mediathread {% block title %}&mdash; Switch Course{% endblock %}</title>
+        <meta charset="utf-8">
+        <title>Mediathread {% block title %}&mdash; Switch Course{% endblock %}</title>
         
         <script type="text/javascript" src='{% static "jquery/js/jquery-1.11.3.min.js" %}'></script>
         <script type="text/javascript" src="{% static 'bootstrap/js/bootstrap.min.js' %}"></script>    


### PR DESCRIPTION
A brief skim through mediathread looks fine using the new
doctype.

This could have minor rendering effects throughout
mediathread, so if you want to put this off until another
release I understand. Otherwise, our QA session at noon
would be a good time to find any of these things.