### PR TITLE
Fix tinymce error when editing assignment - PMT #104751

### DIFF
--- a/media/js/app/panel.js
+++ b/media/js/app/panel.js
@@ -6,17 +6,17 @@
 
 (function() {
     var PanelFactory = function() {
-        this.create = function(el, $parent, type, panels, space_owner) {
+        this.create = function(el, $parent, type, panel, space_owner) {
             // Instantiate the panel's handler
             var handler = null;
             if (type === 'project') {
-                handler = new ProjectPanelHandler(el, $parent, panels,
+                handler = new ProjectPanelHandler(el, $parent, panel,
                                                   space_owner);
             } else if (type === 'discussion') {
-                handler = new DiscussionPanelHandler(el, $parent, panels,
+                handler = new DiscussionPanelHandler(el, $parent, panel,
                                                      space_owner);
             } else if (type === 'asset') {
-                handler = new AssetPanelHandler(el, $parent, panels,
+                handler = new AssetPanelHandler(el, $parent, panel,
                                                 space_owner);
             }
 

--- a/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
+++ b/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
@@ -76,7 +76,7 @@
         _decorateCitationAdders: function(ed, citation_plugin, dom) {
             var highlighter = null;
             each(DOM.select('img.' + klass, dom), function(citer) {
-                if (DomQuery(citer).hasClass('materialCitation')) {
+                if (DomQuery(citer).hasClass('clickableCitation')) {
                     citer.onclick = function(evt) {
                         citation_plugin.addCitation(evt);
                     };

--- a/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
+++ b/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
@@ -1,5 +1,11 @@
 /* global tinymce: true, CitationView: true, wordCount: true */
 
+/*
+ * This file is named plugin.min.js because that's what TinyMCE 4
+ * expects. I'd still like to keep it unminified because it makes
+ * development easier.
+ */
+
 (function() {
     var DOM = tinymce.DOM;
     var DomQuery = tinymce.dom.DomQuery;
@@ -13,9 +19,9 @@
             return {
                 longname : 'Citation Plugin',
                 author : 'Schuyler Duveen',
-                authorurl : 'http://ccnmtl.columbia.edu',
-                infourl : 'http://ccnmtl.columbia.edu/mediathread',
-                version : "1.1" //for tinymce 3!
+                authorurl : 'http://ctl.columbia.edu/',
+                infourl : 'http://mediathread.info/',
+                version : "1.2"
             };
         },
         createCitationHTML: function(annotation) {
@@ -69,26 +75,12 @@
         },
         _decorateCitationAdders: function(ed, citation_plugin, dom) {
             var highlighter = null;
-            each(DOM.select('img.'+klass, dom),function(citer) {
-                if (citer.onclick) {
-                    citer.onclick = function(evt){citation_plugin.addCitation(evt);};
+            each(DOM.select('img.' + klass, dom), function(citer) {
+                if (DomQuery(citer).hasClass('materialCitation')) {
+                    citer.onclick = function(evt) {
+                        citation_plugin.addCitation(evt);
+                    };
                 }
-
-                ///Adds a little cursor to where it will get added.
-                ///tested in Firefox, Webkit
-                EventUtils.bind(citer,'mouseover',function(evt) {
-                    if (highlighter === null) {
-                        var active_ed = tinymce.activeEditor;
-                        var editor_pos = DOM.getPos(active_ed.getContentAreaContainer());
-                        var editor_rect = DOM.getRect(active_ed.getContentAreaContainer());
-                        var cursor_pos = DOM.getPos(active_ed.selection.getNode());
-
-                        var pos = {x:editor_pos.x + editor_rect.w, y:editor_pos.y+cursor_pos.y};
-                        highlighter = DOM.create('div',{'class': 'mceContentBodyCursor', style:'top:'+pos.y+'px;left:'+pos.x+'px'},'&#171;');
-                        document.body.appendChild(highlighter);
-                    }
-                    evt.stopPropagation();
-                });
             },this);
             EventUtils.bind(document.body,'mouseover',function(evt) {
                 if (highlighter !== null) {

--- a/media/templates/collection_assets.mustache
+++ b/media/templates/collection_assets.mustache
@@ -68,7 +68,7 @@
                 </div>
                 {{#citable}}
                     <span class="citationTemplate">
-                        <img class="materialCitation" alt=""
+                        <img class="materialCitation clickableCitation" alt=""
                         src="/media/img/icons/meth_insert_{{media_type_label}}.png#annotation={{local_url}}&title={{title}}&type={{primary_type}}&range1=0"
                         title="Add item to the composition"
                         name="{{local_url}}"/>
@@ -146,7 +146,7 @@
                                             <td class="selection-inserter">
                                                 {{#citable}}
                                                     <span class="citationTemplate">
-                                                        <img class="materialCitation" alt=""
+                                                        <img class="materialCitation clickableCitation" alt=""
                                                         src="/media/img/icons/meth_insert_selection.png#annotation={{url}}&title={{metadata.title}}&type={{metadata.primary_type}}&range1={{range1}}"
                                                         title="Add selection to the composition"
                                                         name="{{url}}"/>

--- a/media/templates/collection_assets.mustache
+++ b/media/templates/collection_assets.mustache
@@ -70,7 +70,6 @@
                     <span class="citationTemplate">
                         <img class="materialCitation" alt=""
                         src="/media/img/icons/meth_insert_{{media_type_label}}.png#annotation={{local_url}}&title={{title}}&type={{primary_type}}&range1=0"
-                        onclick="addMaterialCitation(event)"
                         title="Add item to the composition"
                         name="{{local_url}}"/>
                     </span>
@@ -149,7 +148,6 @@
                                                     <span class="citationTemplate">
                                                         <img class="materialCitation" alt=""
                                                         src="/media/img/icons/meth_insert_selection.png#annotation={{url}}&title={{metadata.title}}&type={{metadata.primary_type}}&range1={{range1}}"
-                                                        onclick="addMaterialCitation(event)"
                                                         title="Add selection to the composition"
                                                         name="{{url}}"/>
                                                     </span>


### PR DESCRIPTION
This issue came up because there are two potential tinymce editing
areas on this view - one for the response and one for the assignment.
As an instructor, tinymce is initialized for the assignment, as a
student it's initialized for the response, based on the `can_edit`
variable.

In some cases, this if clause in the onTinyMCEInitialize callback
was false when it should be true, due to multiple instances of
ProjectPanelHandler setting self.panel.

    instance.id === self.panel.context.project.id + '-project-content'

Now, I'm not sure yet why there was a conflict - two different instances
should be isolated from each other. But I addressed the issue by
refactoring: only defining the tinymce settings when necessary, taking
this object out of the constructor.

There's also some minor cleanup here:
* Putting the tinymce.show() calls in an if statement prevents the bad
  bug where the screen goes blank. If for some reason there's another
  issue like this, tinymce just won't be initialized.
* Renamed a variable in panel.js that was referring to a single panel,
  not multiple panels.