### PR TITLE
:arrow_up: mediathread-safari 0.0.7

### DIFF
--- a/media/safari_update_manifest.plist
+++ b/media/safari_update_manifest.plist
@@ -12,9 +12,9 @@
        <key>CFBundleVersion</key>
        <string>1</string>
        <key>CFBundleShortVersionString</key>
-       <string>0.0.6</string>
+       <string>0.0.7</string>
        <key>URL</key>
-       <string>https://github.com/ccnmtl/mediathread-safari/releases/download/0.0.6/Mediathread.safariextz</string>
+       <string>https://github.com/ccnmtl/mediathread-safari/releases/download/0.0.7/Mediathread.safariextz</string>
        <key>Update From Gallery</key>
        <true/>
      </dict>


### PR DESCRIPTION
I'm still getting used to having this version number in two places. (https://github.com/ccnmtl/mediathread/pull/535)