### PR TITLE
Add "Update From Gallery" field to safari plist

### DIFF
--- a/media/safari_update_manifest.plist
+++ b/media/safari_update_manifest.plist
@@ -15,6 +15,8 @@
        <string>0.0.5</string>
        <key>URL</key>
        <string>https://github.com/ccnmtl/mediathread-safari/releases/download/0.0.5/Mediathread.safariextz</string>
+       <key>Update From Gallery</key>
+       <true/>
      </dict>
    </array>
 </dict>


### PR DESCRIPTION
This field is required to allow for automatic updating from the Safari
Extensions Gallery, as documented here:
https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/DistributingYourExtension/DistributingYourExtension.html#//apple_ref/doc/uid/TP40009977-CH19-SW4