### PR TITLE
Set SECURE_PROXY_SSL_HEADER

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -318,6 +318,8 @@ LTI_TOOL_CONFIGURATION = {
     'embed_tool_id': 'mediathread',
 }
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
+
 # if you add a 'deploy_specific' directory
 # then you can put a settings.py file and templates/ overrides there
 # otherwise, make sure you specify the correct database settings in your


### PR DESCRIPTION
Nginx translates https:// scheme into the X-Forwarded-Protocol header.
Configure Django to use this header to determine if a request is secure.
(This configuration change should resolve an oauth handshake issue in production.)