### PR TITLE
Blackboard Roles

### DIFF
--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -22,7 +22,10 @@ class LTIAuthMixin(object):
         # add the user to the requested groups
         user.groups.add(ctx.group)
         for role in lti.user_roles():
-            if role.lower() in ['staff', 'instructor', 'administrator']:
+            role = role.lower()
+            if ('staff' in role or
+                'instructor' in role or
+                    'administrator' in role):
                 user.groups.add(ctx.faculty_group)
                 break
 


### PR DESCRIPTION
Blackboard sends over: urn:lti:role:ims/lis/Instructor rather than Instructor or Staff. Refactor the role comparators to be a little more flexible.