### PR TITLE
Vimeo: refactoring seek

### DIFF
--- a/media/js/lib/sherdjs/src/base.js
+++ b/media/js/lib/sherdjs/src/base.js
@@ -252,16 +252,6 @@ Sherd.Base = {
                             // Create microformat.components (self.components)
                             var top = document.getElementById(createObj.htmlID);
 
-                            // If the created element was a vimeo video, we need to
-                            // initialize its 'ready' handler.
-                            if (/^vimeo-wrapper-\d+$/.test(createObj.htmlID)) {
-                                var iframe = jQuery(top).find('iframe')[0];
-                                var froogaloop = $f(iframe);
-                                froogaloop.addEvent('ready', function() {
-                                    djangosherd.assetview.settings.vimeo.view.vimeoPlayerReady(
-                                        froogaloop);
-                                });
-                            }
                             self.html.put(top, createObj);
                         }
                     }

--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -322,6 +322,9 @@ if (!Sherd.Video.Vimeo) {
                 if (starttime !== undefined && starttime > 0) {
                     if (self.components.player.api) {
                         self.components.player.api('seekTo', starttime);
+                        if (!self.state.autoplay) {
+                            self.components.player.api('pause');
+                        }
                     }
                 }
 


### PR DESCRIPTION
Removing a lot of old confusing, seek hacks needed for the old Moogaloop api. As the player
events seem *much* more robust this go around, also leveraging them to pickup isPlaying, currentTime & currentDuration.