### PR TITLE
Add homepage view for instructors - PMT #105457

### DIFF
--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -4,7 +4,7 @@ import json
 from courseaffils.lib import in_course_or_404, in_course
 from courseaffils.middleware import SESSION_KEY
 from courseaffils.models import Course
-from courseaffils.views import get_courses_for_user
+from courseaffils.views import get_courses_for_user, CourseListView
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
@@ -38,9 +38,12 @@ from mediathread.main.forms import RequestCourseForm, ContactUsForm, \
     CourseDeleteMaterialsForm, ActivateInvitationForm
 from mediathread.main.models import UserSetting, CourseInvitation
 from mediathread.main.util import send_template_email, user_display_name
-from mediathread.mixins import ajax_required, \
-    AjaxRequiredMixin, JSONResponseMixin, LoggedInFacultyMixin, \
+from mediathread.mixins import (
+    ajax_required,
+    AjaxRequiredMixin, JSONResponseMixin,
+    LoggedInAsFacultyMixin, LoggedInFacultyMixin,
     LoggedInSuperuserMixin
+)
 from mediathread.projects.api import ProjectResource
 from mediathread.projects.models import Project
 from structuredcollaboration.models import Collaboration
@@ -713,3 +716,13 @@ class CourseAcceptInvitationView(FormView):
 
     def get_success_url(self):
         return HttpResponseRedirect(reverse('course-invite-complete'))
+
+
+class HomepageView(LoggedInAsFacultyMixin, CourseListView):
+    template_name = 'main/homepage.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(HomepageView, self).get_context_data(**kwargs)
+        activatable_courses = []
+        context.update({'activatable_courses': activatable_courses})
+        return context

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -1,7 +1,7 @@
 import csv
 import json
 
-from courseaffils.lib import in_course_or_404
+from courseaffils.lib import in_course_or_404, faculty_courses_for_user
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -179,6 +179,17 @@ class LoggedInFacultyMixin(object):
             return HttpResponseForbidden("forbidden")
 
         return super(LoggedInFacultyMixin, self).dispatch(*args, **kwargs)
+
+
+class LoggedInAsFacultyMixin(object):
+    """Mixin for views that only allow faculty."""
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        if not faculty_courses_for_user(self.request.user).exists():
+            return HttpResponseForbidden('forbidden')
+
+        return super(LoggedInAsFacultyMixin, self).dispatch(
+            *args, **kwargs)
 
 
 class LoggedInSuperuserMixin(object):

--- a/mediathread/templates/main/homepage.html
+++ b/mediathread/templates/main/homepage.html
@@ -1,0 +1,96 @@
+{% extends 'base.html' %}
+{% load coursetags %}
+{% load static %}
+
+{% block title %}&mdash; Homepage{% endblock %}
+
+{% block coursetitle %}
+    Homepage
+{% endblock %}
+
+{% block css %}
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.min.css' %}">
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.custom.css' %}">
+{% endblock %}
+
+{% block js %}
+    <script src="{% static 'js/lib/tablesorter/jquery.tablesorter.combined.min.js' %}"></script>
+    <script>
+        jQuery(document).ready(function () {
+            jQuery('.tablesorter').tablesorter({
+                headers: {
+                    '.nosort': {
+                        sorter: false
+                    }
+                },
+                widgets: ['filter'],
+                widgetOptions: {
+                    filter_external: '.course-search',
+                    filter_columnFilters: false
+                }
+            });
+            jQuery("#coursefilter").buttonset();
+
+            jQuery("#create-course").button();
+        });
+    </script>
+{% endblock %}
+
+{% block content %}
+    <div id="course-list">
+        <div id="coursefilter">
+            <span class="h5">View courses for:</span>
+
+            <div class="btn-group" role="group" aria-label="select year">
+                <a id="pastsemesters"
+                   href="?semester_view=past"
+                   class="btn btn-default {% if semester_view == 'past' %}active{% endif %}"
+                >Past Courses</a>
+                <a id="currentsemester"
+                   href="?semester_view=current"
+                   class="btn btn-default {% if semester_view == 'current' %}active{% endif %}"
+                >Current Courses</a>
+            </div>
+        </div>
+    </div>
+    <div class="visualclear"></div>
+
+    <form role="search">
+        <input class="course-search search-box form-control"
+               type="search"
+               data-column="all"
+               placeholder="Search">
+    </form>
+
+    {% if semester_view == 'past' %}
+        <h2>Past Courses</h2>
+    {% elif semester_view == 'current' %}
+        <h2>Current Courses</h2>
+    {% endif %}
+
+    {% if object_list|length > 0 %}
+        <table class="table course-choices tablesorter">
+            <thead>
+                <tr>
+                    <th>Course Title</th>
+                    <th>Term</th>
+                    <th>Instructor</th>
+                    <th>Role</th>
+                    {% if add_privilege %}
+                        <th class="nosort">Actions</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for course in object_list %}
+                    {% include 'courseaffils/course_row.html' %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        No courses match this criteria.
+    {% endif %}
+
+    </div>
+
+{% endblock %}

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -17,6 +17,7 @@ from mediathread.assetmgr.views import (
     AssetCreateView, BookmarkletMigrationView)
 from mediathread.main.forms import CustomRegistrationForm
 from mediathread.main.views import (
+    HomepageView,
     ContactUsView, RequestCourseView, IsLoggedInView, IsLoggedInDataView,
     MigrateMaterialsView, MigrateCourseView, CourseManageSourcesView,
     CourseSettingsView, CourseDeleteMaterialsView, triple_homepage,
@@ -153,6 +154,8 @@ urlpatterns = patterns(
     (r'^crossdomain.xml$', 'django.views.static.serve',
      {'document_root': os.path.abspath(os.path.dirname(__file__)),
       'path': 'crossdomain.xml'}),
+
+    url(r'^homepage/$', HomepageView.as_view(), name='homepage'),
 
     url(r'^dashboard/migrate/materials/(?P<course_id>\d+)/$',
         MigrateMaterialsView.as_view(), {}, 'dashboard-migrate-materials'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ django-reversion==1.9.3
 djangohelpers==0.18.1
 django-contrib-comments==1.6.1
 django-threadedcomments==1.0b1
-django-courseaffils==2.1.0
+django-courseaffils==2.1.1
 django-statsd-mozilla==0.3.16
 raven==5.10.1
 django-appconf==1.0.1  # django_compressor
@@ -84,5 +84,6 @@ path.py==8.1.2
 simplegeneric==0.8.1
 ipython==4.1.2
 ipdb==0.9.0
+freezegun==0.3.6
 
 ccnmtlsettings==0.1.6


### PR DESCRIPTION
This is will turn into the homepage that instructors see when they log
in to mediathread. It will contain a list of future courses to activate,
fetched from the CAS affils. Right now just the basic auth and tests are
in place.