### PR TITLE
Course activation preliminary - PMT #105457

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -33,7 +33,7 @@ from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from mediathread.djangosherd.views import create_annotation, edit_annotation, \
     delete_annotation, update_annotation
 from mediathread.main.models import UserSetting
-from mediathread.mixins import ajax_required, LoggedInMixin, \
+from mediathread.mixins import ajax_required, LoggedInCourseMixin, \
     JSONResponseMixin, AjaxRequiredMixin, RestrictedMaterialsMixin, \
     LoggedInSuperuserMixin
 from mediathread.taxonomy.api import VocabularyResource
@@ -46,7 +46,7 @@ def _parse_domain(url):
     return '{uri.scheme}://{uri.netloc}/'.format(uri=parsed_uri)
 
 
-class ManageExternalCollectionView(LoggedInMixin, View):
+class ManageExternalCollectionView(LoggedInCourseMixin, View):
 
     def post(self, request):
         suggested_id = request.POST.get('suggested_id', None)
@@ -364,7 +364,7 @@ def annotation_delete(request, asset_id, annot_id):
         return HttpResponseNotFound()
 
 
-class RedirectToExternalCollectionView(LoggedInMixin, View):
+class RedirectToExternalCollectionView(LoggedInCourseMixin, View):
     """
         simple way to redirect to a stored (thus obfuscated) url
     """
@@ -374,7 +374,7 @@ class RedirectToExternalCollectionView(LoggedInMixin, View):
         return HttpResponseRedirect(exc.url)
 
 
-class RedirectToUploaderView(LoggedInMixin, View):
+class RedirectToUploaderView(LoggedInCourseMixin, View):
 
     def post(self, request, *args, **kwargs):
         collection_id = kwargs['collection_id']
@@ -670,7 +670,7 @@ class ScalarExportView(LoggedInSuperuserMixin, RestrictedMaterialsMixin, View):
         return HttpResponse(json.dumps(self.export))
 
 
-class AssetReferenceView(LoggedInMixin, RestrictedMaterialsMixin,
+class AssetReferenceView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                          AjaxRequiredMixin, JSONResponseMixin, View):
 
     def get(self, request, asset_id):
