### PR TITLE
jQuery cleanup

### DIFF
--- a/media/js/app/assetmgr/assetembed.js
+++ b/media/js/app/assetmgr/assetembed.js
@@ -15,7 +15,7 @@
             _.bindAll(this, 'render');
 
             this.collectionList = new CollectionList({
-                'parent': this.el,
+                '$parent': jQuery(this.el),
                 'template': 'embed',
                 'template_label': 'collection_table',
                 'create_annotation_thumbs': true,

--- a/media/js/app/assetmgr/assetpanel.js
+++ b/media/js/app/assetmgr/assetpanel.js
@@ -18,13 +18,12 @@
  * Nothing
  */
 
-var AssetPanelHandler = function(el, parent, panel, space_owner) {
+var AssetPanelHandler = function(el, $parent, panel, space_owner) {
     var self = this;
 
-    self.el = el;
-    self.$el = jQuery(self.el);
+    self.$el = jQuery(el);
     self.panel = panel;
-    self.parentContainer = parent;
+    self.$parentContainer = $parent;
     self.space_owner = space_owner;
 
     djangosherd.storage.json_update(panel.context);
@@ -80,17 +79,17 @@ var AssetPanelHandler = function(el, parent, panel, space_owner) {
             if (self.dialogWindow) {
                 return 450;
             } else {
-                var elt = self.$el.find('div.asset-view-published')[0];
-                return jQuery(elt).height() -
-                    (jQuery(elt).find('div.annotation-title').height() +
-                     jQuery(elt).find('div.asset-title').height() + 15);
+                var $elt = self.$el.find('div.asset-view-published');
+                return $elt.height() -
+                    ($elt.find('div.annotation-title').height() +
+                     $elt.find('div.asset-title').height() + 15);
             }
         }
     });
 
     if (self.panel.show_collection) {
         self.collectionList = new CollectionList({
-            'parent': self.el,
+            '$parent': self.$el,
             'template': 'gallery',
             'template_label': 'media_gallery',
             'create_asset_thumbs': true,
@@ -101,12 +100,12 @@ var AssetPanelHandler = function(el, parent, panel, space_owner) {
                 var self = this;
 
                 if (assetCount > 0) {
-                    var container = self.$el.find('div.asset-table')[0];
-                    jQuery(container).masonry({
+                    var $container = self.$el.find('div.asset-table');
+                    $container.masonry({
                         itemSelector: '.gallery-item',
                         columnWidth: 23
                     });
-                    jQuery(container).masonry('bindResize');
+                    $container.masonry('bindResize');
                 } else {
                     jQuery('div.asset-table').css('height', '500px');
                 }
@@ -142,10 +141,10 @@ AssetPanelHandler.prototype.dialog = function(event, assetId, annotationId) {
         }
     }
 
-    var dlg = jQuery('#asset-workspace-panel-container')[0];
-    var elt = jQuery(dlg).find('div.asset-view-tabs').hide();
+    var $dlg = jQuery('#asset-workspace-panel-container');
+    var elt = $dlg.find('div.asset-view-tabs').hide();
 
-    self.dialogWindow = jQuery(dlg).dialog({
+    self.dialogWindow = $dlg.dialog({
         open: function() {
             self.dialogWindow = true;
             self.citationView.openCitationById(null, assetId, annotationId);
@@ -209,7 +208,7 @@ AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id,
         'vocabulary': self.panel.vocabulary,
         'view_callback': function() {
             self.$el.find('div.tabs').fadeIn('fast', function() {
-                window.panelManager.verifyLayout(self.el);
+                window.panelManager.verifyLayout(self.$el);
                 jQuery(window).trigger('resize');
             });
             jQuery('html').removeClass('busy');
@@ -292,8 +291,8 @@ AssetPanelHandler.prototype.resize = function() {
         jQuery('div.accordion').accordion('refresh');
     }
 
-    var container = self.$el.find('div.asset-table')[0];
-    jQuery(container).masonry();
+    var $container = self.$el.find('div.asset-table');
+    $container.masonry();
 };
 
 AssetPanelHandler.prototype.onClickAssetTitle = function(evt) {

--- a/media/js/app/assetmgr/collection.js
+++ b/media/js/app/assetmgr/collection.js
@@ -24,7 +24,7 @@ var CollectionList = function(config) {
     self.view_callback = config.view_callback;
     self.create_annotation_thumbs = config.create_annotation_thumbs;
     self.create_asset_thumbs = config.create_asset_thumbs;
-    self.parent = config.parent;
+    self.$parent = config.$parent;
     self.selected_view = config.hasOwnProperty('selectedView') ?
         config.selectedView : 'Medium';
     self.citable = config.hasOwnProperty('citable') ? config.citable : false;
@@ -33,16 +33,15 @@ var CollectionList = function(config) {
     self.loading = false;
     self.current_asset = config.current_asset;
 
-    self.el = jQuery(self.parent).find('div.' + self.template_label)[0];
-    self.$el = jQuery(self.el);
+    self.$el = self.$parent.find('div.' + self.template_label);
 
     self.switcher_context = jQuery.extend({}, MediaThread.mustacheHelpers);
 
     jQuery(window).on('asset.on_delete', {'self': self}, function(event) {
         var self = event.data.self;
-        var div = self.$el.find('div.collection-assets');
-        if (!self.citable && div.length > 0) {
-            self.scrollTop = jQuery(div[0]).scrollTop();
+        var $div = self.$el.find('div.collection-assets');
+        if (!self.citable && $div.length > 0) {
+            self.scrollTop = $div.scrollTop();
             event.data.self.refresh();
         }
     });
@@ -136,12 +135,12 @@ var CollectionList = function(config) {
 
     self.$el.on(
         'change select2-removed', 'select.course-tags', function() {
-            var elt = self.$el.find('select.course-tags');
-            self.current_records.active_filters.tag = jQuery(elt).val();
+            var $elt = self.$el.find('select.course-tags');
+            self.current_records.active_filters.tag = $elt.val();
             return self.filter();
         });
 
-    jQuery(self.parent).on(
+    self.$parent.on(
         'click', 'a.switcher-choice.filterbytag', function(evt) {
             var src = evt.srcElement || evt.target || evt.originalTarget;
             var bits = src.href.split('/');
@@ -196,12 +195,12 @@ var CollectionList = function(config) {
         });
 
     var q = '#collection-overlay, #collection-help, #collection-help-tab';
-    jQuery(self.parent).on('click', '#collection-help-button', function() {
+    self.$parent.on('click', '#collection-help-button', function() {
         jQuery(q).show();
         return false;
     });
 
-    jQuery(self.parent).on('click', '.dismiss-help', function() {
+    self.$parent.on('click', '.dismiss-help', function() {
         jQuery(q).hide();
         return false;
     });
@@ -223,7 +222,7 @@ CollectionList.prototype.setLoading = function(isLoading) {
 CollectionList.prototype.constructUrl = function(config, updating) {
     var url;
 
-    if (config && config.parent) {
+    if (config && config.$parent) {
         // Retrieve the full asset w/annotations from storage
         if (config.view === 'all' || !config.space_owner) {
             url = MediaThread.urls['all-space'](
@@ -347,8 +346,9 @@ CollectionList.prototype.filterByVocabulary = function(srcElement) {
     var self = this;
     self.setLoading(true);
     var url = MediaThread.urls['all-space'](null, null, self.citable);
-    url += jQuery(srcElement).data('vocabulary-id') + '=' +
-        jQuery(srcElement).data('term-id');
+    var $srcElement = jQuery(srcElement);
+    url += $srcElement.data('vocabulary-id') + '=' +
+        $srcElement.data('term-id');
     djangosherd.storage.get({
         type: 'asset',
         url: url
@@ -655,11 +655,12 @@ CollectionList.prototype.assetPostUpdate = function($elt, the_records) {
     } else {
         // handle the minimized view
         var q = 'div.collection-assets';
-        var container = self.$el.find(q)[0];
-        jQuery(container).scroll(function() {
+        var $container = self.$el.find(q);
+        var container = $container[0];
+        $container.scroll(function() {
             if (!self.getLoading() &&
                 container.scrollTop +
-                jQuery(container).innerHeight() >=
+                $container.innerHeight() >=
                 container.scrollHeight - 300) {
                 self.appendItems(self.current_records);
             }
@@ -691,8 +692,8 @@ CollectionList.prototype.appendAssets = function(the_records) {
             MediaThread.templates[self.config.template + '_assets'],
             jQuery.extend({}, the_records, MediaThread.mustacheHelpers)
         ));
-        var container = self.$el.find('div.asset-table');
-        jQuery(container).append(html);
+        var $container = self.$el.find('div.asset-table');
+        $container.append(html);
 
         if (self.create_annotation_thumbs) {
             self.createThumbs(the_records.assets);

--- a/media/js/app/discussion/discussionpanel.js
+++ b/media/js/app/discussion/discussionpanel.js
@@ -3,12 +3,12 @@
 /* global tinymce: true, tinymceSettings: true, showMessage: true */
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
-var DiscussionPanelHandler = function(el, parent, panel, space_owner) {
+var DiscussionPanelHandler = function(el, $parent, panel, space_owner) {
     var self = this;
     self.el = el;
     self.$el = jQuery(self.el);
     self.panel = panel;
-    self.parentContainer = parent;
+    self.$parentContainer = $parent;
     self.space_owner = space_owner;
     self.form = self.$el.find('form.threaded_comments_form')[0];
     self.max_comment_length =
@@ -21,7 +21,7 @@ var DiscussionPanelHandler = function(el, parent, panel, space_owner) {
     });
 
     // hook up behaviors
-    self._bind(self.el, 'td.panel-container', 'panel_state_change',
+    self._bind(self.$el, 'td.panel-container', 'panel_state_change',
         function() {
             self.onClosePanel(jQuery(this).hasClass('subpanel'));
         });
@@ -41,7 +41,7 @@ var DiscussionPanelHandler = function(el, parent, panel, space_owner) {
                  jQuery(elt).find('div.discussion-toolbar-row').height() + 15);
         }
     });
-    self.citationView.decorateLinks(self.el.id);
+    self.citationView.decorateLinks(self.$el.attr('id'));
 
     jQuery(this.form).bind('submit', {
         self: this
@@ -110,7 +110,7 @@ DiscussionPanelHandler.prototype.onTinyMCEInitialize = function(instance) {
         }
 
         self.collectionList = new CollectionList({
-            'parent': self.el,
+            '$parent': self.$el,
             'template': 'collection',
             'template_label': 'collection_table',
             'create_annotation_thumbs': true,
@@ -375,9 +375,9 @@ DiscussionPanelHandler.prototype.hide_comment_form = function() {
     });
 };
 
-DiscussionPanelHandler.prototype._bind = function(parent, elementSelector,
+DiscussionPanelHandler.prototype._bind = function($parent, elementSelector,
         event, handler) {
-    var elements = jQuery(parent).find(elementSelector);
+    var elements = $parent.find(elementSelector);
     if (elements.length) {
         jQuery(elements[0]).bind(event, handler);
         return true;

--- a/media/js/app/projects/projectpanel.js
+++ b/media/js/app/projects/projectpanel.js
@@ -4,13 +4,12 @@
 /* global tinymce: true, tinymceSettings: true */
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
-var ProjectPanelHandler = function(el, parent, panel, space_owner) {
+var ProjectPanelHandler = function(el, $parent, panel, space_owner) {
     var self = this;
 
-    this.el = el;
-    this.$el = jQuery(this.el);
+    this.$el = jQuery(el);
     this.panel = panel;
-    this.parentContainer = parent;
+    this.$parentContainer = $parent;
     this.space_owner = space_owner;
     this.tinymceSettings = jQuery.extend(tinymceSettings, {
         init_instance_callback: function(editor) {
@@ -27,7 +26,7 @@ var ProjectPanelHandler = function(el, parent, panel, space_owner) {
     djangosherd.storage.json_update(panel.context);
     MediaThread.loadTemplate('project_revisions')
         .then(function() {
-            self.initAfterTemplateLoad(el, parent, panel, space_owner);
+            self.initAfterTemplateLoad(el, $parent, panel, space_owner);
         });
 };
 
@@ -59,56 +58,56 @@ ProjectPanelHandler.prototype.initAfterTemplateLoad = function(
         self.resize();
     });
 
-    self._bind(self.el, 'td.panel-container', 'panel_state_change',
+    self._bind(self.$el, 'td.panel-container', 'panel_state_change',
         function() {
             self.onClosePanel(jQuery(this).hasClass('subpanel'));
         });
 
-    self._bind(self.el, 'form[name="editproject"]', 'keypress keydown keyup',
+    self._bind(self.$el, 'form[name="editproject"]', 'keypress keydown keyup',
         function(e) {
             if (e.keyCode === 13) {
                 e.preventDefault();
             }
         });
 
-    self._bind(self.el, '.project-savebutton', 'click', function(evt) {
+    self._bind(self.$el, '.project-savebutton', 'click', function(evt) {
         return self.showSaveOptions(evt);
     });
-    self._bind(self.el, 'a.project-visibility-link', 'click', function(evt) {
+    self._bind(self.$el, 'a.project-visibility-link', 'click', function(evt) {
         self.$el.find('.project-savebutton').click();
     });
-    self._bind(self.el, '.project-previewbutton', 'click', function(evt) {
+    self._bind(self.$el, '.project-previewbutton', 'click', function(evt) {
         return self.preview(evt);
     });
-    self._bind(self.el, '.participants_toggle', 'click', function(evt) {
+    self._bind(self.$el, '.participants_toggle', 'click', function(evt) {
         return self.showParticipantList(evt);
     });
 
-    self._bind(self.el, '.project-revisionbutton', 'click',
+    self._bind(self.$el, '.project-revisionbutton', 'click',
         function(evt) {
             self.showRevisions(evt);
         });
-    self._bind(self.el, '.project-responsesbutton', 'click',
+    self._bind(self.$el, '.project-responsesbutton', 'click',
         function(evt) {
             self.showResponses(evt);
         });
-    self._bind(self.el, '.project-my-responses', 'click', function(evt) {
+    self._bind(self.$el, '.project-my-responses', 'click', function(evt) {
         self.showMyResponses(evt);
     });
-    self._bind(self.el, '.project-my-response', 'click', function(evt) {
+    self._bind(self.$el, '.project-my-response', 'click', function(evt) {
         self.showMyResponse(evt);
     });
 
-    self._bind(self.el, '.project-create-assignment-response', 'click',
+    self._bind(self.$el, '.project-create-assignment-response', 'click',
         function(evt) {
             self.createAssignmentResponse(evt);
         });
-    self._bind(self.el, '.project-create-instructor-feedback', 'click',
+    self._bind(self.$el, '.project-create-instructor-feedback', 'click',
         function(evt) {
             self.createInstructorFeedback(evt);
         });
 
-    self._bind(self.el, 'input.project-title', 'keypress', function(evt) {
+    self._bind(self.$el, 'input.project-title', 'keypress', function(evt) {
         self.setDirty(true);
     });
 
@@ -158,7 +157,7 @@ ProjectPanelHandler.prototype.onTinyMCEInitialize = function(instance) {
         });
 
         self.collectionList = new CollectionList({
-            'parent': self.el,
+            '$parent': self.$el,
             'template': 'collection',
             'template_label': 'collection_table',
             'create_annotation_thumbs': true,
@@ -290,7 +289,7 @@ ProjectPanelHandler.prototype.createAssignmentResponse = function(evt) {
     // Navigate to a new project if the user is looking
     // at another response.
     var q = 'td.panel-container.composition';
-    if (jQuery(self.parentContainer).find(q).length > 0) {
+    if (self.$parentContainer.find(q).length > 0) {
         context.callback = function(json) {
             window.location = json.context.project.url;
         };
@@ -915,14 +914,14 @@ ProjectPanelHandler.prototype.beforeUnload = function() {
     }
 
     if (msg) {
-        window.panelManager.openPanel(self.el);
+        window.panelManager.openPanel(self.$el);
         return msg;
     }
 };
 
-ProjectPanelHandler.prototype._bind = function(parent, elementSelector,
+ProjectPanelHandler.prototype._bind = function($parent, elementSelector,
                                                event, handler) {
-    var elements = jQuery(parent).find(elementSelector);
+    var elements = $parent.find(elementSelector);
     if (elements.length) {
         jQuery(elements[0]).on(event, handler);
         return true;

--- a/media/js/app/util.js
+++ b/media/js/app/util.js
@@ -40,13 +40,14 @@ function getVisibleContentHeight() {
 function switcher(event, a) {
     event.preventDefault();
     event.stopPropagation();
-    if (jQuery(a).hasClass('menuclosed')) {
+    var $a = jQuery(a);
+    if ($a.hasClass('menuclosed')) {
         // we're going to open. make sure everyone else is CLOSED
         jQuery('.menuopen').toggleClass('menuopen menuclosed');
         jQuery('.switcher-options').hide();
     }
-    jQuery(a).toggleClass('menuclosed menuopen');
-    jQuery(a).parent().children('.switcher-options').toggle();
+    $a.toggleClass('menuclosed menuopen');
+    $a.parent().children('.switcher-options').toggle();
     return false;
 }
 
@@ -138,15 +139,16 @@ function retrieveData(name) {
 
 function showMessage(msg, onclose, customTitle, position) {
     var title = customTitle ? customTitle : 'Success';
-    jQuery('#dialog-confirm').html(msg);
-    jQuery('#dialog-confirm').dialog({
+    var $dialogConfirm = jQuery('#dialog-confirm');
+    $dialogConfirm.html(msg);
+    $dialogConfirm.dialog({
         resizable: false,
         modal: true,
         title: title,
         close: function() {
             if (onclose) {
                 onclose();
-                jQuery('#dialog-confirm').html('');
+                $dialogConfirm.html('');
             }
         },
         buttons: {
@@ -157,6 +159,6 @@ function showMessage(msg, onclose, customTitle, position) {
     });
     // position newly opened dialog (using its parent container) below $div.
     if (position) {
-        jQuery('#dialog-confirm').dialog('widget').position(position);
+        $dialogConfirm.dialog('widget').position(position);
     }
 }


### PR DESCRIPTION
Avoid calling `jQuery()` when not necessary.

I'm using the convention of $ at the beginning of the variable name
to remind us when we're dealing with a jQuery object, so we don't
have to initialize it with jQuery again.