### PR TITLE
TinyMCE4 - bump font size

### DIFF
--- a/media/css/project.css
+++ b/media/css/project.css
@@ -55,17 +55,6 @@ body.mce-content-body {
     font: 0.8em/120% 'lucida grande',arial,verdana,sans-serif;
 }
 
-.mceContentBodyCursor {
-    width:10px;
-    background-color:red;
-    position:absolute;
-    padding: none;
-    margin: none;
-    font:1em/100% 'lucida grande',arial,verdana,sans-serif;
-    font-weight: bold;
-}
-
-
 div.mce_editorwindow {
     min-width: 324px;
 }

--- a/media/css/project.css
+++ b/media/css/project.css
@@ -47,7 +47,7 @@ h4 img.materialCitation {
     border: none;
 }
 
-body.mceContentBody {
+body.mce-content-body {
     /**overrides tinyMCE's default 10px which will not correspond
       to styled as published (and 10px is too small for the image-annotation
       icon)

--- a/media/js/app/tinymce_init.js
+++ b/media/js/app/tinymce_init.js
@@ -9,5 +9,6 @@ var tinymceSettings = {
     'selector': '.mceEditor',
     'toolbar': 'bold, italic, underline, spacer, bullist, numlist, ' +
         'spacer, outdent, indent, spacer, undo, redo, spacer, link, ' +
-        'unlink, image, spacer, code, pasteword'
+        'unlink, image, spacer, code, pasteword',
+    'content_css': '/media/css/project.css'
 };


### PR DESCRIPTION
The font was previously picked up via the content_css attribute in tinymceSettings.
Restore this connection. (And remember to update it once we switch to static serving...)
The attribute was also renamed in v4