### PR TITLE
Standalone Video Play Button

### DIFF
--- a/media/js/lib/sherdjs/src/assets.js
+++ b/media/js/lib/sherdjs/src/assets.js
@@ -20,6 +20,7 @@ if (!Sherd.GenericAssetView) {
         //consts
         var Clipstripper = Sherd.Video.Annotators.ClipStrip;
         var Clipformer = Sherd.Video.Annotators.ClipForm;
+        var Clipplayer = Sherd.Video.Annotators.ClipPlay;
         this.options = options;
         // //INIT
         this.settings = {};
@@ -36,6 +37,10 @@ if (!Sherd.GenericAssetView) {
                     viewgroup.clipstrip = new Clipstripper();
                     viewgroup.clipstrip.attachView(viewgroup.view);
                 }
+                if (options.hasOwnProperty('clipplay') && options.clipplay) {
+                    viewgroup.clipplay = new Clipplayer();
+                    viewgroup.clipplay.attachView(viewgroup.view);
+                }                
             };
             if (Sherd.Video.QuickTime) {
                 var quicktime = this.settings.quicktime = {'view': new Sherd.Video.QuickTime() };
@@ -145,6 +150,12 @@ if (!Sherd.GenericAssetView) {
                     if (cur.clipform) {
                         self.clipform = cur.clipform;
                     }
+                    if (cur.clipplay) {
+                        cur.clipplay.html.push(options.targets.clipplay, {
+                            asset : {}
+                        });
+                        self.clipplay = cur.clipplay;
+                    }
                     if (cur.clipstrip) {
                         var target = 'clipstrip-display'; //default
                         if (options.targets && options.targets.clipstrip) {
@@ -174,6 +185,9 @@ if (!Sherd.GenericAssetView) {
                 cur.view.setState.apply(cur.view, arguments);
                 if (self.clipstrip) {
                     self.clipstrip.setState.apply(self.clipstrip, arguments);
+                }
+                if (self.clipplay) {
+                    self.clipplay.setState.apply(self.clipplay, arguments);
                 }
             }
         };

--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -280,6 +280,7 @@ CitationView.prototype.init = function (options) {
     // This may be DANGEROUS in any sense. The old assetview should be destroyed first?
     if (!djangosherd.assetview) {
         var clipform = options.hasOwnProperty('clipform') ? options.clipform : false;
+        var clipplay = options.hasOwnProperty('clipplay') ? options.clipplay : false;
 
         if (!clipform) {
             djangosherd.assetview = new Sherd.GenericAssetView({ clipform: false, clipstrip: true});
@@ -288,8 +289,12 @@ CitationView.prototype.init = function (options) {
             djangosherd.assetview = new Sherd.GenericAssetView({
                 'clipform': true,
                 'clipstrip': true,
+                'clipplay': clipplay,
                 'storage': djangosherd.noteform,
-                'targets': { clipstrip: 'clipstrip-display' }
+                'targets': {
+                    clipstrip: 'clipstrip-display',
+                    clipplay: 'clipplay'
+                }
             });
         }
     }
@@ -422,6 +427,7 @@ CitationView.prototype.displayCitation = function (anchor, ann_obj, id) {
     var targets = {
         "top": asset_target,
         "clipstrip": jQuery(asset_target).find('div.clipstrip-display').get(0),
+        "clipplay": jQuery(asset_target).find('div.clipplay').get(0),
         "asset": jQuery(asset_target).find('div.asset-display').get(0),
         "asset_title": jQuery(asset_target).find('div.asset-title').get(0),
         "annotation_title": jQuery(asset_target).find('div.annotation-title').get(0)
@@ -460,7 +466,10 @@ CitationView.prototype.displayCitation = function (anchor, ann_obj, id) {
         }
         djangosherd.assetview.html.push(targets.asset, {
             asset : asset_obj,
-            targets: {clipstrip: targets.clipstrip},
+            targets: {
+                clipstrip: targets.clipstrip,
+                clipplay: targets.clipplay
+            },
             functions: { winHeight: self.options.winHeight }
         });
 

--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -283,13 +283,16 @@ CitationView.prototype.init = function (options) {
         var clipplay = options.hasOwnProperty('clipplay') ? options.clipplay : false;
 
         if (!clipform) {
-            djangosherd.assetview = new Sherd.GenericAssetView({ clipform: false, clipstrip: true});
+            djangosherd.assetview = new Sherd.GenericAssetView({
+                clipform: false,
+                clipstrip: true,
+                'clipplay': clipplay
+            });
         } else {
             // GenericAssetView is a wrapper in ../assets.js.
             djangosherd.assetview = new Sherd.GenericAssetView({
                 'clipform': true,
                 'clipstrip': true,
-                'clipplay': clipplay,
                 'storage': djangosherd.noteform,
                 'targets': {
                     clipstrip: 'clipstrip-display',

--- a/media/js/lib/sherdjs/src/video/annotators/clipplay.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipplay.js
@@ -1,0 +1,74 @@
+/* global Sherd: true */
+//Use Cases:
+//Default
+//-- starttime:0, endtime:0
+
+//Signals:
+//seek: when a user clicks on the start/end time of the ClipPlay, sends a seek event out
+
+if (!Sherd) {Sherd = {}; }
+if (!Sherd.Video) {Sherd.Video = {}; }
+if (!Sherd.Video.Annotators) {Sherd.Video.Annotators = {}; }
+if (!Sherd.Video.Annotators.ClipPlay) {
+    Sherd.Video.Annotators.ClipPlay = function () {
+        var self = this;
+
+        Sherd.Video.Base.apply(this, arguments); //inherit off video.js - base.js
+
+        this.attachView = function (view) {
+            this.targetview = view;
+        };
+
+        this.getState = function () {
+            var obj = {};
+
+            obj.starttime = self.components.starttime;
+            obj.endtime = self.components.endtime;
+            return obj;
+        };
+
+        this.setState = function (obj) {
+            if (typeof obj === 'object') {
+                var c = self.components;
+                if (obj === null) {
+                    c.starttime = c.endtime = 0;
+                } else {
+                    c.starttime = obj.start || 0;
+                    c.endtime = obj.end || c.starttime;
+                }
+                return true;
+            }
+        };
+
+        this.initialize = function (create_obj) {
+            self.events.connect(self.components.clipPlay, 'click', function (evt) {
+                var obj = self.getState();
+                self.events.signal(self.targetview, 'playclip', { start: obj.starttime, end: obj.endtime });
+            });
+        };
+
+        this.microformat.create = function (obj) {
+            return {
+                htmlID: 'play-selection',
+                text: '<button class="btn btn-sm btn-default"' +
+                    'id="play-selection">' +
+                    'Play Selection ' +
+                    '<span class="glyphicon glyphicon-play" ' +
+                    'aria-hidden="true"></span></button>'
+            };
+        };
+
+        // self.components -- Access to the internal player and any options needed at runtime
+        this.microformat.components = function (html_dom, create_obj) {
+            try {
+                return {
+                    clipPlay: document.getElementById(create_obj.htmlID),
+                    starttime: 0,
+                    endtime: 0,
+                };
+            } catch (e) {}
+            return false;
+        };
+    };/* function Sherd.Video.Annotators.ClipPlay() */
+        
+}/*if !ClipPlay...*/

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -826,11 +826,19 @@ class AssetEmbedView(TemplateView):
         else:
             presentation = 'small'
 
-        return {'item': json.dumps(ctx),
-                'item_id': selection.asset.id,
-                'selection_id': selection.id,
-                'presentation': presentation,
-                'title': selection.display_title()}
+        media_type = selection.asset.media_type()
+
+        ctx = {'item': json.dumps(ctx),
+               'item_id': selection.asset.id,
+               'selection_id': selection.id,
+               'presentation': presentation,
+               'media_type': media_type,
+               'title': selection.display_title()}
+
+        if media_type == 'video':
+            ctx['timecode'] = selection.range_as_timecode()
+
+        return ctx
 
 
 class AssetWorkspaceView(LoggedInMixin, RestrictedMaterialsMixin,

--- a/mediathread/templates/assetmgr/asset_embed_view.html
+++ b/mediathread/templates/assetmgr/asset_embed_view.html
@@ -1,12 +1,14 @@
-{% load compress static %}
+{% load compress static bootstrap3 %}
 <!DOCTYPE html>
 <html lang="en" style="height: auto;">
 <head>
-    <script type="text/javascript" src='{% static "jquery/js/jquery-1.11.3.min.js" %}'></script>
-    <script src="{{STATIC_URL}}js/flowplayer/flowplayer-5.5.0.min.js"></script>
+    <script type="text/javascript" src="{% static 'jquery/js/jquery-1.11.3.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/flowplayer/flowplayer-5.5.0.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/lib/sherdjs/lib/OpenLayers-min.js' %}"></script>
     <script type="text/javascript" src="/jsi18n"></script>
-    
+
+    {% bootstrap_css %}
+
     {% compress css %}
         <link rel="stylesheet" href='{% static "css/mediathread.css" %}' media="screen" />
         <!--All the annotation css -->
@@ -15,8 +17,9 @@
 </head>
 
 <body>
-    <h3>{{title|truncatechars:40}}</h3>
+    <h3>{{title|truncatechars:40}} {{timecode}}</h3>
     <div id="videoclipbox" class="videoclipbox" style="display: none;">
+        <div class="clipplay"></div><br />
         <div class="asset-object" style="border: none; background-color: #ededed;"></div>
         <div class="asset-display"></div>
         <div class="clipstrip-display"></div>
@@ -37,6 +40,9 @@
                 'default_target': 'videoclipbox',
                 'presentation': '{{presentation}}',
                 'clipform': false,
+                {% if media_type == 'video' %}
+                    'clipplay': true,
+                {% endif %}
                 'autoplay': false,
                 'winHeight': function() {
                     return 200;

--- a/mediathread/templates/djangosherd/annotator_resources.html
+++ b/mediathread/templates/djangosherd/annotator_resources.html
@@ -30,6 +30,7 @@
 
 <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/src/video/annotators/clipform.js"></script>
 <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/src/video/annotators/clipstrip.js"></script>
+<script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/src/video/annotators/clipplay.js"></script>
 
 <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/src/image/views/openlayers.js"></script>
 <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/src/image/annotators/openlayers.js"></script>


### PR DESCRIPTION
Meth videos are normally displayed with a clipform that contains a "play" button along
with a set of selection tools. This play button seeks to the correct selection location
and plays the video. In cases where the clipform is not displayed, for example, the LTI
embed selection form,  an alternate way to play the selection is needed. This PR creates a small bit of UI that optionally injects a play button into a citation view.

<img width="339" alt="screen shot 2016-01-05 at 10 07 58 am" src="https://cloud.githubusercontent.com/assets/141369/12118412/46ac919c-b394-11e5-9866-4d0b2be4c296.png">
