### PR TITLE
Optimize Project.visible_by_course_and_user

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -143,9 +143,14 @@ class ProjectManager(models.Manager):
         projects = Project.objects.filter(
             Q(author=user, course=course) |
             Q(participants=user, course=course)
-        ).distinct().select_related('author')
+        ).distinct()
 
-        lst = [p for p in projects if p.can_read(course, viewer)]
+        lst = []
+        for collab in Collaboration.objects.get_for_object_list(projects):
+            project = collab.content_object
+            if project.can_read(course, viewer, collab):
+                lst.append(project)
+
         lst.sort(reverse=False, key=lambda project: project.title)
         lst.sort(reverse=True, key=lambda project: project.modified)
 

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -559,7 +559,6 @@ class ProjectCollectionView(LoggedInMixin, RestrictedMaterialsMixin,
         /api/project/user/sld2131/
         /api/project/
     """
-
     def get(self, request):
         ures = UserResource()
         course_res = CourseResource()


### PR DESCRIPTION
Retrieving all the Collaborations at once combined with the Collaboration.get_for_object_list prefetch of the content_object generic foreign key speeds things up.

25 projects, 24 assignments with ~18 responses each and 1 composition

previous: 501.545906, ms
now: 182.909012, ms