### PR TITLE
Hide bookmarklet instructions on Chrome - PMT #104081

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -110,7 +110,8 @@ MIDDLEWARE_CLASSES = [
     'courseaffils.middleware.CourseManagerMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'impersonate.middleware.ImpersonateMiddleware',
-    'waffle.middleware.WaffleMiddleware'
+    'waffle.middleware.WaffleMiddleware',
+    'django_user_agents.middleware.UserAgentMiddleware',
 ]
 
 ROOT_URLCONF = 'mediathread.urls'

--- a/mediathread/templates/assetmgr/install_bookmarklet.html
+++ b/mediathread/templates/assetmgr/install_bookmarklet.html
@@ -1,48 +1,46 @@
-        <div id="firefox-instruction" class="browser-instruction">
-            <strong>How to install the bookmarklet in Firefox</strong>
-            <ol>
-              <li>In the <b>View</b> menu, show the "Bookmarks"  toolbar.</li><br />
-              <li>Drag the link below onto your browser bookmarks toolbar.</li>
-            </ol>
-        </div>
-        <div id="ie-instruction" class="browser-instruction">
-            <strong>How to install the bookmarklet in Internet Explorer</strong>
-            <ol>
-              <li>Right-click on the blue bookmarklet button below.</li>  
-              <li>and choose <b>Add to Favorites</b></li>
-            </ol>
-        </div>
-        <div id="safari-instruction" class="browser-instruction">
-            <strong>How to install the bookmarklet in Safari</strong>
-            <ol>
-             <li>In the <b>View</b> menu, show the "Favorites Bar".</li><br />
-              <li>Drag the link below onto your browser bookmarks toolbar</li>
-            </ol>
-        </div>
-        <div id="chrome-instruction" class="browser-instruction">
-            <strong>How to install the bookmarklet in Chrome</strong>
-            <ol>
-              <li>Under the <b>Tools</b> menu (the Wrench), show the "Bookmarks bar".</li><br />
-              <li>Drag the link below onto your browser bookmarks toolbar:  <br />Collect w/Mediathread</li>
-            </ol>
-        </div>
-        {% include "assetmgr/bookmarklet.html" %} 
-        <script type="text/javascript">
-            var u = navigator.userAgent;
-            if (/Trident/.test(u)) {
-                jQuery('.browser-instruction').hide();
-                jQuery('#ie-instruction').show();
-            } else if (/Chrome/.test(u)) {
-                jQuery('.browser-instruction').hide();
-                jQuery('#chrome-instruction').show();
-            } else if (/Safari/.test(u)) {
-                jQuery('.browser-instruction').hide();
-                jQuery('#safari-instruction').show();
-            } else if (/MSIE/.test(u)) {
-                jQuery('.browser-instruction').hide();
-                jQuery('#ie-instruction').show();
-            } else if (/Gecko/.test(u)) {
-                jQuery('.browser-instruction').hide();
-                jQuery('#firefox-instruction').show();
-            }
-        </script>
+{% if request.user_agent.browser.family == 'Firefox' %}
+<p>
+    Use the Mediathread Bookmarklet to import images and video from any
+    web page containing Mediathread-friendly items.
+    <div id="firefox-instruction" class="browser-instruction">
+        <strong>How to install the bookmarklet in Firefox</strong>
+        <ol>
+            <li>In the <b>View</b> menu, show the "Bookmarks"  toolbar.</li><br />
+            <li>Drag the link below onto your browser bookmarks toolbar.</li>
+        </ol>
+    </div>
+    {% include "assetmgr/bookmarklet.html" %}
+</p>
+{% elif request.user_agent.browser.family == 'MSIE' %}
+<p>
+    Use the Mediathread Bookmarklet to import images and video from any
+    web page containing Mediathread-friendly items.
+    <div id="ie-instruction" class="browser-instruction">
+        <strong>How to install the bookmarklet in Internet Explorer</strong>
+        <ol>
+            <li>Right-click on the blue bookmarklet button below.</li>
+            <li>and choose <b>Add to Favorites</b></li>
+        </ol>
+    </div>
+    {% include "assetmgr/bookmarklet.html" %}
+</p>
+{% elif request.user_agent.browser.family == 'Safari' %}
+<p>
+    Use the Mediathread Bookmarklet to import images and video from any
+    web page containing Mediathread-friendly items.
+    <div id="safari-instruction" class="browser-instruction">
+        <strong>How to install the bookmarklet in Safari</strong>
+        <ol>
+            <li>In the <b>View</b> menu, show the "Favorites Bar".</li><br />
+            <li>Drag the link below onto your browser bookmarks toolbar</li>
+        </ol>
+    </div>
+    {% include "assetmgr/bookmarklet.html" %}
+</p>
+{% elif request.user_agent.browser.family != 'Chrome' and request.user_agent.browser.family != 'Chromium' %}
+<p>
+    Use the Mediathread Bookmarklet to import images and video from any
+    web page containing Mediathread-friendly items.
+    {% include "assetmgr/bookmarklet.html" %}
+</p>
+{% endif %}

--- a/mediathread/templates/homepage.html
+++ b/mediathread/templates/homepage.html
@@ -272,11 +272,7 @@
                     </a>
                     <div class="arrowContent" id="import_collection" style="display: none">
                         {% include "assetmgr/install_chrome_extension.html" %}
-                        <p>
-                            Use the Mediathread Bookmarklet to import images and video from any web page containing Mediathread-friendly items.                                
-                            
-                            {% include "assetmgr/install_bookmarklet.html" %}
-                        </p>
+                        {% include "assetmgr/install_bookmarklet.html" %}
                     </div> <!-- end import into collection box --> 
                 </div><!-- end collection content box -->
                 {% if can_upload and uploader %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,6 @@ oauthlib==0.6.3
 pylti>=0.1.3
 nameparser==0.3.10
 django-bootstrap3==6.2.2
+ua_parser==0.5.1
+user_agents==1.0.1
+django_user_agents==0.3.0


### PR DESCRIPTION
I've replaced the javascript UA parsing code with a more up to date
back-end method - the JS method interpreted my Chrome browser as
Safari because Chrome puts 'Safari' in its user agent string.