### PR TITLE
return instead of raise HttpResponseForbidden

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -206,7 +206,7 @@ class AssetCreateView(View):
     def post(self, request):
         user = self.parse_user(request)
         if not request.course or not request.course.is_member(user):
-            raise HttpResponseForbidden(
+            return HttpResponseForbidden(
                 "You must be a member of the course to add assets.")
 
         req_dict = getattr(request, request.method)


### PR DESCRIPTION
I was messing with mediathread on staging, trying to get
the chrome extension's configurable host url to work, and
I ran into a 500 error.

https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/952/

Here is the stack trace:

[u'TypeError: exceptions must be old-style classes or derived from
BaseException, not HttpResponseForbidden', u'  File
"django/core/handlers/base.py", line 132, in get_response', u'  File
"django/utils/decorators.py", line 145, in inner', u'  File
"django/views/generic/base.py", line 71, in view', u'  File
"django/views/generic/base.py", line 89, in dispatch', u'  File
"mediathread/assetmgr/views.py", line 210, in post']