### PR TITLE
Address collaboration/project performance issues

### DIFF
--- a/mediathread/main/course_details.py
+++ b/mediathread/main/course_details.py
@@ -2,6 +2,7 @@ from courseaffils.models import Course
 from django.core.cache import cache
 
 from mediathread.assetmgr.models import ExternalCollection
+from structuredcollaboration.models import Collaboration
 
 
 UPLOAD_PERMISSION_KEY = "upload_permission"
@@ -89,6 +90,19 @@ def cached_course_is_faculty(course, user):
     if key not in cache:
         cache.set(key, course.is_faculty(user))
     return cache.get(key)
+
+
+def cached_course_collaboration(course):
+    key = "%s:course:collaboration" % (course.id)
+    the_collaboration = cache.get(key)
+    if the_collaboration is None:
+        try:
+            the_collaboration = Collaboration.objects.get_for_object(course)
+            cache.set(key, the_collaboration)
+        except Collaboration.DoesNotExist:
+            the_collaboration = None
+
+    return the_collaboration
 
 
 def get_guest_sandbox():

--- a/structuredcollaboration/migrations/0005_auto_20151111_0930.py
+++ b/structuredcollaboration/migrations/0005_auto_20151111_0930.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('structuredcollaboration', '0004_auto_20151016_1401'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='collaborationpolicyrecord',
+            name='policy_name',
+            field=models.CharField(max_length=512, db_index=True),
+        ),
+    ]

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class CollaborationPolicyRecord(models.Model):
-    policy_name = models.CharField(max_length=512)
+    policy_name = models.CharField(max_length=512, db_index=True)
 
     def __unicode__(self):
         return self.policy_name

--- a/structuredcollaboration/policies.py
+++ b/structuredcollaboration/policies.py
@@ -1,5 +1,5 @@
-from structuredcollaboration.models import Collaboration
-from mediathread.main.course_details import cached_course_is_faculty
+from mediathread.main.course_details import cached_course_is_faculty, \
+    cached_course_collaboration
 
 
 class CollaborationPolicy(object):
@@ -40,14 +40,14 @@ class PrivateEditorsAreOwners(PublicEditorsAreOwners):
 
 class PrivateStudentAndFaculty(CollaborationPolicy):
     def manage(self, coll, course, user):
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration and
                 course and cached_course_is_faculty(course, user))
 
     delete = manage
 
     def read(self, coll, course, user):
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration and
                 ((course and cached_course_is_faculty(course, user)) or
                  coll.user_id == user.id or
@@ -65,14 +65,14 @@ class InstructorShared(PrivateEditorsAreOwners):
 
 class InstructorManaged(CollaborationPolicy):
     def manage(self, coll, course, user):
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration and
                 ((course and cached_course_is_faculty(course, user)) or
                  coll.user == user))
     delete = manage
 
     def read(self, coll, course, user):
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration)
 
     edit = read
@@ -80,7 +80,7 @@ class InstructorManaged(CollaborationPolicy):
 
 class CourseProtected(CollaborationPolicy):
     def manage(self, coll, course, user):
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration and
                 (coll.user == user or
                  (coll.group and
@@ -93,7 +93,7 @@ class CourseProtected(CollaborationPolicy):
         if not course:
             return False
 
-        course_collaboration = Collaboration.objects.get_for_object(course)
+        course_collaboration = cached_course_collaboration(course)
         return (coll.context == course_collaboration and
                 course.is_member(user))
 


### PR DESCRIPTION
small gains - 25% fewer queries, 30% quicker to load the ProjectCollectionView for Music Humanities

* cache the course collaboration
* refactor visible by course to retrieve all collaborations at once
* Collaboration queries, select_related context, policy_record
* index CollaborationPolicyRecord.name