### PR TITLE
docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+ve
+*.pyc
+reports

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ reports/
 node_modules
 media/js/CHANGES.txt
 the_report
+wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ccnmtl/django.base
+ADD wheelhouse /wheelhouse
+RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.txt \
+&& rm -rf /wheelhouse
+WORKDIR /app
+COPY . /app/
+#RUN /ve/bin/python manage.py test
+EXPOSE 8000
+ADD docker-run.sh /run.sh
+ENV APP mediathread
+ENTRYPOINT ["/run.sh"]
+CMD ["run"]

--- a/README.markdown
+++ b/README.markdown
@@ -86,6 +86,34 @@ Go to your site in a web browser.
    http://myhost.example.com:8000/save/
 
 
+DOCKER DEVELOPMENT
+------------------
+
+[Please note that the docker setup for Mediathread is still
+experimental. There are likely to be rough edges here.]
+
+If you have docker set up and docker-compose installed, you can get a
+development environment up and running very quickly. To initialize it,
+the following steps are recommended:
+
+    $ docker pull ccnmtl/mediathread
+    $ docker-compose run web manage syncdb # create a superuser when asked to
+	$ docker-compose run web migrate
+
+After that, a simple:
+
+    $ docker-compose up
+
+will bring up a development server on port 8000 (if you are running
+boot2docker, it may end up on a different port) backed by a PostgreSQL
+database.
+
+Production deployment with Docker is also possible, though even less
+tested than development. The `settings_docker.py` file has the default
+settings that the docker image uses and is designed to allow you to
+override/set the important values through environment variables (so
+configuration can be kept out of the docker image).
+
 DJANGO SITE INFRASTRUCTURE
 ----------------
 Mediathread makes use of the Django Sites framework. https://docs.djangoproject.com/en/1.6/ref/contrib/sites/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+db:
+  image: postgres
+web:
+  image: ccnmtl/mediathread
+  environment:
+    - SETTINGS=settings_compose
+  command: manage runserver 0.0.0.0:8000
+  volumes:
+    - .:/app/
+  ports:
+    - "8000:8000"
+  links:
+    - db

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+cd /app/
+
+if [[ "$SETTINGS" ]]; then
+		export DJANGO_SETTINGS_MODULE="$APP.$SETTINGS"
+else
+		export DJANGO_SETTINGS_MODULE="$APP.settings_docker"
+fi
+
+if [ "$1" == "migrate" ]; then
+		exec /ve/bin/python manage.py migrate --noinput
+fi
+
+if [ "$1" == "collectstatic" ]; then
+		exec /ve/bin/python manage.py collectstatic --noinput
+fi
+
+if [ "$1" == "compress" ]; then
+		exec /ve/bin/python manage.py compress
+fi
+
+if [ "$1" == "shell" ]; then
+		exec /ve/bin/python manage.py shell
+fi
+
+if [ "$1" == "test" ]; then
+		exec /ve/bin/python manage.py test
+fi
+
+if [ "$1" == "worker" ]; then
+		exec /ve/bin/python manage.py celery worker
+fi
+
+if [ "$1" == "beat" ]; then
+		exec /ve/bin/python manage.py celery beat
+fi
+
+# run arbitrary commands
+if [ "$1" == "manage" ]; then
+		shift
+		exec /ve/bin/python manage.py "$@"
+fi
+
+
+if [ "$1" == "run" ]; then
+		exec /ve/bin/gunicorn --env \
+				 DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE \
+				 $APP.wsgi:application -b 0.0.0.0:8000 -w 3 \
+				 --access-logfile=- --error-logfile=-
+fi

--- a/mediathread/settings_compose.py
+++ b/mediathread/settings_compose.py
@@ -1,0 +1,21 @@
+# flake8: noqa
+from settings_shared import *
+
+DEBUG = True
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432,
+        'ATOMIC_REQUESTS': True,
+    }
+}
+
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+try:
+    from local_settings import *
+except ImportError:
+    pass

