### PR TITLE
Clean up Instructor Homepage / CourseList naming

### DIFF
--- a/mediathread/main/middleware.py
+++ b/mediathread/main/middleware.py
@@ -1,13 +1,17 @@
 import waffle
 from courseaffils.middleware import CourseManagerMiddleware
-from mediathread.main.views import HomepageView
+from mediathread.main.views import MethCourseListView
 
 
 class MethCourseManagerMiddleware(CourseManagerMiddleware):
     def process_request(self, request):
-        r = super(MethCourseManagerMiddleware, self).process_request(
-            request)
-        if waffle.flag_is_active(request, 'instructor_homepage') and \
-           r is not None:
-            r = HomepageView.as_view()(request)
-        return r
+        override_view = None
+
+        # When course_activation is turned on, use the MethCourseListView
+        # which has the course activation feature instead of courseaffils'
+        # CourseListView.
+        if waffle.flag_is_active(request, 'course_activation'):
+            override_view = MethCourseListView
+
+        return super(MethCourseManagerMiddleware, self).process_request(
+            request, override_view)

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1111,45 +1111,45 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
                         in response.cookies['messages'].value)
 
 
-class HomepageAnonViewTest(TestCase):
+class MethCourseListAnonViewTest(TestCase):
     def test_get(self):
-        url = reverse('homepage')
+        url = reverse('course_list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
 
-class HomepageViewTest(LoggedInFacultyTestMixin, TestCase):
+class MethCourseListViewTest(LoggedInFacultyTestMixin, TestCase):
     def setUp(self):
-        super(HomepageViewTest, self).setUp()
+        super(MethCourseListViewTest, self).setUp()
 
     def test_get_without_featureflag(self):
-        url = reverse('homepage')
-        with override_flag('instructor_homepage', active=False):
+        url = reverse('course_list')
+        with override_flag('course_activation', active=False):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Homepage')
+        self.assertContains(response, 'Course Selection')
         self.assertEqual(len(response.context['object_list']), 0)
         with self.assertRaises(KeyError):
             response.context['activatable_affils']
 
     def test_get_no_affils(self):
-        url = reverse('homepage')
-        with override_flag('instructor_homepage', active=True):
+        url = reverse('course_list')
+        with override_flag('course_activation', active=True):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Homepage')
+        self.assertContains(response, 'Course Selection')
         self.assertEqual(len(response.context['object_list']), 0)
         self.assertEqual(len(response.context['activatable_affils']), 0)
 
     def test_get(self):
-        url = reverse('homepage')
+        url = reverse('course_list')
         aa = AffilFactory(
             user=self.u,
             name='t1.y2016.s001.cf1000.scnc.fc.course:columbia.edu')
-        with override_flag('instructor_homepage', active=True):
+        with override_flag('course_activation', active=True):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Homepage')
+        self.assertContains(response, 'Course Selection')
         self.assertEqual(len(response.context['object_list']), 0)
         self.assertEqual(len(response.context['activatable_affils']), 1)
         self.assertEqual(response.context['activatable_affils'][0], aa)

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -724,12 +724,12 @@ class CourseAcceptInvitationView(FormView):
         return HttpResponseRedirect(reverse('course-invite-complete'))
 
 
-class HomepageView(LoggedInMixin, CourseListView):
-    template_name = 'main/homepage.html'
+class MethCourseListView(LoggedInMixin, CourseListView):
+    template_name = 'main/course_list.html'
 
     def get_context_data(self, **kwargs):
-        context = super(HomepageView, self).get_context_data(**kwargs)
-        if not waffle.flag_is_active(self.request, 'instructor_homepage'):
+        context = super(MethCourseListView, self).get_context_data(**kwargs)
+        if not waffle.flag_is_active(self.request, 'course_activation'):
             return context
 
         affils = Affil.objects.filter(user=self.request.user, activated=False)

--- a/mediathread/templates/main/course_list.html
+++ b/mediathread/templates/main/course_list.html
@@ -6,7 +6,7 @@
 {% block title %}&mdash; Homepage{% endblock %}
 
 {% block coursetitle %}
-    Homepage
+    Course Selection
 {% endblock %}
 
 {% block css %}
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block content %}
-    {% flag 'instructor_homepage' %}
+    {% flag 'course_activation' %}
     <div id="course-list">
         <div id="coursefilter">
             <span class="h5">View courses for:</span>
@@ -119,10 +119,10 @@
         </table>
     {% endif %}
 
-    {% if activatable_affils|length > 0 %}
+    {% if course_activations|length > 0 %}
         <h2>Activatable Courses</h2>
         <ul>
-            {% for affil in activatable_affils %}
+            {% for affil in course_activations %}
                 <li>
                     {{affil.name}}
                     <a class="btn btn-default btn-xs"
@@ -134,7 +134,7 @@
     {% endif %}
     </div>
     {% else %}
-    The instructor_homepage flag isn't enabled for this user.
+    The course_activation flag isn't enabled for this user.
     {% endflag %}
 
 {% endblock %}

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -17,7 +17,7 @@ from mediathread.assetmgr.views import (
     AssetCreateView, BookmarkletMigrationView)
 from mediathread.main.forms import CustomRegistrationForm
 from mediathread.main.views import (
-    HomepageView, AffilActivateView,
+    MethCourseListView, AffilActivateView,
     ContactUsView, RequestCourseView, IsLoggedInView, IsLoggedInDataView,
     MigrateMaterialsView, MigrateCourseView, CourseManageSourcesView,
     CourseSettingsView, CourseDeleteMaterialsView, course_detail_view,
@@ -143,6 +143,9 @@ urlpatterns = patterns(
     url(r'^affil/(?P<pk>\d+)/activate/$',
         AffilActivateView.as_view(),
         name='affil_activate'),
+    url(r'^course/list/$',
+        MethCourseListView.as_view(),
+        name='course_list'),
 
     # Bookmarklet
     url(r'^accounts/logged_in.js$', IsLoggedInView.as_view(), {},
@@ -157,8 +160,6 @@ urlpatterns = patterns(
     (r'^crossdomain.xml$', 'django.views.static.serve',
      {'document_root': os.path.abspath(os.path.dirname(__file__)),
       'path': 'crossdomain.xml'}),
-
-    url(r'^homepage/$', HomepageView.as_view(), name='homepage'),
 
     url(r'^dashboard/migrate/materials/(?P<course_id>\d+)/$',
         MigrateMaterialsView.as_view(), {}, 'dashboard-migrate-materials'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ django-reversion==1.9.3
 djangohelpers==0.18.1
 django-contrib-comments==1.6.1
 django-threadedcomments==1.0b1
-django-courseaffils==2.1.3
+django-courseaffils==2.1.4
 django-statsd-mozilla==0.3.16
 raven==5.12.0
 django-appconf==1.0.1  # django_compressor


### PR DESCRIPTION
I was confused when naming this feature - I'm not really making a new
'instructor-specific' page, and in addition the 'homepage' in
Mediathread refers to the page you're at when you're in a course, not
the course selection page. So I've renamed some things to try and keep
things straight:

* The instructor_homepage waffle flag is now called course_activation
* I'm really just making a new 'CourseList' view, not a new homepage. So
  I've renamed HomepageView to MethCourseListView to differentiate this
  from courseaffils' CourseListView.