### PR TITLE
Add jshint checking to sherd code

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,11 +3,11 @@
     "trailing": true,
     "undef": true,
     "browser": true,
-		"eqeqeq": true,
-		"curly": true,
+    "eqeqeq": true,
+    "curly": true,
     "predef": [
         "$",
-				"confirm",
+        "confirm",
         "jQuery"
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ jenkins: ./ve/bin/python validate jshint jscs flake8 test
 	./bootstrap.py
 
 jshint: node_modules/jshint/bin/jshint
-	./node_modules/jshint/bin/jshint --config=.jshintrc media/js/app/
+	./node_modules/jshint/bin/jshint --config=.jshintrc media/js/app/ media/js/lib/sherdjs/src
 
 jscs: node_modules/jscs/bin/jscs
 	./node_modules/jscs/bin/jscs media/js/app/

--- a/media/js/lib/sherdjs/src/assets.js
+++ b/media/js/lib/sherdjs/src/assets.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 if (typeof Sherd === 'undefined') {
     Sherd = {};
 }
@@ -159,8 +160,8 @@ if (!Sherd.GenericAssetView) {
                     }
                 } else {
                     if (window.console) {
-                        console.log(options);
-                        console.log(self.settings);
+                        window.console.log(options);
+                        window.console.log(self.settings);
                     }
                     throw new Error("Your asset does not have a (supported) type marked.");
                 }

--- a/media/js/lib/sherdjs/src/base.js
+++ b/media/js/lib/sherdjs/src/base.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, MochiKit: true */
 if (typeof Sherd === 'undefined' || !Sherd) {
     Sherd = {};
 }
