### PR TITLE
Asset workspace layout

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -3439,7 +3439,7 @@ div.asset-view-container {
 div.asset-view-container div.asset-view-published {
     margin-left: 10px;
     min-width: 475px;
-    width: 65%;
+    width: 63%;
     float: left;
     border: 1px solid #CCC;
 }

--- a/media/js/app/assetmgr/assetpanel.js
+++ b/media/js/app/assetmgr/assetpanel.js
@@ -227,6 +227,8 @@ AssetPanelHandler.prototype.resize = function() {
     var self = this;
     var $collection = self.$el.find('td.panel-container.collection');
 
+    window.panelManager.verifyLayout(self.$el);
+
     if ($collection.length < 1 || $collection.hasClass('minimized')) {
         jQuery('td.asset-view-header').show();
     } else {


### PR DESCRIPTION
At low resolutions, the selection list & edit area were wrapping. Resolved by shrinking the item view window slightly, and completely collapsing the collection viewing area if needed. (Noting: the collection area does not "uncollapse" once fully collapsed. This is as designed.)