### PR TITLE
Media Selection Form - Rendering Bug Fixes 

### DIFF
--- a/media/js/app/assetmgr/assetpanel.js
+++ b/media/js/app/assetmgr/assetpanel.js
@@ -155,11 +155,12 @@ AssetPanelHandler.prototype.dialog = function(event, assetId, annotationId) {
                 'update_history': false,
                 'vocabulary': self.panel.vocabulary,
                 'view_callback': function() {
-                    self.citationView.openCitationById(
-                        null, assetId, annotationId);
-                    if (self.dialogWindow) {
-                        jQuery(elt).fadeIn('slow');
+                    if (assetId !== self.citationView.asset_id ||
+                            annotationId !== self.citationView.annotation_id) {
+                        self.citationView.openCitationById(
+                            null, assetId, annotationId);
                     }
+                    jQuery(elt).fadeIn('slow');
                 }
             });
         },
@@ -213,9 +214,10 @@ AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id) {
             });
             jQuery('html').removeClass('busy');
 
-            if (asset_id != self.citationView.asset_id ||
-                    annotation_id != self.citationView.annotation_id) {
-                self.citationView.openCitationById(null, asset_id, annotation_id);
+            if (asset_id !== self.citationView.asset_id ||
+                    annotation_id !== self.citationView.annotation_id) {
+                self.citationView.openCitationById(
+                    null, asset_id, annotation_id);
             }
         }
     });

--- a/media/js/app/assetmgr/assetpanel.js
+++ b/media/js/app/assetmgr/assetpanel.js
@@ -199,7 +199,6 @@ AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id) {
 
     self.current_asset = parseInt(asset_id, 10);
     self.showAssetContainer();
-    self.citationView.openCitationById(null, asset_id, annotation_id);
 
     // Setup the edit view
     window.annotationList.init({
@@ -213,6 +212,11 @@ AssetPanelHandler.prototype.showAsset = function(asset_id, annotation_id) {
                 jQuery(window).trigger('resize');
             });
             jQuery('html').removeClass('busy');
+
+            if (asset_id != self.citationView.asset_id ||
+                    annotation_id != self.citationView.annotation_id) {
+                self.citationView.openCitationById(null, asset_id, annotation_id);
+            }
         }
     });
 };

--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -354,6 +354,8 @@ CitationView.prototype.openCitation = function (anchor) {
 
 CitationView.prototype.openCitationById = function (anchor, asset_id, annotation_id) {
     var self = this;
+    self.asset_id = asset_id;
+    self.annotation_id = annotation_id;
 
     if (anchor && jQuery(anchor).hasClass("disabled")) {
         return;

--- a/media/js/lib/sherdjs/src/image/annotators/openlayers.js
+++ b/media/js/lib/sherdjs/src/image/annotators/openlayers.js
@@ -48,11 +48,20 @@ if (!Sherd.Image.Annotators.OpenLayers) {
             }
         };
 
+        this.deinitialize = function () {
+            if (self.vectorLayer !== undefined &&
+                    self.vectorLayer.id !== 
+                        self.targetview.openlayers.vectorLayer.getLayer().id) {
+                self.openlayers.editingtoolbar = undefined;
+            }
+        };
+
         this.initialize = function (create_obj) {
             if (!self.openlayers.editingtoolbar) {
-                self.openlayers.editingtoolbar = new self.openlayers.CustomEditingToolbar(
-                        self.targetview.openlayers.vectorLayer.getLayer()
-                );
+                self.vectorLayer =
+                    self.targetview.openlayers.vectorLayer.getLayer(); 
+                self.openlayers.editingtoolbar =
+                    new self.openlayers.CustomEditingToolbar(self.vectorLayer);
                 self.targetview.openlayers.map.addControl(self.openlayers.editingtoolbar);
                 self.openlayers.editingtoolbar.deactivate();
 

--- a/media/js/lib/sherdjs/src/image/views/openlayers.js
+++ b/media/js/lib/sherdjs/src/image/views/openlayers.js
@@ -233,13 +233,13 @@ if (!Sherd.Image.OpenLayers) {
 
                 return this;
             },
-            destroy: function () {
+            destroyAll: function() {
                 //remove from mouselistener obj
-                this.all_layers.splice(this.root.layers[this.v.id].index, 1);
-                delete this.root.layers[this.v.id];
-                //destroy layer -- openlayers does the rest
-                this.v.destroy();
-                //delete ann pointers
+                for (var i = 0; i < this.all_layers.length; i++) {
+                    layer = this.all_layers[i];
+                    delete this.root.layers[layer.id];
+                }
+                this.all_layers = [];
                 for (var ann_id in this._anns) {
                     if (this._anns.hasOwnProperty(ann_id)) {
                         delete this._anns[ann_id];
@@ -498,13 +498,7 @@ if (!Sherd.Image.OpenLayers) {
         };
         this.deinitialize = function () {
             if (this.openlayers.map) {
-                var lays = this.Layer.prototype.root.layers;
-                for (var a in lays) {
-                    if (lays[a].name !== 'annotating') {
-                        lays[a].me.destroy();
-                    }
-                }
-
+                this.Layer.prototype.destroyAll();
                 this.openlayers.map.destroy();
             }
         };
@@ -550,14 +544,7 @@ if (!Sherd.Image.OpenLayers) {
                     } else {
                         //everything should fit in this?
                         objopt.maxExtent = new OpenLayers.Bounds(-180, (80 - 360), 180, 80);
-                        //earth dimensions
-                        //opt.maxExtent=new OpenLayers.Bounds(-180, -90, 180, 80);
                     }
-                    //opt.maxExtent=new OpenLayers.Bounds(-180, -280, 180, 80);//DEBUG
-                    ///so it doesn't cut off the bottom/right of the image--by partial tile
-                    //opt.displayOutsideMaxExtent = true;
-
-                    //opt.transitionEffect='resize'; //bug: doesn't hide gutter tiles quickly enough
                     self.openlayers.graphic = new OpenLayers.Layer.XYZ(
                             create_obj.object.title || 'Image',
                             create_obj.object.xyztile,
@@ -690,28 +677,6 @@ if (!Sherd.Image.OpenLayers) {
                 };
 
                 self.openlayers.map.addControl(new OpenLayers.Control.MousePosition());
-
-                /* /// Issues with overview window:
-                   /// 1. loads slowly
-                   /// 2. positioning is too zoomed in and not synced with map (xy coords)
-                   /// TODO: investigate further
-                self.openlayers.graphicOverview = self.openlayers.graphic.clone();
-
-                self.openlayers.graphicOverview.getImageSize = function (){return null;};
-
-                self.openlayers.ovwin = new OpenLayers.Control.OverviewMap({
-                  maximized:true,
-                  layers:[self.openlayers.graphicOverview],
-                  minRatio:1,
-                  //needs to be low or we don't see the image altogether
-                  maxRatio:2,
-                  mapOptions: OpenLayers.Util.extend(objopt, {
-                     numZoomLevels:objopt.numZoomLevels-1,
-
-                  })
-                })
-                self.openlayers.map.addControl(self.openlayers.ovwin);
-                 */
                 self.openlayers.map.addLayers([self.openlayers.graphic]);
                 self.openlayers.vectorLayer = new self.Layer().create('annotating', {
                     zIndex: 1000


### PR DESCRIPTION
* Openlayers annotator: delete the editing toolbar once the outer view has deleted the vector layer
* Openlayers view: delete all layers at once. Openlayers appears to be taking care of layer destruction
* CitationView: only redisplay the citation if the asset or annotation is changing.