### PR TITLE
lettuce test: click edit button before attempting to edit

### DIFF
--- a/mediathread/projects/features/assignment.feature
+++ b/mediathread/projects/features/assignment.feature
@@ -141,7 +141,8 @@ Feature: Assignment
         
         # Create Instructor Feedback
         When I click the Create Instructor Feedback button
-        Then there is an open Discussion panel        
+        Then there is an open Discussion panel
+        Then I click the Edit button
         Then I write some text for the discussion
         Then I click the Save Comment button
         Then there is a comment from "Instructor One"


### PR DESCRIPTION
There's a missing step in this test - the edit button must be clicked in order for the
editing iframe to be populated. This error only happens when the test browser is
not "Headless".