@@ -698,7 +698,7 @@ class AssetReferenceView(LoggedInMixin, RestrictedMaterialsMixin,
         return self.render_to_json_response(ctx)
 
 
-class AssetEmbedListView(LoggedInMixin, RestrictedMaterialsMixin,
+class AssetEmbedListView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                          TemplateView):
 
     template_name = 'assetmgr/asset_embed_list.html'
@@ -841,7 +841,7 @@ class AssetEmbedView(TemplateView):
         return ctx
 
 
-class AssetWorkspaceView(LoggedInMixin, RestrictedMaterialsMixin,
+class AssetWorkspaceView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                          JSONResponseMixin, View):
 
     def get(self, request, asset_id=None, annot_id=None):
@@ -883,7 +883,7 @@ class AssetWorkspaceView(LoggedInMixin, RestrictedMaterialsMixin,
         return self.render_to_json_response(ctx)
 
 
-class AssetDetailView(LoggedInMixin, RestrictedMaterialsMixin,
+class AssetDetailView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                       AjaxRequiredMixin, JSONResponseMixin, View):
 
     def get(self, request, asset_id):
@@ -913,7 +913,7 @@ class AssetDetailView(LoggedInMixin, RestrictedMaterialsMixin,
         return self.render_to_json_response(ctx)
 
 
-class AssetCollectionView(LoggedInMixin, RestrictedMaterialsMixin,
+class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                           AjaxRequiredMixin, JSONResponseMixin, View):
     """
     An ajax-only request to retrieve assets for a course or a specified user
@@ -1012,7 +1012,7 @@ class AssetCollectionView(LoggedInMixin, RestrictedMaterialsMixin,
 AUTO_COURSE_SELECT[AssetWorkspaceView.as_view()] = asset_workspace_courselookup
 
 
-class TagCollectionView(LoggedInMixin, RestrictedMaterialsMixin,
+class TagCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                         AjaxRequiredMixin, JSONResponseMixin, View):
 
     def get(self, request):

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -23,7 +23,7 @@ from mediathread.assetmgr.api import AssetResource
 from mediathread.discussions.utils import pretty_date
 from mediathread.djangosherd.api import SherdNoteResource
 from mediathread.djangosherd.models import DiscussionIndex
-from mediathread.mixins import faculty_only, LoggedInMixin, \
+from mediathread.mixins import faculty_only, LoggedInCourseMixin, \
     LoggedInFacultyMixin
 from mediathread.taxonomy.api import VocabularyResource
 from mediathread.taxonomy.models import Vocabulary
@@ -133,7 +133,7 @@ class DiscussionDeleteView(LoggedInFacultyMixin, View):
         return HttpResponseRedirect(reverse('home'))
 
 
-class DiscussionView(LoggedInMixin, View):
+class DiscussionView(LoggedInCourseMixin, View):
 
     def get(self, request, *args, **kwargs):
         """Show a threadedcomments discussion of an arbitrary object.

--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -13,7 +13,7 @@ from mediathread.assetmgr.models import Asset, Source, ExternalCollection, \
     SuggestedExternalCollection
 from mediathread.discussions.views import discussion_create
 from mediathread.djangosherd.models import SherdNote
-from mediathread.main.models import UserProfile
+from mediathread.main.models import UserProfile, ActivatableAffil
 from mediathread.projects.models import Project, AssignmentItem, ProjectNote
 from mediathread.taxonomy.models import Vocabulary, Term, TermRelationship
 from structuredcollaboration.models import Collaboration, \
@@ -284,3 +284,12 @@ class MediathreadTestMixin(object):
     def enable_upload(self, course):
         ExternalCollectionFactory.create(course=course,
                                          uploader=True)
+
+
+class ActivatableAffilFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = ActivatableAffil
+
+    name = factory.Sequence(
+        lambda n: 't1.y2016.s001.cf1000.scnc.st.course:%d.columbia.edu' % n)
+    user = factory.SubFactory(UserFactory)

--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -163,3 +163,14 @@ class ActivateInvitationForm(forms.Form):
     password2 = forms.CharField(
         required=True,
         widget=forms.PasswordInput(attrs={'class': 'form-control'}))
+
+
+class CourseActivateForm(forms.Form):
+    term = forms.ChoiceField(required=True, choices=TERM_CHOICES)
+    consult_or_demo = forms.ChoiceField(
+        required=True,
+        choices=(
+            ('consultation', 'Consultation'),
+            ('demo', 'In-class demo')),
+        widget=forms.RadioSelect
+    )

--- a/mediathread/main/middleware.py
+++ b/mediathread/main/middleware.py
@@ -1,0 +1,13 @@
+import waffle
+from courseaffils.middleware import CourseManagerMiddleware
+from mediathread.main.views import HomepageView
+
+
+class MethCourseManagerMiddleware(CourseManagerMiddleware):
+    def process_request(self, request):
+        r = super(MethCourseManagerMiddleware, self).process_request(
+            request)
+        if waffle.flag_is_active(request, 'instructor_homepage') and \
+           r is not None:
+            r = HomepageView.as_view()(request)
+        return r

--- a/mediathread/main/migrations/0003_auto_20160413_1447.py
+++ b/mediathread/main/migrations/0003_auto_20160413_1447.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('main', '0002_courseinvitation'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ActivatableAffil',
+            fields=[
+                ('id', models.AutoField(
+                    verbose_name='ID',
+                    serialize=False,
+                    auto_created=True,
+                    primary_key=True)),
+                ('name', models.TextField()),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='activatableaffil',
+            unique_together=set([('name', 'user')]),
+        ),
+    ]

--- a/mediathread/main/models.py
+++ b/mediathread/main/models.py
@@ -90,3 +90,15 @@ class CourseInvitation(models.Model):
 
     def activated(self):
         return self.activated_at is not None
+
+
+class ActivatableAffil(models.Model):
+    """Model for storing activatable affiliations.
+
+    Faculty use this to 'activate' it into a Group/Course.
+    """
+    class Meta:
+        unique_together = ('name', 'user')
+
+    name = models.TextField()
+    user = models.ForeignKey(User)

--- a/mediathread/main/tests/test_auth.py
+++ b/mediathread/main/tests/test_auth.py
@@ -1,9 +1,12 @@
-from django.test.testcases import TestCase
+from django.test import TestCase, override_settings
+from django.contrib.auth.models import AnonymousUser
+from courseaffils.columbia import CourseStringMapper
 
 from mediathread.factories import UserFactory, CourseFactory
 from mediathread.main.auth import CourseGroupMapper
 
 
+@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper)
 class TestCourseGroupMapper(TestCase):
 
     def setUp(self):
@@ -14,7 +17,7 @@ class TestCourseGroupMapper(TestCase):
         affils = [self.user.username]
         self.assertEquals(self.user.groups.count(), 0)
 
-        CourseGroupMapper().map(self.user, affils)
+        CourseGroupMapper.map(self.user, affils)
         self.assertEquals(self.user.groups.count(), 0)
 
     def test_map_user_group_does_not_exist(self):
@@ -22,14 +25,14 @@ class TestCourseGroupMapper(TestCase):
                   'CUcourse_ENGLW3872:columbia.edu']
         self.assertEquals(self.user.groups.count(), 0)
 
-        CourseGroupMapper().map(self.user, affils)
+        CourseGroupMapper.map(self.user, affils)
         self.assertEquals(self.user.groups.count(), 0)
 
     def test_map_user_student_affiliation(self):
         affils = [self.user.username, self.course.group.name]
         self.assertEquals(self.user.groups.count(), 0)
 
-        CourseGroupMapper().map(self.user, affils)
+        CourseGroupMapper.map(self.user, affils)
         self.assertEquals(self.user.groups.count(), 1)
         self.assertTrue(self.course.group in self.user.groups.all())
 
@@ -40,7 +43,52 @@ class TestCourseGroupMapper(TestCase):
 
         self.assertEquals(self.user.groups.count(), 0)
 
-        CourseGroupMapper().map(self.user, affils)
+        CourseGroupMapper.map(self.user, affils)
         self.assertEquals(self.user.groups.count(), 2)
         self.assertTrue(self.course.group in self.user.groups.all())
         self.assertTrue(self.course.faculty_group in self.user.groups.all())
+
+    def test_create_activatable_affil_empty_course_string(self):
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, '', 2016))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, '', None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(None, '', None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(
+                AnonymousUser(), '', 2016))
+
+    def test_create_activatable_affil_student_course_string(self):
+        s = 't1.y2016.s001.cf1000.scnc.st.course:columbia.edu'
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, s, 2016))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, s, None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(None, s, None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(
+                AnonymousUser(), s, 2016))
+
+    def test_create_activatable_affil_faculty_course_string(self):
+        s = 't1.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
+        aa = CourseGroupMapper.create_activatable_affil(self.user, s, 2016)
+        self.assertIsNotNone(aa)
+        self.assertEqual(aa.name, s)
+        self.assertEqual(aa.user, self.user)
+
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, s, 2017))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(self.user, s, None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(None, s, None))
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(
+                AnonymousUser(), s, 2016))
+
+    def test_create_activatable_affil_misc_course_string(self):
+        self.assertIsNone(
+            CourseGroupMapper.create_activatable_affil(
+                self.user, 'ALL_CU', 2016))

