### PR TITLE
Project.can_read optimization

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -485,7 +485,7 @@ class Project(models.Model):
             return True  # this project is an assignment
 
         parent = collaboration.get_parent()
-        if parent is None or parent.content_object is None:
+        if parent is None:
             return True  # this project does not have a parent assignment
 
         # the author & faculty can always view a submitted response

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -342,7 +342,9 @@ class Project(models.Model):
         '''not protected by can_read, strictly internal'''
         children = children.filter(Q(user=author) | Q(group__user=author))
         response = children.first()
-        return response.content_object if response else None
+        if response:
+            return response.content_object
+        return None
 
     def responses(self, course, viewer, author=None):
         visible = []

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -351,9 +351,11 @@ class Project(models.Model):
         children = self.get_collaboration().get_children_for_object(
             self).prefetch_related('content_object__author')
 
-        viewer_response = self._response_by_author(children, viewer)
+        viewer_response = None
+        if viewer and not viewer.is_anonymous():
+            viewer_response = self._response_by_author(children, viewer)
 
-        if author:
+        if author and not author.is_anonymous():
             children = children.filter(Q(user=author) | Q(group__user=author))
 
         for child in children:

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -424,7 +424,8 @@ class Project(models.Model):
             return u"Private"
 
     def is_participant(self, user):
-        return (user == self.author or user in self.participants.all())
+        return (user == self.author or
+                self.participants.filter(id=user.id).exists())
 
     def citations(self):
         """
@@ -473,8 +474,8 @@ class Project(models.Model):
             return True  # this project does not have a parent assignment
 
         # the author & faculty can always view a submitted response
-        if (self.is_participant(viewer) or
-                cached_course_is_faculty(course, viewer)):
+        if (cached_course_is_faculty(course, viewer) or
+                self.is_participant(viewer)):
             return True
 
         assignment = parent.content_object

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -612,3 +612,10 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         lst = Project.objects.unresponded_assignments(self.sample_course,
                                                       self.student_one)
         self.assertEquals(len(lst), 0)
+
+    def test_is_participant(self):
+        self.assertTrue(self.project_private.is_participant(self.student_one))
+        self.assertFalse(self.project_private.is_participant(self.student_two))
+
+        self.project_private.participants.add(self.student_two)
+        self.assertTrue(self.project_private.is_participant(self.student_two))


### PR DESCRIPTION
With the introduction of the selection assignment, the can_read functionality sometimes needs to check whether the viewer (self.request.user) has submitted their own response before viewing a peer's response. The initial implementation, while simple, was vastly inefficient.

This PR provides an internal model mechanism (_response_by_author) to directly get the self.request.user's response for a given assignment. This mechanism assumes that the viewer, as author, has permission to view their own response. The get is now very fast and cuts overall view times down throughout the application.

In addition, there are a few small optimizations to help speed things along. 