@@ -134,7 +135,7 @@ Sherd.Base = {
                     } else if (typeof possiblePromise === 'object') {
                         self.components = possiblePromise;
                     } else {
-                        console.error('components error:', possiblePromise);
+                        window.console.error('components error:', possiblePromise);
                     }
                 } else {
                     self.components = {

--- a/media/js/lib/sherdjs/src/configs/demo.js
+++ b/media/js/lib/sherdjs/src/configs/demo.js
@@ -1,5 +1,5 @@
-
-var annotations=[
+/* global Sherd: true */
+var annotations = [
     {type:'annotation',
      view:{editable:true,color:'red'},
      metadata:{title:'My favorite part'},

--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, djangosherd: true */
 function DjangoSherd_NoteForm() {
     var self = this;
     Sherd.Base.DomObject.apply(this, arguments);// inherit
@@ -124,7 +125,7 @@ function DjangoSherd_AssetMicroFormat() {
                 // /use getAttribute rather than href, to avoid
                 // urlencodings
                 /// unescape necessary for IE7 (and sometimes 8)
-                rv[reg[1]] = unescape(elt.getAttribute('href'));
+                rv[reg[1]] = decodeURI(elt.getAttribute('href'));
                 // /TODO: maybe look for some data attributes here, too,
                 // when we put them there.
                 var metadata = elt.getAttribute('data-metadata');
@@ -315,7 +316,7 @@ CitationView.prototype.decorateElementLinks = function (element) {
             jQuery(this).addClass('active-annotation');
         } catch (e) {
             if (window.console) {
-                console.log('ERROR opening citation:' + e.message);
+                window.console.log('ERROR opening citation:' + e.message);
             }
         }
         evt.preventDefault();
@@ -538,7 +539,7 @@ function DjangoSherd_Storage() {
                             errorCallback();
                         }
                         if (window.console) {
-                            console.log(textStatus);
+                            window.console.log(textStatus);
                         }
                     }
                 });
@@ -670,4 +671,4 @@ window.DjangoSherd_Colors = {
 
 };
 
-DjangoSherd_Colors.reset();
+window.DjangoSherd_Colors.reset();

--- a/media/js/lib/sherdjs/src/image/annotators/fsiviewer.js
+++ b/media/js/lib/sherdjs/src/image/annotators/fsiviewer.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 if (!Sherd) { Sherd = {}; }
 if (!Sherd.Image) { Sherd.Image = {}; }
 if (!Sherd.Image.Annotators) { Sherd.Image.Annotators = {}; }

--- a/media/js/lib/sherdjs/src/image/annotators/openlayers.js
+++ b/media/js/lib/sherdjs/src/image/annotators/openlayers.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, OpenLayers: true */
 if (!Sherd) { Sherd = {}; }
 if (!Sherd.Image) { Sherd.Image = {}; }
 if (!Sherd.Image.Annotators) { Sherd.Image.Annotators = {}; }

--- a/media/js/lib/sherdjs/src/image/views/fsiviewer.js
+++ b/media/js/lib/sherdjs/src/image/views/fsiviewer.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 //jQuery dependencies
 if (!Sherd) { Sherd = {}; }
 if (!Sherd.Image) { Sherd.Image = {}; }

--- a/media/js/lib/sherdjs/src/image/views/openlayers.js
+++ b/media/js/lib/sherdjs/src/image/views/openlayers.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, OpenLayers: true */
 /****
 An annotation looks like this:
 ///1

--- a/media/js/lib/sherdjs/src/video/annotators/clipform.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipform.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 ///clipform-display
 ///1. update noteform field: DjangoSherd_UpdateHack()
 ///2. initialize clipform field vals

--- a/media/js/lib/sherdjs/src/video/annotators/clipstrip.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipstrip.js
@@ -1,4 +1,4 @@
-
+/* global Sherd: true */
 //Use Cases:
 //Default
 //-- starttime:0, endtime:0, duration:0

--- a/media/js/lib/sherdjs/src/video/views/flowplayer.js
+++ b/media/js/lib/sherdjs/src/video/views/flowplayer.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, flowplayer: true, $f: true */
 /*
  * Using Flowplayer to support the flash video and mp4 formats
  * Support for the Flowplayer js-enabled player.  documentation at:
@@ -169,7 +170,7 @@ if (!Sherd.Video.Flowplayer && Sherd.Video.Base) {
             var newUrl = self.microformat._getPlayerParams(obj);
             if (newUrl.url && document.getElementById(self.components.playerID) && self.media.state() > 0) {
                 var playlist = self.components.player.getPlaylist();
-                if (playlist[0].url == newUrl.url) {
+                if (playlist[0].url === newUrl.url) {
                     // If the url is the same as the previous, just seek to the right spot.
                     // This works just fine.
                     rc = true;
@@ -234,7 +235,7 @@ if (!Sherd.Video.Flowplayer && Sherd.Video.Base) {
                 if (queryString === 'start={start}') {
                     queryString = 'start=${start}';
                 }
-                rc.queryString = escape('?' + queryString);
+                rc.queryString = encodeURI('?' + queryString);
                 rc.url = pieces.join('?');
             }
             return rc;
@@ -388,7 +389,9 @@ if (!Sherd.Video.Flowplayer && Sherd.Video.Base) {
                            options);
     
                 // Save reference to the player
-                self.components.player = $f(create_obj.playerID);
+                if (typeof $f === 'function') {
+                    self.components.player = $f(create_obj.playerID);
+                }
                 self.components.provider = create_obj.playerParams.provider;
                 
                 // Setup timers to watch for readiness to seek/setState

--- a/media/js/lib/sherdjs/src/video/views/flowplayer5.js
+++ b/media/js/lib/sherdjs/src/video/views/flowplayer5.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, flowplayer: true */
 /*
  * Using Flowplayer 5 to support the flash video and mp4 formats
  * Support for the Flowplayer js-enabled player.  documentation at:
@@ -131,7 +132,7 @@ if (!Sherd.Video.Flowplayer && Sherd.Video.Base) {
             var rc = false;
             var newUrl = self.microformat._getPlayerParams(obj);
             if (newUrl.url && document.getElementById(self.components.playerID) && self.media.ready()) {
-                if (self.components.player.video.url == newUrl.url) {
+                if (self.components.player.video.url === newUrl.url) {
                     // If the url is the same as the previous, just seek to the right spot.
                     // This works just fine.
                     rc = true;

--- a/media/js/lib/sherdjs/src/video/views/jwplayer.js
+++ b/media/js/lib/sherdjs/src/video/views/jwplayer.js
@@ -1,3 +1,4 @@
+/* global Sherd: true, jwplayer: true */
 /*
  * Using Flowplayer 5 to support the flash video and mp4 formats
  * Support for the Flowplayer js-enabled player.  documentation at:
@@ -109,7 +110,7 @@ if (!Sherd.Video.JWPlayer && Sherd.Video.Base) {
             var newUrl = obj.mp4_audio;
             if (newUrl && document.getElementById(self.components.playerID) && self.state.ready) {
                 var playlist = self.components.player.getPlaylistItem(0);
-                if (playlist.file == newUrl) {
+                if (playlist.file === newUrl) {
                     // If the url is the same as the previous, just seek to the right spot.
                     // This works just fine.
                     rc = true;
@@ -196,7 +197,7 @@ if (!Sherd.Video.JWPlayer && Sherd.Video.Base) {
         };
 
         this.media.isPlaying = function () {
-            return self.components.player && self.components.player.getState() == 'PLAYING';
+            return self.components.player && self.components.player.getState() === 'PLAYING';
         };
         
         this.media.ready = function () {

--- a/media/js/lib/sherdjs/src/video/views/kaltura.js
+++ b/media/js/lib/sherdjs/src/video/views/kaltura.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 /*
   Support for the Kaltura js-enabled player.  documentation at:
   http://Kaltura.com/api/docs/oembed

--- a/media/js/lib/sherdjs/src/video/views/quicktime.js
+++ b/media/js/lib/sherdjs/src/video/views/quicktime.js
@@ -1,3 +1,6 @@
+/* global Sherd: true */
+/* global onQuicktimePlay: true, onQuicktimePause: true */
+/* global onQuicktimeFinish: true */
 /*
  http://developer.apple.com/mac/library/documentation/QuickTime/Conceptual/QTScripting_JavaScript/aQTScripting_Javascro_AIntro/Introduction%20to%20JavaScript%20QT.html
 http://developer.apple.com/safari/library/documentation/QuickTime/Conceptual/QTScripting_JavaScript/bQTScripting_JavaScri_Document/QuickTimeandJavaScri.html

--- a/media/js/lib/sherdjs/src/video/views/realplayer.js
+++ b/media/js/lib/sherdjs/src/video/views/realplayer.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 /*
 Documentation:
   http://service.real.com/help/library/guides/ScriptingGuide/HTML/samples/javaembed/JAVAFrames.htm

--- a/media/js/lib/sherdjs/src/video/views/video.js
+++ b/media/js/lib/sherdjs/src/video/views/video.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 /**
  * baseline video helper functions:
  *

--- a/media/js/lib/sherdjs/src/video/views/videotag.js
+++ b/media/js/lib/sherdjs/src/video/views/videotag.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 /*
 Documentation:
 

--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -1,3 +1,4 @@
+/* global Sherd: true */
 /*
   Support for the Vimeo js-enabled player.  documentation at:
   http://vimeo.com/api/docs/oembed

--- a/media/js/lib/sherdjs/src/video/views/youtube.js
+++ b/media/js/lib/sherdjs/src/video/views/youtube.js
@@ -1,3 +1,5 @@
+/* global Sherd: true, console: true, getYouTubeID: true */
+/* global YT: true */
 /*
   Support for the YouTube js-enabled player.  documentation at:
   http://code.google.com/apis/youtube/js_api_reference.html
@@ -227,7 +229,7 @@ if (!Sherd.Video.YouTube) {
 
         // Global function required for the player
         window.onPlayerReady = function() {
-            if (unescape(self.playerID) === self.components.playerID) {
+            if (decodeURI(self.playerID) === self.components.playerID) {
                 self.media._ready = true;
 
                 // Once the player is ready -- sort out any autoplay+seek requests
@@ -254,7 +256,7 @@ if (!Sherd.Video.YouTube) {
             } else {
                 console.error(
                     'playerID mismatch:',
-                    unescape(self.playerID),
+                    decodeURI(self.playerID),
                     self.components.playerID);
             }
         };


### PR DESCRIPTION
Mediathread has a stricter `.jshintrc` than SherdJS did, so
there were some changes needed to get this passing.

`escape()` and `unescape()` are deprecated -- I've converted
them to `encodeURI` / `decodeURI`.
http://www.w3schools.com/jsref/jsref_escape.asp
http://www.w3schools.com/jsref/jsref_unescape.asp