### PR TITLE
Vimeo fixes

### DIFF
--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -335,6 +335,16 @@ if (!Sherd.Video.Vimeo) {
                 delete self.state.endtime;
                 delete self.state.autoplay;
                 self.state.seeking = false;
+            } else {
+                self.state.starttime = starttime;
+                self.state.endtime = endtime;
+                self.state.seeking = true;
+
+                if (!self.media.isPlaying()) {
+                    if (self.components.player.api) {
+                        self.components.player.api('play');
+                    }
+                }
             }
         };
 

--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -76,7 +76,10 @@ if (!Sherd.Video.Vimeo) {
             // get out of the "loaded" function before seeking happens
             if (self.state.starttime !== undefined) {
                 setTimeout(function () {
-                    self.media.seek(self.state.starttime, self.state.endtime, self.state.autoplay);
+                    self.media.seek(
+                        self.state.starttime,
+                        self.state.endtime,
+                        self.state.autoplay);
                 }, 100);
             }
         };
@@ -119,12 +122,16 @@ if (!Sherd.Video.Vimeo) {
                 player_id: playerID
             });
 
-            var embedCode = '<div id="' + wrapperID + '" class="sherd-vimeo-wrapper">' +
+            var src = 'https://player.vimeo.com/video/' + clipId + '?' +
+                params;
+
+            var embedCode = '<div id="' + wrapperID + '" ' +
+                'class="sherd-vimeo-wrapper">' +
                 '<iframe id="' + playerID + '" ' +
-                'src="//player.vimeo.com/video/' + clipId +
-                '?' + params + '" ' +
+                'src="' + src + '" ' +
                 'width="' + obj.options.width + '" ' +
                 'height="' + obj.options.height + '" ' +
+                'autoplay="' + autoplay + '" ' +
                 '></iframe>' +
                 '</div>';
 


### PR DESCRIPTION
Clean up some vimeo initialization stuff - pass 'autoplay'
param to vimeo embed.

We talked about how the videos on Composition view aren't supposed
to autoplay. The parameter that controls this is here:
https://github.com/ccnmtl/mediathread/blob/master/media/js/lib/sherdjs/src/configs/djangosherd.js#L256

Setting that to 'false' makes these videos not autoplay when clicked on,
however, that also makes selections on this view not get initialized
in the right place, for youtube and vimeo videos, so I'm leaving
this set to true for now.

I've also included a commit that automatically plays the vimeo video at the right time when clicking between selections, just like we do for youtube (PMT #104087).