### PR TITLE
Add safari update manifest plist file

### DIFF
--- a/media/safari_update_manifest.plist
+++ b/media/safari_update_manifest.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>Extension Updates</key>
+   <array>
+     <dict>
+       <key>CFBundleIdentifier</key>
+       <string>edu.columbia.safari.mediathread</string>
+       <key>Developer Identifier</key>
+       <string>N4GV9R3SDD</string>
+       <key>CFBundleVersion</key>
+       <string>1</string>
+       <key>CFBundleShortVersionString</key>
+       <string>0.0.5</string>
+       <key>URL</key>
+       <string>https://github.com/ccnmtl/mediathread-safari/releases/download/0.0.5/Mediathread.safariextz</string>
+     </dict>
+   </array>
+</dict>
+</plist>


### PR DESCRIPTION
I got an email back from Apple saying we need to set this up as
described here:
  https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/UpdatingExtensions/UpdatingExtensions.html