### PR TITLE
Optimize Project.render_projects

### DIFF
--- a/mediathread/projects/api.py
+++ b/mediathread/projects/api.py
@@ -199,25 +199,25 @@ class ProjectResource(ModelResource):
             dehydrated = self.full_dehydrate(abundle)
             ctx = self._meta.serializer.to_simple(dehydrated, None)
 
-            if self.editable:
-                feedback = project.feedback_discussion()
-                if feedback:
-                    ctx['feedback'] = feedback.id
-
-            parent_assignment = project.assignment()
-            if parent_assignment:
-                ctx['display_as_assignment'] = True
-                ctx['collaboration'] = {}
-                ctx['collaboration']['title'] = parent_assignment.title
-                ctx['collaboration']['url'] = \
-                    parent_assignment.get_absolute_url()
-                ctx['collaboration']['due_date'] = \
-                    parent_assignment.get_due_date()
-            elif project.is_assignment() or project.is_selection_assignment():
+            if project.is_assignment() or project.is_selection_assignment():
                 responses = project.responses(course, user)
                 ctx['responses'] = len(responses)
                 ctx['is_assignment'] = True
                 ctx['display_as_assignment'] = True
+            else:
+                parent_assignment = project.assignment()
+                if parent_assignment:
+                    if self.editable:
+                        feedback = project.feedback_discussion()
+                        if feedback:
+                            ctx['feedback'] = feedback.id
+                    ctx['display_as_assignment'] = True
+                    ctx['collaboration'] = {}
+                    ctx['collaboration']['title'] = parent_assignment.title
+                    ctx['collaboration']['url'] = \
+                        parent_assignment.get_absolute_url()
+                    ctx['collaboration']['due_date'] = \
+                        parent_assignment.get_due_date()
 
             lst.append(ctx)
         return lst

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -315,14 +315,13 @@ class Project(models.Model):
 
     def responses(self, course, viewer, by_user=None):
         visible = []
-        col = self.get_collaboration()
-        project_type = ContentType.objects.get_for_model(Project)
-        for child in col.children.filter(content_type=project_type):
-            if (child.content_object and
-                (by_user is None or
-                 child.content_object.is_participant(by_user))):
-                    if child.content_object.can_read(course, viewer):
-                        visible.append(child.content_object)
+        children = self.get_collaboration().get_children_for_object(self)
+        for child in children:
+            response = child.content_object
+            if (response and
+                    (by_user is None or response.is_participant(by_user))):
+                if response.can_read(course, viewer, child):
+                    visible.append(response)
         return visible
 
     def description(self):

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -49,12 +49,6 @@ class CollaborationManager(models.Manager):
             'user', 'group', '_parent', 'policy_record').get(
             content_type=ctype, object_pk=str(obj.pk))
 
-    def get_children_for_object(self, obj):
-        ctype = ContentType.objects.get_for_model(obj)
-        return self.select_related(
-            'user', 'group', '_parent', 'policy_record').filter(
-            content_type=ctype, _parent=obj)
-
 
 class Collaboration(models.Model):
     objects = CollaborationManager()
@@ -119,6 +113,11 @@ class Collaboration(models.Model):
 
     def get_parent(self):
         return self._parent
+
+    def get_children_for_object(self, obj):
+        return self.children.filter(
+                content_type=ContentType.objects.get_for_model(obj)
+            ).prefetch_related('content_object', 'policy_record', 'user')
 
     def get_top_ancestor(self):  # i.e. domain
         result = self


### PR DESCRIPTION
* reorder conditions to avoid heavy collaboration fetches
* StructuredCollaboration.get_for_children - add prefetch
* Project.responses - pass through existing collaboration to prevent duplicate fetches. This was the main change that boosted performance.

ProjectCollectionView.get
25 projects, 24 assignments with responses + 1 composition
Pre-refactor: 4870ms
Post-refactor: 2707ms
