### PR TITLE
Add Course Activation email functionality - PMT #105457

### DIFF
--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -25,6 +25,7 @@ class UserFactory(factory.DjangoModelFactory):
         model = User
     username = factory.Sequence(lambda n: 'user%d' % n)
     password = factory.PostGenerationMethodCall('set_password', 'test')
+    email = factory.LazyAttribute(lambda u: '%s@example.com' % u.username)
 
 
 class UserProfileFactory(factory.DjangoModelFactory):

--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -168,9 +168,12 @@ class ActivateInvitationForm(forms.Form):
 class CourseActivateForm(forms.Form):
     course_name = forms.CharField(label='Course Name')
     consult_or_demo = forms.ChoiceField(
+        label='Will you need a consultation or an in-class demo?',
         required=True,
         choices=(
             ('consultation', 'Consultation'),
-            ('demo', 'In-class demo')),
-        widget=forms.RadioSelect
+            ('demo', 'In-class demo'),
+            ('none', 'None')),
+        widget=forms.RadioSelect,
+        initial='none'
     )

--- a/mediathread/main/models.py
+++ b/mediathread/main/models.py
@@ -1,6 +1,7 @@
 import uuid
 
 from courseaffils.models import Course
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.fields import UUIDField
@@ -105,3 +106,48 @@ class Affil(models.Model):
     user = models.ForeignKey(User)
     created_at = models.DateTimeField(auto_now_add=True)
     modified_at = models.DateTimeField(auto_now=True)
+
+    def __unicode__(self):
+        return self.name
+
+    @property
+    def courseworks_name(self):
+        """Returns the Courseworks formatted name.
+
+        e.g.: CUcourse_NURSN6610_001_2008_2
+
+        If no mapper is configured, returns None.
+        """
+        if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER') and \
+           settings.COURSEAFFILS_COURSESTRING_MAPPER is not None:
+            affil_dict = settings.COURSEAFFILS_COURSESTRING_MAPPER.to_dict(
+                self.name)
+            return 'CUcourse_{}{}{}_{}_{}_{}'.format(
+                affil_dict['dept'].upper(),
+                affil_dict['letter'],
+                affil_dict['number'],
+                affil_dict['section'],
+                affil_dict['year'],
+                affil_dict['term'])
+        return None
+
+    @property
+    def coursedirectory_name(self):
+        """Returns the Course Directory formatted name.
+
+        e.g.: 20082NURS6610N001
+
+        If no mapper is configured, returns None.
+        """
+        if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER') and \
+           settings.COURSEAFFILS_COURSESTRING_MAPPER is not None:
+            affil_dict = settings.COURSEAFFILS_COURSESTRING_MAPPER.to_dict(
+                self.name)
+            return '{}{}{}{}{}{}'.format(
+                affil_dict['year'],
+                affil_dict['term'],
+                affil_dict['dept'].upper(),
+                affil_dict['number'],
+                affil_dict['letter'].upper(),
+                affil_dict['section'])
+        return None

--- a/mediathread/main/tests/mixins.py
+++ b/mediathread/main/tests/mixins.py
@@ -1,0 +1,10 @@
+from mediathread.factories import UserFactory
+
+
+class LoggedInUserTestMixin(object):
+    def setUp(self):
+        self.u = UserFactory(username='test_user')
+        self.u.set_password('test')
+        self.u.save()
+        login = self.client.login(username='test_user', password='test')
+        assert(login is True)

--- a/mediathread/main/tests/test_models.py
+++ b/mediathread/main/tests/test_models.py
@@ -1,6 +1,7 @@
 from django.test.client import RequestFactory
-from django.test.testcases import TestCase
+from django.test.testcases import TestCase, override_settings
 
+from courseaffils.columbia import CourseStringMapper
 from mediathread.factories import (
     MediathreadTestMixin, UserFactory, UserProfileFactory, CourseFactory,
     AffilFactory
@@ -74,9 +75,42 @@ class UserRegistrationTest(TestCase):
         self.assertTrue(course.is_member(user))
 
 
-class AffilTest(TestCase):
+@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=None)
+class AffilNoMapperTest(TestCase):
     def setUp(self):
         self.aa = AffilFactory()
 
     def test_is_valid_from_factory(self):
         self.aa.full_clean()
+
+    def test_unicode(self):
+        self.assertEqual(unicode(self.aa), self.aa.name)
+
+    def test_courseworks_name(self):
+        self.assertIsNone(self.aa.courseworks_name)
+
+    def test_coursedirectory_name(self):
+        self.assertIsNone(self.aa.coursedirectory_name)
+
+
+@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper)
+class AffilTest(TestCase):
+    def setUp(self):
+        self.aa = AffilFactory(
+            name='t1.y2016.s001.cf1002.scnc.st.course:columbia.edu')
+
+    def test_is_valid_from_factory(self):
+        self.aa.full_clean()
+
+    def test_unicode(self):
+        self.assertEqual(unicode(self.aa), self.aa.name)
+
+    def test_courseworks_name(self):
+        self.assertEqual(
+            self.aa.courseworks_name,
+            'CUcourse_SCNCf1002_001_2016_1')
+
+    def test_coursedirectory_name(self):
+        self.assertEqual(
+            self.aa.coursedirectory_name,
+            '20161SCNC1002F001')

--- a/mediathread/templates/main/course_activate.html
+++ b/mediathread/templates/main/course_activate.html
@@ -6,7 +6,7 @@
 {% block content %}
     <form action="." method="post" class="form col-md-6">
         {% csrf_token %}
-        <h1>Course Activation: {{affil.name}}</h1>
+        <h1>Course Activation: {{affil.coursedirectory_name}}</h1>
         {% bootstrap_form form %}
         {% buttons submit='Submit' %}{% endbuttons %}
     </form>

--- a/mediathread/templates/main/course_list.html
+++ b/mediathread/templates/main/course_list.html
@@ -119,12 +119,12 @@
         </table>
     {% endif %}
 
-    {% if course_activations|length > 0 %}
+    {% if activatable_affils|length > 0 %}
         <h2>Activatable Courses</h2>
         <ul>
-            {% for affil in course_activations %}
+            {% for affil in activatable_affils %}
                 <li>
-                    {{affil.name}}
+                    {{affil.coursedirectory_name}}
                     <a class="btn btn-default btn-xs"
                        href="{% url 'affil_activate' affil.id %}" role="button"
                     >Activate</a>


### PR DESCRIPTION
Also: courseworks / coursedirectory formats for course string.
I'll eventually factor this functionality out to `courseworks.columbia`.