### PR TITLE
Revisions View: fix Respond To Assignment button display

### DIFF
--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -301,6 +301,8 @@ class ProjectReadOnlyView(ProjectReadableMixin, JSONResponseMixin,
             panel = {'panel_state': 'open',
                      'panel_state_label': "Version View",
                      'context': project_context,
+                     'is_faculty':
+                         self.request.course.is_faculty(request.user),
                      'template': 'project'}
             panels.append(panel)
 

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -290,6 +290,9 @@ class ProjectReadOnlyView(ProjectReadableMixin, JSONResponseMixin,
 
             panels = []
 
+            is_faculty = (self.request.course and
+                          self.request.course.is_faculty(request.user))
+
             # Requested project, either assignment or composition
             request.public = True
 
@@ -301,8 +304,7 @@ class ProjectReadOnlyView(ProjectReadableMixin, JSONResponseMixin,
             panel = {'panel_state': 'open',
                      'panel_state_label': "Version View",
                      'context': project_context,
-                     'is_faculty':
-                         self.request.course.is_faculty(request.user),
+                     'is_faculty': is_faculty,
                      'template': 'project'}
             panels.append(panel)
 


### PR DESCRIPTION
Faculty were incorrectly seeing the Respond To Assignment button in the revisions view.
The 'is_faculty' data point was missing for template rendering.