### PR TITLE
Remove django-registration handling /accounts/ route [question]

### DIFF
--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -99,7 +99,6 @@ urlpatterns = patterns(
     url(r'^accounts/register/$',
         RegistrationView.as_view(form_class=CustomRegistrationForm),
         name='registration_register'),
-    (r'^accounts/', include('registration.backends.default.urls')),
 
     # API - JSON rendering layers. Half hand-written, half-straight tasty=pie
     (r'^api/asset/user/(?P<record_owner_name>\w[^/]*)/$',


### PR DESCRIPTION
I really just have some questions about the login routes in
mediathread.. this might not be good to merge. I was trying to trigger
a breakpoint in djangowind's login() view, and it looks like it's being
overridden by django-registration. We're putting both djangowind and
django-registration's routes on the `/accounts/` route. After removing the
django-registration include, I'm still able to login, and I'm also
triggering the breakpoint as it's going to the expected view. I think we
should at least separate the djangowind and django-registration routes
to avoid confusion.

Here are the URLs that django-registration is handling. Some of these
are not being used in mediathread. For example, the change password link
goes to accounts/password_change/, not accounts/password/change.

    ^accounts/ ^activate/complete/$ [name='registration_activation_complete']
    ^accounts/ ^activate/(?P<activation_key>\w+)/$ [name='registration_activate']
    ^accounts/ ^register/complete/$ [name='registration_complete']
    ^accounts/ ^register/closed/$ [name='registration_disallowed']
    ^accounts/ ^register/$ [name='registration_register']
    ^accounts/ ^login/$ [name='auth_login']
    ^accounts/ ^logout/$ [name='auth_logout']
    ^accounts/ ^password/change/$ [name='auth_password_change']
    ^accounts/ ^password/change/done/$ [name='auth_password_change_done']
    ^accounts/ ^password/reset/$ [name='auth_password_reset']
    ^accounts/ ^password/reset/complete/$ [name='auth_password_reset_complete']
    ^accounts/ ^password/reset/done/$ [name='auth_password_reset_done']
    ^accounts/
    ^password/reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$ [name='auth_password_reset_confirm']

I guess my question is.. are we using django-registration for more than
just registration in Mediathread? The `/accounts/register/` route is
separated out of the include I'm removing in this PR.