### PR TITLE
Fix Assignment feature when testing in Firefox

### DIFF
--- a/mediathread/projects/features/assignment.feature
+++ b/mediathread/projects/features/assignment.feature
@@ -22,7 +22,7 @@ Feature: Assignment
         # Add a title and some text
         Then I call the Assignment "Assignment: Scenario 1"
         And there is a Save button
-        And I write some text for the Composition
+        And I write some text for the Assignment
         
         # Save as an Assignment
         When I click the Save button


### PR DESCRIPTION
When running this test in Firefox, it throws a missing selector error when searching for `td.panel-container.open.composition`. When it's in this state, there is an open Assignment panel, not Composition. I ran into this when trying to debug a different error on my bootstrap buttons branch.

To reproduce this problem, change the test browser in `settings_test.py` to Firefox, and run `./manage.py harvest --settings=mediathread.settings_test mediathread/projects/features/assignment.feature --failfast --pdb`.

See line 1051 of `terrain.py` - this code isn't being run when `BROWSER` is `Headless`.