--- a/mediathread/main/tests/test_models.py
+++ b/mediathread/main/tests/test_models.py
@@ -1,10 +1,14 @@
 from django.test.client import RequestFactory
 from django.test.testcases import TestCase
 
-from mediathread.factories import MediathreadTestMixin, \
-    UserFactory, UserProfileFactory, CourseFactory
-from mediathread.main.models import UserSetting, user_registered_callback, \
+from mediathread.factories import (
+    MediathreadTestMixin, UserFactory, UserProfileFactory, CourseFactory,
+    ActivatableAffilFactory
+)
+from mediathread.main.models import (
+    UserSetting, user_registered_callback,
     user_activated_callback
+)
 
 
 class UserSettingsTest(MediathreadTestMixin, TestCase):
@@ -68,3 +72,11 @@ class UserRegistrationTest(TestCase):
         user_activated_callback(None, user, None)
 
         self.assertTrue(course.is_member(user))
+
+
+class ActivatableAffilTest(TestCase):
+    def setUp(self):
+        self.aa = ActivatableAffilFactory()
+
+    def test_is_valid_from_factory(self):
+        self.aa.full_clean()

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -1,7 +1,7 @@
 import csv
 import json
 
-from courseaffils.lib import in_course_or_404, faculty_courses_for_user
+from courseaffils.lib import in_course_or_404
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -166,10 +166,16 @@ class CSVResponseMixin():
 class LoggedInMixin(object):
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
+        return super(LoggedInMixin, self).dispatch(*args, **kwargs)
+
+
+class LoggedInCourseMixin(object):
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
         if not self.request.user.is_staff:
             in_course_or_404(self.request.user.username, self.request.course)
 
-        return super(LoggedInMixin, self).dispatch(*args, **kwargs)
+        return super(LoggedInCourseMixin, self).dispatch(*args, **kwargs)
 
 
 class LoggedInFacultyMixin(object):
@@ -180,17 +186,6 @@ class LoggedInFacultyMixin(object):
             return HttpResponseForbidden("forbidden")
 
         return super(LoggedInFacultyMixin, self).dispatch(*args, **kwargs)
