### PR TITLE
Link to FF extension file on addons.mozilla.org

### DIFF
--- a/mediathread/templates/assetmgr/install_firefox_extension.html
+++ b/mediathread/templates/assetmgr/install_firefox_extension.html
@@ -10,7 +10,7 @@
         this extension.
     </p>
     <a id="firefox-install-button"
-       href="https://github.com/ccnmtl/mediathread-firefox/releases/download/0.1.7/mediathread-0.1.7-fx.xpi"
+       href="https://addons.mozilla.org/firefox/downloads/latest/669813/addon-669813-latest.xpi"
        class="btn btn-primary pull-left">
         + Add to Firefox
     </a>


### PR DESCRIPTION
Now that the Firefox extension has been fully approved by Mozilla, we
can have users install this version instead.

> Dear Author,
> Full approval has been granted. Usually, due to your low user count, it
> is not granted. However I see that this tool is very helpful to students
> in many different colleges. I feel the audience would be great.