### PR TITLE
Collection Rendering Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 media/js/CHANGES.txt
 the_report
 wheelhouse
+mediathread/templates/debug.html

--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -56,9 +56,6 @@
                 window.location.hash = '';
             }
 
-            djangosherd.assetview.clipform
-                .setState({'start': 0, 'end': 0}, {'mode': 'reset'});
-
             this.refresh(config);
 
             if (this.update_history) {
@@ -160,6 +157,11 @@
                     function(asset_full) {
                         self.processAsset(asset_full);
 
+                        // let the caller display the citationview if needed
+                        if (self.view_callback) {
+                            self.view_callback();
+                        }
+
                         // window.location.hash
                         // #annotation_id=xxxx
                         // #xywh=pixel:x,y,w,h (MediaFragment syntax)
@@ -209,9 +211,6 @@
                                 self.groupBy(val);
                             });
                             self.groupBy(value);
-                        }
-                        if (self.view_callback) {
-                            self.view_callback();
                         }
                         jQuery('.annotation-ajaxloader').hide();
                     }

--- a/media/js/app/assetmgr/assetpanel.js
+++ b/media/js/app/assetmgr/assetpanel.js
@@ -114,8 +114,7 @@ var AssetPanelHandler = function(el, $parent, panel, space_owner) {
     }
 
     if (self.panel.current_asset) {
-        self.showAsset(self.panel.current_asset, self.panel.current_annotation,
-                       true);
+        self.showAsset(self.panel.current_asset, self.panel.current_annotation);
     }
 
     jQuery(window).trigger('resize');
@@ -179,26 +178,26 @@ AssetPanelHandler.prototype.dialog = function(event, assetId, annotationId) {
     return false;
 };
 
-AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id,
-                                                 displayNow) {
+AssetPanelHandler.prototype.showAssetContainer = function() {
+    var self = this;
+
+    self.$el.find('td.panel-container.collection')
+        .removeClass('maximized').addClass('minimized');
+    self.$el.find('td.pantab-container')
+        .removeClass('maximized').addClass('minimized');
+    self.$el.find('div.pantab.collection')
+        .removeClass('maximized').addClass('minimized');
+    self.$el.find('td.panel-container.asset')
+        .removeClass('closed').addClass('open');
+    self.$el.find('td.panel-container.asset').show();
+    self.$el.find('td.panel-container.asset-details').show();
+};
+
+AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id) {
     var self = this;
 
     self.current_asset = parseInt(asset_id, 10);
-
-    if (displayNow) {
-        self.$el.find('td.panel-container.collection')
-            .removeClass('maximized').addClass('minimized');
-        self.$el.find('td.pantab-container')
-            .removeClass('maximized').addClass('minimized');
-        self.$el.find('div.pantab.collection')
-            .removeClass('maximized').addClass('minimized');
-        self.$el.find('td.panel-container.asset')
-            .removeClass('closed').addClass('open');
-        self.$el.find('td.panel-container.asset').show();
-        self.$el.find('td.panel-container.asset-details').show();
-
-        self.citationView.openCitationById(null, asset_id, annotation_id);
-    }
+    self.showAssetContainer();
 
     // Setup the edit view
     window.annotationList.init({
@@ -212,6 +211,7 @@ AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id,
                 jQuery(window).trigger('resize');
             });
             jQuery('html').removeClass('busy');
+            self.citationView.openCitationById(null, asset_id, annotation_id);
         }
     });
 };
@@ -302,7 +302,7 @@ AssetPanelHandler.prototype.onClickAssetTitle = function(evt) {
     var srcElement = evt.srcElement || evt.target || evt.originalTarget;
 
     var bits = srcElement.href.split('/');
-    self.showAsset(bits[bits.length - 2], null, true);
+    self.showAsset(bits[bits.length - 2], null);
 
     return false;
 };
@@ -312,7 +312,7 @@ AssetPanelHandler.prototype.editItem = function(evt) {
     var srcElement = evt.srcElement || evt.target || evt.originalTarget;
 
     var bits = srcElement.parentNode.href.split('/');
-    self.showAsset(bits[bits.length - 2], null, true);
+    self.showAsset(bits[bits.length - 2], null);
     return false;
 };
 

--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -369,7 +369,7 @@ CitationView.prototype.openCitationById = function (anchor, asset_id, annotation
         type = "asset";
     }
 