-
-
-class LoggedInAsFacultyMixin(object):
-    """Mixin for views that only allow faculty."""
-    @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        if not faculty_courses_for_user(self.request.user).exists():
-            return HttpResponseForbidden('forbidden')
-
-        return super(LoggedInAsFacultyMixin, self).dispatch(
-            *args, **kwargs)
 
 
 class LoggedInSuperuserMixin(object):

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -22,7 +22,7 @@ from mediathread.assetmgr.models import Asset
 from mediathread.discussions.views import threaded_comment_json
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from mediathread.mixins import (
-    LoggedInMixin, RestrictedMaterialsMixin, AjaxRequiredMixin,
+    LoggedInCourseMixin, RestrictedMaterialsMixin, AjaxRequiredMixin,
     JSONResponseMixin, LoggedInFacultyMixin, ProjectReadableMixin,
     ProjectEditableMixin, CreateReversionMixin)
 from mediathread.projects.api import ProjectResource
@@ -34,7 +34,7 @@ from mediathread.taxonomy.models import Vocabulary
 from structuredcollaboration.models import Collaboration
 
 
-class ProjectCreateView(LoggedInMixin, JSONResponseMixin,
+class ProjectCreateView(LoggedInCourseMixin, JSONResponseMixin,
                         CreateReversionMixin, View):
 
     def get_title(self):
@@ -93,8 +93,9 @@ class ProjectCreateView(LoggedInMixin, JSONResponseMixin,
             return self.render_to_json_response(data)
 
 
-class ProjectSaveView(LoggedInMixin, AjaxRequiredMixin, JSONResponseMixin,
-                      ProjectEditableMixin, CreateReversionMixin, View):
+class ProjectSaveView(LoggedInCourseMixin, AjaxRequiredMixin,
+                      JSONResponseMixin, ProjectEditableMixin,
+                      CreateReversionMixin, View):
 
     def post(self, request, *args, **kwargs):
         frm = ProjectForm(request, instance=self.project, data=request.POST)
@@ -152,7 +153,7 @@ class ProjectSaveView(LoggedInMixin, AjaxRequiredMixin, JSONResponseMixin,
         return self.render_to_json_response(ctx)
 
 
-class ProjectDeleteView(LoggedInMixin, ProjectEditableMixin, View):
+class ProjectDeleteView(LoggedInCourseMixin, ProjectEditableMixin, View):
     def post(self, request, *args, **kwargs):
         """
         Delete the requested project. Regular access conventions apply.
@@ -313,7 +314,7 @@ class ProjectReadOnlyView(ProjectReadableMixin, JSONResponseMixin,
             return self.render_to_json_response(data)
 
 
-class SelectionAssignmentView(LoggedInMixin, ProjectReadableMixin,
+class SelectionAssignmentView(LoggedInCourseMixin, ProjectReadableMixin,
                               TemplateView):
     template_name = 'projects/selection_assignment_view.html'
 
@@ -381,7 +382,7 @@ class SelectionAssignmentView(LoggedInMixin, ProjectReadableMixin,
         return ctx
 
 
-class DefaultProjectView(LoggedInMixin, ProjectReadableMixin,
+class DefaultProjectView(LoggedInCourseMixin, ProjectReadableMixin,
                          JSONResponseMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
@@ -515,7 +516,7 @@ class DefaultProjectView(LoggedInMixin, ProjectReadableMixin,
             return self.render_to_json_response(data)
 
 
-class ProjectWorkspaceView(LoggedInMixin, ProjectReadableMixin, View):
+class ProjectWorkspaceView(LoggedInCourseMixin, ProjectReadableMixin, View):
 
     def dispatch(self, request, *args, **kwargs):
         project = get_object_or_404(Project, pk=kwargs.get('project_id', None))
@@ -571,7 +572,7 @@ def project_export_msword(request, project_id):
     return response
 
 
-class ProjectDetailView(LoggedInMixin, RestrictedMaterialsMixin,
+class ProjectDetailView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                         AjaxRequiredMixin, JSONResponseMixin,
                         ProjectReadableMixin, View):
 
@@ -587,7 +588,7 @@ class ProjectDetailView(LoggedInMixin, RestrictedMaterialsMixin,
         return self.render_to_json_response(context)
 
 
-class ProjectCollectionView(LoggedInMixin, RestrictedMaterialsMixin,
+class ProjectCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                             AjaxRequiredMixin, JSONResponseMixin, View):
     """
     An ajax-only request to retrieve assets for a course or a specified user
@@ -668,7 +669,7 @@ class SelectionAssignmentEditView(LoggedInFacultyMixin, TemplateView):
         })
 
 
-class ProjectItemView(LoggedInMixin, JSONResponseMixin,
+class ProjectItemView(LoggedInCourseMixin, JSONResponseMixin,
                       AjaxRequiredMixin, View):
 
     def get(self, *args, **kwargs):

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -42,7 +42,7 @@ TEMPLATE_CONTEXT_PROCESSORS += [  # noqa
 
 MIDDLEWARE_CLASSES += [  # noqa
     'corsheaders.middleware.CorsMiddleware',
-    'courseaffils.middleware.CourseManagerMiddleware',
+    'mediathread.main.middleware.MethCourseManagerMiddleware',
     'django_user_agents.middleware.UserAgentMiddleware',
 ]
 

--- a/mediathread/templates/main/activate_course.html
+++ b/mediathread/templates/main/activate_course.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% load bootstrap3 %}
+
+{% block title %}&mdash; Activate Course{% endblock %}
+
+{% block content %}
+    <h1>Course Activation: {{group.name}}</h1>
+    {% bootstrap_form form layout='inline' %}
+    {% buttons submit='Submit' %}{% endbuttons %}
+{% endblock %}

--- a/mediathread/templates/main/homepage.html
+++ b/mediathread/templates/main/homepage.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load coursetags %}
 {% load static %}
+{% load waffle_tags %}
 
 {% block title %}&mdash; Homepage{% endblock %}
 
@@ -37,6 +38,7 @@
 {% endblock %}
 
 {% block content %}
+    {% flag 'instructor_homepage' %}
     <div id="course-list">
         <div id="coursefilter">
             <span class="h5">View courses for:</span>
@@ -91,6 +93,22 @@
         No courses match this criteria.
     {% endif %}
 
+    {% if activatable_affils|length > 0 %}
+        <h2>Activatable Courses</h2>
+        <ul>
+            {% for affil in activatable_affils %}
+                <li>
+                    {{affil.name}}
+                    <a class="btn btn-default btn-xs"
+                       href="{% url 'affil_activate' affil.id %}" role="button"
+                    >Activate</a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
     </div>
+    {% else %}
+    The instructor_homepage flag isn't enabled for this user.
+    {% endflag %}
 
 {% endblock %}

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -17,10 +17,10 @@ from mediathread.assetmgr.views import (
     AssetCreateView, BookmarkletMigrationView)
 from mediathread.main.forms import CustomRegistrationForm
 from mediathread.main.views import (
-    HomepageView,
+    HomepageView, AffilActivateView,
     ContactUsView, RequestCourseView, IsLoggedInView, IsLoggedInDataView,
     MigrateMaterialsView, MigrateCourseView, CourseManageSourcesView,
-    CourseSettingsView, CourseDeleteMaterialsView, triple_homepage,
+    CourseSettingsView, CourseDeleteMaterialsView, course_detail_view,
     CourseRosterView, CoursePromoteUserView, CourseDemoteUserView,
     CourseRemoveUserView, CourseAddUserByUNIView,
     CourseInviteUserByEmailView, CourseAcceptInvitationView)
@@ -64,7 +64,7 @@ if hasattr(settings, 'CAS_BASE'):
 urlpatterns = patterns(
     '',
 
-    url(r'^$', triple_homepage, name='home'),
+    url(r'^$', course_detail_view, name='home'),
     admin_logout_page,
     logout_page,
     (r'^admin/', admin.site.urls),
@@ -140,6 +140,9 @@ urlpatterns = patterns(
     (r'^course/request/success/$',
      TemplateView.as_view(template_name='main/course_request_success.html')),
     (r'^course/request/', RequestCourseView.as_view()),
+    url(r'^affil/(?P<pk>\d+)/activate/$',
+        AffilActivateView.as_view(),
+        name='affil_activate'),
 
     # Bookmarklet
     url(r'^accounts/logged_in.js$', IsLoggedInView.as_view(), {},


### PR DESCRIPTION
Course activation preliminary - PMT #105457
    
CourseActivateView basics
    
Renamed `LoggedInMixin` to `LoggedInCourseMixin`. `LoggedInMixin` is now
a simple check to see if the user is logged in - doesn't rely on course
stuff.
    
The ActivatableAffil model stores affiliations that the user may want to
activate into a Mediathread course. There are checks in auth.py to see
if the user is a faculty-member of this affiliation, if the date makes
sense, etc. I'll fine-tune these conditions as we go.
    
There's a simple course-activation form that's not functional yet.
    
I've introduced MethCourseManagerMiddleware that forwards the user to
this new 'homepage' instead of the old one, if the waffle flag is
active for them.
