### PR TITLE
Optimize Project.visible_by_course

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -129,13 +129,10 @@ class ProjectManager(models.Manager):
     def visible_by_course(self, course, viewer):
         projects = Project.objects.filter(course=course)
 
-        # get all the collaborations
-        lst = Collaboration.objects.get_for_object_list(projects)
-
         visible = []
-        for collaboration in lst:
-            project = collaboration.content_object
-            if project.can_read(course, viewer, collaboration):
+        for collab in Collaboration.objects.get_for_object_list(projects):
+            project = collab.content_object
+            if project.can_read(course, viewer, collab):
                 visible.append(project)
 
         visible.sort(reverse=False, key=lambda project: project.title)

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -37,11 +37,11 @@ class CollaborationManager(models.Manager):
         else:
             ctype = ContentType.objects.get_for_model(object_list[0])
             ids = [str(o.id) for o in object_list]
-            return self.filter(
-                content_type=ctype,
-                object_pk__in=ids).select_related('user', 'group',
-                                                  '_parent',
-                                                  'policy_record')
+
+            prefetch = ['user', 'group', 'context', 'content_object',
+                        '_parent', 'policy_record']
+            return self.filter(content_type=ctype,
+                               object_pk__in=ids).prefetch_related(*prefetch)
 
     def get_for_object(self, obj):
         ctype = ContentType.objects.get_for_model(obj)


### PR DESCRIPTION
Refactor to retrieve all collaborations and pass through to can_read.
Discovering the joys of prefetch_related for GenericForeignKeys (!)
also led to some good performance increases. 

Testing in Music Humanities, which has a few hundred projects and lots of selections, and through a browser request to pick up the django-debug-toolbar metrics.

Initial Benchmark (from local dev, debug environment)
CPU: 25902ms
SQL: 2033 q in 2488ms

Refactor
CPU: 14671ms
SQL: 1284 q in 1355ms