### PR TITLE
LTI: Rethink user to course mapping

### DIFF
--- a/lti_auth/admin.py
+++ b/lti_auth/admin.py
@@ -1,0 +1,4 @@
+from django.contrib import admin
+from lti_auth.models import LTICourseContext
+
+admin.site.register(LTICourseContext)

--- a/lti_auth/lti.py
+++ b/lti_auth/lti.py
@@ -59,14 +59,14 @@ class LTI(object):
 
         return []
 
-    def course_group(self):  # pylint: disable=no-self-use
+    def context_id(self):
         """
         Returns course_group as provided by LTI
 
         :return: course_group -- the course string
         """
-        if 'custom_course_group' in self.lti_params:
-            return self.lti_params['custom_course_group']
+        if 'context_id' in self.lti_params:
+            return self.lti_params['context_id']
 
         return None
 

--- a/lti_auth/migrations/0001_initial.py
+++ b/lti_auth/migrations/0001_initial.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LTICourseContext',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False,
+                                        auto_created=True, primary_key=True)),
+                ('lms_context_id', models.TextField()),
+                ('faculty_group', models.ForeignKey(
+                 related_name='course_faculty_group', to='auth.Group')),
+                ('group', models.ForeignKey(related_name='course_group',
+                                            to='auth.Group')),
+            ],
+        ),
+    ]

--- a/lti_auth/models.py
+++ b/lti_auth/models.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.models import Group
+from django.db import models
+
+
+class LTICourseContext(models.Model):
+    group = models.ForeignKey(Group, related_name='course_group')
+    faculty_group = models.ForeignKey(Group,
+                                      related_name='course_faculty_group')
+    lms_context_id = models.TextField()

--- a/lti_auth/tests/factories.py
+++ b/lti_auth/tests/factories.py
@@ -1,15 +1,18 @@
 import urllib
 from urlparse import parse_qs, urlparse
 
+from django.contrib.auth.models import User, Group
 from django.test.client import RequestFactory
+import factory
 import oauthlib.oauth1
 from oauthlib.oauth1.rfc5849 import CONTENT_TYPE_FORM_URLENCODED
 
+from lti_auth.models import LTICourseContext
+
+TEST_CONTEXT_ID = u'course-v1:edX+DemoX+Demo_Course'
 
 BASE_LTI_PARAMS = {
-    u'context_id': u'course-v1:edX+DemoX+Demo_Course',
-    u'custom_course_group':
-        u't3.y2011.s001.ce0001.aaaa.st.course:columbia.edu',
+    u'context_id': TEST_CONTEXT_ID,
     u'launch_presentation_return_url': u'',
     u'lis_person_contact_email_primary': u'foo@bar.com',
     u'lis_person_name_full': u'Foo Bar Baz',
@@ -55,3 +58,25 @@ def generate_lti_request():
     request = RequestFactory().post('/lti/', params)
     request.session = {}
     return request
+
+
+class UserFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = User
+    username = factory.Sequence(lambda n: 'user%d' % n)
+    password = factory.PostGenerationMethodCall('set_password', 'test')
+
+
+class GroupFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Group
+    name = factory.Sequence(lambda n: 'group %s' % n)
+
+
+class LTICourseContextFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = LTICourseContext
+
+    lms_context_id = TEST_CONTEXT_ID
+    group = factory.SubFactory(GroupFactory)
+    faculty_group = factory.SubFactory(GroupFactory)

--- a/lti_auth/tests/test_lti.py
+++ b/lti_auth/tests/test_lti.py
@@ -4,7 +4,7 @@ from pylti.common import LTI_SESSION_KEY, LTINotInSessionException
 
 from lti_auth.lti import LTI
 from lti_auth.tests.factories import BASE_LTI_PARAMS, CONSUMERS, \
-    generate_lti_request
+    generate_lti_request, TEST_CONTEXT_ID
 
 
 class LTITest(TestCase):
@@ -47,11 +47,10 @@ class LTITest(TestCase):
 
     def test_course_group(self):
         lti = LTI('initial', 'any')
-        self.assertEquals(lti.course_group(), None)
+        self.assertEquals(lti.context_id(), None)
 
         lti.lti_params = BASE_LTI_PARAMS
-        self.assertEquals(lti.course_group(),
-                          't3.y2011.s001.ce0001.aaaa.st.course:columbia.edu')
+        self.assertEquals(lti.context_id(), TEST_CONTEXT_ID)
 
     def test_consumers(self):
         lti = LTI('any', 'any')


### PR DESCRIPTION
Previously, configuration needed to be completed on the LMS-side to map
the LMS course to a Mediathread course. This refactor enables the LTI activation
in Mediathread proper, and leverages the consumer's existing context identifiers.

* Remove courseaffils dependency
* Introduces an abstraction layer: LTICourseContext to map an LMS context_id
to two django groups: regular & faculty.
* Use the LTICourseContext to map the user to a course.