### PR TITLE
Validate Selection Start/End Times

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -2870,6 +2870,12 @@ tr.sherd-clipform-editing td {
     text-align: right;
 }
 
+.sherd-clipform-editing .helptext.timecode {
+    text-align: right;
+    width: 89%;
+}
+
+
 .sherd-clipform-editing input.videoplay {
     width: 25px;
     margin: -2px 0 0 0;

--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -897,7 +897,7 @@
                     djangosherd.assetview.clipform.storage.update(obj, true);
                 }
             }
-            
+
             var msg;
             if (frm.elements['annotation-title'].value === '') {
                 msg = 'Please specify a selection title';
@@ -905,11 +905,11 @@
                 if (obj.start > obj.duration) {
                     msg = 'The start time is greater than the video length. ' +
                         'Please specify the start time in hours, minutes ' +
-                        'and seconds (HH:MM:SS).'
+                        'and seconds (HH:MM:SS).';
                 } else if (obj.end > obj.duration) {
                     msg = 'The end time is greater than the video length. ' +
                         'Please specify the end time in hours, minutes ' +
-                        'and seconds (HH:MM:SS).'
+                        'and seconds (HH:MM:SS).';
                 } else if (obj.start > obj.end) {
                     msg = 'The start time is greater than the end time.';
                 }
@@ -928,7 +928,7 @@
                             at: 'center',
                             of: jQuery('div.asset-view-tabs')
                         });
-                    return;
+                return;
             }
 
             // Save the results up on the server

--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -897,21 +897,38 @@
                     djangosherd.assetview.clipform.storage.update(obj, true);
                 }
             }
-
+            
+            var msg;
             if (frm.elements['annotation-title'].value === '') {
-                showMessage('Please specify a selection title',
-                    function() {
-                        jQuery(saveButton).removeAttr('disabled');
-                        jQuery(saveButton).removeClass('saving');
-                        jQuery(saveButton).attr('value', 'Save');
-                    },
-                    'Error',
-                    {
-                        my: 'center',
-                        at: 'center',
-                        of: jQuery('div.asset-view-tabs')
-                    });
-                return;
+                msg = 'Please specify a selection title';
+            } else if (obj.duration && obj.duration > 0) {
+                if (obj.start > obj.duration) {
+                    msg = 'The start time is greater than the video length. ' +
+                        'Please specify the start time in hours, minutes ' +
+                        'and seconds (HH:MM:SS).'
+                } else if (obj.end > obj.duration) {
+                    msg = 'The end time is greater than the video length. ' +
+                        'Please specify the end time in hours, minutes ' +
+                        'and seconds (HH:MM:SS).'
+                } else if (obj.start > obj.end) {
+                    msg = 'The start time is greater than the end time.';
+                }
+            }
+
+            if (msg) {
+                showMessage(msg,
+                        function() {
+                            jQuery(saveButton).removeAttr('disabled');
+                            jQuery(saveButton).removeClass('saving');
+                            jQuery(saveButton).attr('value', 'Save');
+                        },
+                        'Error',
+                        {
+                            my: 'center',
+                            at: 'center',
+                            of: jQuery('div.asset-view-tabs')
+                        });
+                    return;
             }
 
             // Save the results up on the server

--- a/media/js/lib/sherdjs/src/video/annotators/clipform.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipform.js
@@ -303,10 +303,12 @@ if (!Sherd.Video.Annotators.ClipForm) {
                        '<tr class="sherd-clipform-editing">' +
                          '<td>' +
                            '<input type="text" class="timecode" id="clipStart" value="' + self.components.start + '" />' +
+                           '<div class="helptext timecode">HH:MM:SS</div>' +
                          '</td>' +
                          '<td style="width: 10px; text-align: center">-</td>' +
                          '<td>' +
                            '<input type="text" class="timecode" id="clipEnd" value="' + self.components.end + '" />' +
+                           '<div class="helptext timecode">HH:MM:SS</div>' +
                          '</td>' +
                          '<td class="sherd-clipform-play">' + 
                          '<input type="image" title="Play Clip" class="regButton videoplay" id="btnPlayClip" src="/media/img/icons/meth_video_play.png"/>' +


### PR DESCRIPTION
Users are occasionally entering video selection times (HH:MM:SS) incorrectly as hours rather than minutes. e.g. 01:01:00 instead of 00:01:01. When this happens, the start and end times are greater than the video duration. The selection times are ignored and the video plays from the beginning.

This code verifies the start & end times are not larger than the duration where possible. Depending on the player, duration is not always immediately available. For example, Vimeo's duration is not recorded until the player begins playing. But, I think this will catch many errors and save some headaches.