### PR TITLE
Remove argparse - it's included in python 2.7

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ FORUM: http://groups.google.com/group/mediathread
 
 REQUIREMENTS
 ------------
-Python 2.7 (Python 2.6 is still supported, but we encourage you to upgrade.)  
+Python 2.7
 Postgres (or MySQL)  
 Flowplayer installation for your site (See below for detailed instructions)  
 Flickr API Key if you want to bookmark from FLICKR    

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ mock==1.0.1  # sure
 sure==1.2.24  # lettuce
 extras==0.0.3
 linecache2==1.0.0  # traceback2
-argparse==1.3.0  # testtools
 traceback2==1.4.0  # testtools
 testtools==1.8.0  # python-subunit
 pbr>=0.11


### PR DESCRIPTION
https://pypi.python.org/pypi/argparse

Additionally, Django hasn't supported Python 2.6 for a while:
https://docs.djangoproject.com/en/1.8/faq/install/#what-python-version-can-i-use-with-django
So I've removed the note in the readme that Mediathread works on Python
2.6.