--- a/mediathread/settings_docker.py
+++ b/mediathread/settings_docker.py
@@ -1,0 +1,86 @@
+# flake8: noqa
+from settings_shared import *
+
+# required settings:
+SECRET_KEY = os.environ['SECRET_KEY']
+
+# optional/defaulted settings
+DB_NAME = os.environ.get('DB_NAME', app)
+DB_HOST = os.environ.get(
+    'DB_HOST',
+    os.environ.get('POSTGRESQL_PORT_5432_TCP_ADDR', ''))
+DB_PORT = int(
+    os.environ.get(
+        'DB_PORT',
+        os.environ.get('POSTGRESQL_PORT_54342_TCP_PORT', 5432)))
+DB_USER = os.environ.get('DB_USER', '')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
+
+AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
+AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
+AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
+
+RAVEN_DSN = os.environ.get('RAVEN_DSN', '')
+
+if 'ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(',')
+
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/New_York')
+
+EMAIL_HOST = os.environ.get(
+    'EMAIL_HOST',
+    os.environ.get('POSTFIX_PORT_25_TCP_ADDR', 'localhost'))
+EMAIL_PORT = os.environ.get(
+    'EMAIL_PORT',
+    os.environ.get('POSTFIX_PORT_25_TCP_PORT', 25))
+
+SERVER_EMAIL = os.environ.get('SERVER_EMAIL',
+                              app + "@" + app + ".ccnmtl.columbia.edu")
+
+# -------------------------------------------
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
+
+TEMPLATE_DIRS = (
+    os.path.join(base, "templates"),
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': DB_NAME,
+        'HOST': DB_HOST,
+        'PORT': DB_PORT,
+        'USER': DB_USER,
+        'PASSWORD': DB_PASSWORD,
+        'ATOMIC_REQUESTS': True,
+        }
+}
+
+if AWS_S3_CUSTOM_DOMAIN:
+    AWS_PRELOAD_METADATA = True
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+    # static data, e.g. css, js, etc.
+    STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+    STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+    COMPRESS_ENABLED = True
+    COMPRESS_OFFLINE = True
+    COMPRESS_ROOT = STATIC_ROOT
+    COMPRESS_URL = STATIC_URL
+    COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+
+if RAVEN_DSN and 'migrate' not in sys.argv:
+    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
+    RAVEN_CONFIG = {
+        'dsn': RAVEN_DSN,
+    }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--index-url https://pypi.ccnmtl.columbia.edu/
 Django==1.8.6
 psycopg2==2.6.1
 #for MySQL: MySQL-python==1.2.5
@@ -18,7 +19,7 @@ testtools==1.8.0  # python-subunit
 pbr>=0.11
 testscenarios==0.5.0  # python-subunit
 python-subunit==1.1.0  # lettuce
-requirements/src/lettuce-0.2.21.ccnmtl.tar.gz
+lettuce==0.2.21.ccnmtl
 selenium==2.48.0
 six==1.10.0
 sqlparse==0.1.16  # django-debug-toolbar
@@ -39,7 +40,7 @@ django-reversion==1.9.3
 djangohelpers==0.18.1
 django-contrib-comments==1.6.1
 django-threadedcomments==1.0b1
-requirements/src/django-courseaffils-2.0.6.tar.gz
+django-courseaffils==2.0.6
 django-statsd-mozilla==0.3.15
 raven==5.2.0
 django-appconf==1.0.1  # django_compressor


### PR DESCRIPTION
test running step of Dockerfile is currently commented out because tests fail
on my machine whether in docker or not.

If you have docker and docker-compose installed, you can do:

```
$ docker pull ccnmtl/mediathread
$ docker-compose run web migrate
$ docker-compose up
```

and you will have a dev runserver instance running on port 8000. It appears that mediathread needs some additional configuration tweaks for that to be usable, but I haven't dug into that yet.