-    djangosherd.storage.get({id: id, type: type },
+    djangosherd.storage.get({id: id, type: type},
     function (ann_obj) {
         self.options.deleted = false;
         return_value = self.displayCitation(anchor, ann_obj, id);

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -855,30 +855,12 @@ class AssetWorkspaceView(LoggedInMixin, RestrictedMaterialsMixin,
                 ctx = RequestContext(request)
                 return render_to_response('500.html', {}, context_instance=ctx)
 
-        data = {'asset_id': asset_id, 'annotation_id': annot_id}
+        ctx = {'asset_id': asset_id, 'annotation_id': annot_id}
 
         if not request.is_ajax():
             return render_to_response('assetmgr/asset_workspace.html',
-                                      data,
+                                      ctx,
                                       context_instance=RequestContext(request))
-        ctx = {'type': 'asset'}
-        if asset_id:
-            # @todo - refactor this context out of the mix
-            # ideally, the client would simply request the json
-            # the mixin is expecting a queryset, so this becomes awkward here
-            assets = Asset.objects.filter(pk=asset_id)
-            (assets, notes) = self.visible_assets_and_notes(request, assets)
-
-            # only return original author's global annotations
-            notes = notes.exclude(~Q(author=request.user), range1__isnull=True)
-
-            ares = AssetResource()
-            ctx.update(ares.render_one_context(request, asset, notes))
-
-            help_setting = UserSetting.get_setting(request.user,
-                                                   "help_item_detail_view",
-                                                   True)
-            ctx['user_settings'] = {'help_item_detail_view': help_setting}
 
         vocabulary = VocabularyResource().render_list(
             request, Vocabulary.objects.get_for_object(request.course))
@@ -886,23 +868,19 @@ class AssetWorkspaceView(LoggedInMixin, RestrictedMaterialsMixin,
         user_resource = UserResource()
         owners = user_resource.render_list(request, request.course.members)
 
-        update_history = True
-        show_collection = True
-        template = 'asset_workspace'
-
-        data['panels'] = [{
+        ctx['panels'] = [{
             'panel_state': 'open',
             'panel_state_label': "Annotate Media",
-            'context': ctx,
+            'context': {'type': 'asset'},
             'owners': owners,
             'vocabulary': vocabulary,
-            'template': template,
+            'template': 'asset_workspace',
             'current_asset': asset_id,
             'current_annotation': annot_id,
-            'update_history': update_history,
-            'show_collection': show_collection}]
+            'update_history': True,
+            'show_collection': True}]
 
-        return self.render_to_json_response(data)
+        return self.render_to_json_response(ctx)
 
 
 class AssetDetailView(LoggedInMixin, RestrictedMaterialsMixin,

--- a/mediathread/djangosherd/api.py
+++ b/mediathread/djangosherd/api.py
@@ -64,7 +64,7 @@ class SherdNoteResource(ModelResource):
             termResource = TermResource()
             vocabulary = {}
             related = TermRelationship.objects.get_for_object(
-                bundle.obj).prefetch_related('term__vocabulary')
+                bundle.obj).select_related('term__vocabulary')
             for rel in related:
                 if rel.term.vocabulary.id not in vocabulary:
                     vocabulary[rel.term.vocabulary.id] = {

--- a/mediathread/djangosherd/models.py
+++ b/mediathread/djangosherd/models.py
@@ -320,8 +320,10 @@ class SherdNote(Annotation):
                                              self.asset.course.title)
 
     def tags_split(self):
-        "Because |split filter sucks and doesn't break at commas"
-        return Tag.objects.get_for_object(self)
+        if self.tags:
+            "Because |split filter sucks and doesn't break at commas"
+            return Tag.objects.get_for_object(self)
+        return Tag.objects.none()
 
     def add_tag(self, tag):
         self.tags = "%s,%s" % (self.tags, tag)

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -116,10 +116,11 @@ class RestrictedMaterialsMixin(object):
         (visible, hidden) = Project.objects.responses_by_course(
             request.course, self.record_viewer)
 
-        pids = [project.id for project in hidden]
-        pnotes = ProjectNote.objects.filter(project__id__in=pids)
-        pnids = pnotes.values_list('annotation__id', flat=True)
-        visible_notes = visible_notes.exclude(id__in=pnids)
+        if len(hidden) > 0:
+            pids = [project.id for project in hidden]
+            pnotes = ProjectNote.objects.filter(project__id__in=pids)
+            pnids = pnotes.values_list('annotation__id', flat=True)
+            visible_notes = visible_notes.exclude(id__in=pnids)
 
         # return the related asset ids
         ids = visible_notes.values_list('asset__id', flat=True)


### PR DESCRIPTION
* SherdNote.tags_split: check tag existence before performing an expensive generic foreign key lookup
* TermRelationship access: select_related is faster
* avoid executing unnecessary queries
* refactor related term rendering into a separate function
* AssetWorkspaceView refactoring
  * removing a double annotation rendering. (finally!)
  * requires slightly reordering the javascript client flow