### PR TITLE
Use Safari extension from the extension gallery

### DIFF
--- a/mediathread/templates/assetmgr/install_safari_extension.html
+++ b/mediathread/templates/assetmgr/install_safari_extension.html
@@ -10,7 +10,8 @@
         this extension.
     </p>
     <a id="safari-install-button"
-       href="https://github.com/ccnmtl/mediathread-safari/releases/download/0.0.7/Mediathread.safariextz"
+       target="_blank"
+       href="https://safari-extensions.apple.com/details/?id=edu.columbia.safari.mediathread-N4GV9R3SDD"
        class="btn btn-primary pull-left">
         + Add to Safari
     </a>


### PR DESCRIPTION
Now that the Safari extension has been accepted into Apple's extension
gallery, we should have users use that version so they will receive
automatic updates. Unfortunately, there's no way to allow for a
one-click install from within Mediathread, see documentation here:
https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/DistributingYourExtension/DistributingYourExtension.html#//apple_ref/doc/uid/TP40009977-CH19-SW2

When I link directly to the gallery's Mediathread.safariextz file from
Mediathread, it forwards you to the gallery page anyways, so the easiest
way to have users install this is just link them to the gallery page,
and they can do the one-click install from there.

Also, note that the Extension Gallery page for Mediathread
only works if you're using Safari, because that's how Apple operates:
  https://forums.developer.apple.com/thread/43641