### PR TITLE
Cache Course Collaboration

### DIFF
--- a/mediathread/main/course_details.py
+++ b/mediathread/main/course_details.py
@@ -2,6 +2,7 @@ from courseaffils.models import Course
 from django.core.cache import cache
 
 from mediathread.assetmgr.models import ExternalCollection
+from structuredcollaboration.models import Collaboration
 
 
 UPLOAD_PERMISSION_KEY = "upload_permission"
@@ -89,6 +90,19 @@ def cached_course_is_faculty(course, user):
     if key not in cache:
         cache.set(key, course.is_faculty(user))
     return cache.get(key)
+
+
+def cached_course_collaboration(course):
+    key = "%s:course:collaboration" % (course.id)
+    the_collaboration = cache.get(key)
+    if the_collaboration is None:
+        try:
+            the_collaboration = Collaboration.objects.get_for_object(course)
+            cache.set(key, the_collaboration)
+        except Collaboration.DoesNotExist:
+            the_collaboration = None
+
+    return the_collaboration
 
 
 def get_guest_sandbox():


### PR DESCRIPTION
Cache the collaboration associated with the course. It's accessed hundreds of time due to the collaboration policies associated with each project.

Testing in Music Humanities, which has a few hundred projects and lots of selections, and through a browser request to pick up the django-debug-toolbar metrics.

Initial Benchmark
CPU: 14671ms
SQL: 1284q in 1355ms

refactor: cache the course collaboration object
CPU: 11250ms
SQL: 964q om 559ms