### PR TITLE
:arrow_up: courseaffils 2.1.5

### DIFF
--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -138,6 +138,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         url = '/api/asset/?annotations=true'
         response = self.client.get(url, {},
@@ -267,6 +268,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
     def test_getstudentlist_as_instructor(self):
         self.assert_(self.client.login(username=self.instructor_one.username,
                                        password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         record_owner = self.student_one.username
         response = self.client.get(
@@ -334,6 +336,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         response = self.client.get('/api/asset/%s/' % self.asset1.id,
                                    {},

--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -119,6 +119,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         response = self.client.get('/asset/archive/')
         self.assertEquals(response.status_code, 405)
@@ -133,6 +134,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post('/asset/archive/',
                                     {'remove': True,
                                      'collection_id': exc.id})
@@ -151,6 +153,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         self.client.post('/asset/archive/', data)
 
         ExternalCollection.objects.get(course=self.sample_course,
@@ -163,6 +166,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         self.client.post('/asset/archive/', data)
 
         ExternalCollection.objects.get(course=self.sample_course,
@@ -230,7 +234,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
-
+        self.switch_course(self.client, self.sample_course)
         asset1 = AssetFactory.create(course=self.sample_course,
                                      primary_source='image',
                                      author=self.instructor_one)
@@ -245,6 +249,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         asset1 = AssetFactory.create(course=self.sample_course,
                                      author=self.instructor_one,
@@ -267,6 +272,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         asset1 = AssetFactory.create(course=self.sample_course,
                                      author=self.instructor_one,
@@ -317,6 +323,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         # Item Does Not Exist
         response = self.client.get('/asset/5616/')
@@ -352,6 +359,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
 
         self.assert_(self.client.login(username=self.instructor_one.username,
                                        password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         # Update passing in a non-global annotation. This should fail
         post_data = {'asset-title': 'Updated Title',
@@ -375,6 +383,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
 
         self.assert_(self.client.login(username=self.instructor_one.username,
                                        password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         # Update passing in a non-global annotation. This should fail
         post_data = {'asset-title': "Updated Item Title"}
@@ -395,6 +404,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
 
         self.assert_(self.client.login(username=self.instructor_one.username,
                                        password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         # Update passing in a non-global annotation. This should fail
         url = "/asset/save/%s/annotations/%s/" % (asset1.id, note.id)
@@ -414,6 +424,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
 
         self.assert_(self.client.login(username=self.instructor_one.username,
                                        password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         url = "/asset/save/%s/annotations/%s/" % (asset1.id, 42)
         post_data = {'annotation-range1': -4.5}
@@ -636,6 +647,7 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
         return_url = 'http://foo.bar/baz/'
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(self.url, {'return_url': return_url})
         self.assertEquals(response.status_code, 200)
 

--- a/mediathread/discussions/tests/test_views.py
+++ b/mediathread/discussions/tests/test_views.py
@@ -84,6 +84,7 @@ class DiscussionViewsTest(MediathreadTestMixin, TestCase):
         # faculty
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {})
         self.assertEquals(response.status_code, 302)
         discussions = get_course_discussions(self.sample_course)

--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -15,7 +15,7 @@ from mediathread.assetmgr.models import Asset, Source, ExternalCollection, \
     SuggestedExternalCollection
 from mediathread.discussions.views import discussion_create
 from mediathread.djangosherd.models import SherdNote
-from mediathread.main.models import UserProfile, Affil, CourseInvitation
+from mediathread.main.models import UserProfile, CourseInvitation
 from mediathread.projects.models import Project, AssignmentItem, ProjectNote
 from mediathread.taxonomy.models import Vocabulary, Term, TermRelationship
 from structuredcollaboration.models import Collaboration, \
@@ -177,15 +177,6 @@ class AssignmentItemFactory(factory.DjangoModelFactory):
 class ProjectNoteFactory(factory.DjangoModelFactory):
     class Meta:
         model = ProjectNote
-
-
-class AffilFactory(factory.DjangoModelFactory):
-    class Meta:
-        model = Affil
-
-    name = factory.Sequence(
-        lambda n: 't1.y2016.s001.cf100%d.scnc.st.course:columbia.edu' % n)
-    user = factory.SubFactory(UserFactory)
 
 
 class CourseInvitationFactory(factory.DjangoModelFactory):

--- a/mediathread/main/auth.py
+++ b/mediathread/main/auth.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.utils import timezone
-from mediathread.main.models import Affil
+from courseaffils.models import Affil
 
 
 class CourseGroupMapper(object):

--- a/mediathread/main/features/login.feature
+++ b/mediathread/main/features/login.feature
@@ -35,6 +35,11 @@ Feature: Login
         When I type "instructor_one" for username
         When I type "test" for password
         When I click the Log In button
+
+        Then I am at the Switch Course page
+        Then there is an "Sample Course" link
+        When I click the "Sample Course" link
+
         Then I am at the Home page
         When I log out
         Then I am at the Login page

--- a/mediathread/main/migrations/0007_auto_20160502_1311.py
+++ b/mediathread/main/migrations/0007_auto_20160502_1311.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0006_auto_20160430_1123'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='affil',
+            unique_together=set([]),
+        ),
+        migrations.RemoveField(
+            model_name='affil',
+            name='user',
+        ),
+        migrations.DeleteModel(
+            name='Affil',
+        ),
+    ]

--- a/mediathread/main/models.py
+++ b/mediathread/main/models.py
@@ -1,7 +1,6 @@
 import uuid
 
 from courseaffils.models import Course
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.fields import UUIDField
@@ -92,63 +91,3 @@ class CourseInvitation(models.Model):
 
     def accepted(self):
         return self.accepted_at is not None
-
-
-class Affil(models.Model):
-    """Model for storing activatable affiliations.
-
-    Faculty use this to 'activate' it into a Group/Course.
-    """
-    class Meta:
-        unique_together = ('name', 'user')
-
-    activated = models.BooleanField(default=False)
-    name = models.TextField()
-    user = models.ForeignKey(User)
-    created_at = models.DateTimeField(auto_now_add=True)
-    modified_at = models.DateTimeField(auto_now=True)
-
-    def __unicode__(self):
-        return self.name
-
-    @property
-    def courseworks_name(self):
-        """Returns the Courseworks formatted name.
-
-        e.g.: CUcourse_NURSN6610_001_2008_2
-
-        If no mapper is configured, returns None.
-        """
-        if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER') and \
-           settings.COURSEAFFILS_COURSESTRING_MAPPER is not None:
-            affil_dict = settings.COURSEAFFILS_COURSESTRING_MAPPER.to_dict(
-                self.name)
-            return 'CUcourse_{}{}{}_{}_{}_{}'.format(
-                affil_dict['dept'].upper(),
-                affil_dict['letter'],
-                affil_dict['number'],
-                affil_dict['section'],
-                affil_dict['year'],
-                affil_dict['term'])
-        return None
-
-    @property
-    def coursedirectory_name(self):
-        """Returns the Course Directory formatted name.
-
-        e.g.: 20082NURS6610N001
-
-        If no mapper is configured, returns None.
-        """
-        if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER') and \
-           settings.COURSEAFFILS_COURSESTRING_MAPPER is not None:
-            affil_dict = settings.COURSEAFFILS_COURSESTRING_MAPPER.to_dict(
-                self.name)
-            return '{}{}{}{}{}{}'.format(
-                affil_dict['year'],
-                affil_dict['term'],
-                affil_dict['dept'].upper(),
-                affil_dict['number'],
-                affil_dict['letter'].upper(),
-                affil_dict['section'])
-        return None

--- a/mediathread/main/tests/test_models.py
+++ b/mediathread/main/tests/test_models.py
@@ -1,10 +1,8 @@
 from django.test.client import RequestFactory
-from django.test.testcases import TestCase, override_settings
+from django.test.testcases import TestCase
 
-from courseaffils.columbia import CourseStringMapper
 from mediathread.factories import (
     MediathreadTestMixin, UserFactory, UserProfileFactory, CourseFactory,
-    AffilFactory
 )
 from mediathread.main.models import (
     UserSetting, user_registered_callback,
@@ -73,44 +71,3 @@ class UserRegistrationTest(TestCase):
         user_activated_callback(None, user, None)
 
         self.assertTrue(course.is_member(user))
-
-
-@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=None)
-class AffilNoMapperTest(TestCase):
-    def setUp(self):
-        self.aa = AffilFactory()
-
-    def test_is_valid_from_factory(self):
-        self.aa.full_clean()
-
-    def test_unicode(self):
-        self.assertEqual(unicode(self.aa), self.aa.name)
-
-    def test_courseworks_name(self):
-        self.assertIsNone(self.aa.courseworks_name)
-
-    def test_coursedirectory_name(self):
-        self.assertIsNone(self.aa.coursedirectory_name)
-
-
-@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper)
-class AffilTest(TestCase):
-    def setUp(self):
-        self.aa = AffilFactory(
-            name='t1.y2016.s001.cf1002.scnc.st.course:columbia.edu')
-
-    def test_is_valid_from_factory(self):
-        self.aa.full_clean()
-
-    def test_unicode(self):
-        self.assertEqual(unicode(self.aa), self.aa.name)
-
-    def test_courseworks_name(self):
-        self.assertEqual(
-            self.aa.courseworks_name,
-            'CUcourse_SCNCf1002_001_2016_1')
-
-    def test_coursedirectory_name(self):
-        self.assertEqual(
-            self.aa.coursedirectory_name,
-            '20161SCNC1002F001')

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -5,6 +5,7 @@ import json
 
 from courseaffils.columbia import CourseStringMapper
 from courseaffils.models import Course
+from courseaffils.tests.factories import AffilFactory
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.core import mail
@@ -21,7 +22,7 @@ from mediathread.djangosherd.models import SherdNote
 from mediathread.factories import (
     UserFactory, UserProfileFactory, MediathreadTestMixin,
     AssetFactory, ProjectFactory, SherdNoteFactory,
-    AffilFactory, CourseInvitationFactory
+    CourseInvitationFactory
 )
 from mediathread.main import course_details
 from mediathread.main.course_details import allow_public_compositions, \
@@ -606,6 +607,7 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         project = ProjectFactory.create(
             course=self.sample_course, author=self.instructor_one,
             policy='PublicEditorsAreOwners')
@@ -621,6 +623,7 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         data = {
             course_details.COURSE_INFORMATION_TITLE_KEY: "Foo",
             course_details.SELECTION_VISIBILITY_KEY: 0,
@@ -638,6 +641,7 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
     def test_post_disabled_selection_visibility(self):
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         data = {course_details.ITEM_VISIBILITY_KEY: 0}
 
         response = self.client.post('/dashboard/settings/', data)
@@ -690,6 +694,7 @@ class CourseManageSourcesViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
         data = {
             course_details.UPLOAD_PERMISSION_KEY:
             course_details.UPLOAD_PERMISSION_ADMINISTRATOR
@@ -969,6 +974,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
     def test_promote_demote_users(self):
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
 
         url = reverse('course-roster-promote')
         data = {'student_id': self.student_one.id}
@@ -986,6 +992,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
     def test_remove_user(self):
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
 
         url = reverse('course-roster-remove')
         data = {'user_id': self.student_one.id}
@@ -1014,6 +1021,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
     def test_uni_invite_post(self):
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
 
         url = reverse('course-roster-add-uni')
         response = self.client.post(url, {})
@@ -1045,6 +1053,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         url = reverse('course-roster-invite-email')
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {'emails': self.student_one.email})
         self.assertEquals(response.status_code, 302)
         self.assertTrue('Student One is already a course member'
@@ -1057,6 +1066,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
             url = reverse('course-roster-invite-email')
             self.client.login(username=self.instructor_one.username,
                               password='test')
+            self.switch_course(self.client, self.sample_course)
             response = self.client.post(url,
                                         {'emails': self.alt_student.email})
             self.assertEquals(response.status_code, 302)
@@ -1078,6 +1088,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
             url = reverse('course-roster-invite-email')
             self.client.login(username=self.instructor_one.username,
                               password='test')
+            self.switch_course(self.client, self.sample_course)
             response = self.client.post(url, {'emails': 'foo@example.com'})
 
             self.assertEquals(response.status_code, 302)
@@ -1104,6 +1115,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         url = reverse('course-roster-invite-email')
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {})
 
         self.assertEquals(response.status_code, 302)
@@ -1115,6 +1127,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         url = reverse('course-roster-invite-email')
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {'emails': '#$%^,foo@example.com'})
 
         self.assertEquals(response.status_code, 302)
@@ -1182,6 +1195,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         url = reverse('course-roster-resend-email')
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {'invite-id': '3'})
         self.assertEquals(response.status_code, 404)
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -4,7 +4,7 @@ import re
 
 from courseaffils.lib import in_course_or_404, in_course
 from courseaffils.middleware import SESSION_KEY
-from courseaffils.models import Course
+from courseaffils.models import Affil, Course
 from courseaffils.views import get_courses_for_user, CourseListView
 from django.conf import settings
 from django.contrib import messages
@@ -43,9 +43,7 @@ from mediathread.main.forms import (
     CourseDeleteMaterialsForm, AcceptInvitationForm,
     CourseActivateForm
 )
-from mediathread.main.models import (
-    UserSetting, CourseInvitation, Affil
-)
+from mediathread.main.models import UserSetting, CourseInvitation
 from mediathread.main.util import send_template_email, user_display_name, \
     send_course_invitation_email
 from mediathread.mixins import (

--- a/mediathread/projects/tests/test_api.py
+++ b/mediathread/projects/tests/test_api.py
@@ -147,6 +147,7 @@ class ProjectApiTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         response = self.client.get('/api/project/', {},
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
@@ -233,6 +234,7 @@ class ProjectApiTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password="test"))
+        self.switch_course(self.client, self.sample_course)
 
         # Student one private composition
         url = '/api/project/%s/' % self.project_private.id

--- a/mediathread/projects/tests/test_homepage.py
+++ b/mediathread/projects/tests/test_homepage.py
@@ -149,6 +149,7 @@ class HomepageTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         url = '/api/project/user/%s/' % self.instructor_one.username
         response = self.client.get(url, {},
@@ -168,6 +169,7 @@ class HomepageTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_two.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         url = '/api/project/user/%s/' % self.instructor_one.username
         response = self.client.get(url, {},
@@ -187,6 +189,7 @@ class HomepageTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         url = '/api/project/user/%s/' % self.student_one.username
         response = self.client.get(url, {},
@@ -283,6 +286,7 @@ class HomepageTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         response = self.client.get('/api/project/', {},
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -99,6 +99,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.instructor_one.username,
                               password='test'))
+        self.switch_course(self.client, self.sample_course)
 
         # Forbidden to save or view
         url = '/project/save/%s/' % self.project_private.id
@@ -296,6 +297,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         url = reverse('project-delete', args=[project_id])
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {})
         self.assertEquals(response.status_code, 302)
 
@@ -329,6 +331,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         # as faculty
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, data)
         self.assertEquals(response.status_code, 403)
 
@@ -525,6 +528,7 @@ class TestProjectSortView(MediathreadTestMixin, TestCase):
         url = reverse('project-sort')
         c = self.client
         c.login(username=self.instructor_one.username, password='test')
+        self.switch_course(self.client, self.sample_course)
 
         project1 = ProjectFactory.create(
             course=self.sample_course, author=self.instructor_one,
@@ -571,6 +575,7 @@ class SelectionAssignmentViewTest(MediathreadTestMixin, TestCase):
         # alt course instructor
         self.client.login(username=self.alt_instructor.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 403)
 
@@ -662,6 +667,7 @@ class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):
         # alt course instructor
         self.client.login(username=self.alt_instructor.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 403)
 
@@ -697,6 +703,7 @@ class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):
         # author
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         data = {
             'title': 'Updated',
             'body': 'Body Text',

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -575,7 +575,7 @@ class SelectionAssignmentViewTest(MediathreadTestMixin, TestCase):
         # alt course instructor
         self.client.login(username=self.alt_instructor.username,
                           password='test')
-        self.switch_course(self.client, self.sample_course)
+        self.switch_course(self.client, self.alt_course)
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 403)
 
@@ -667,7 +667,7 @@ class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):
         # alt course instructor
         self.client.login(username=self.alt_instructor.username,
                           password='test')
-        self.switch_course(self.client, self.sample_course)
+        self.switch_course(self.client, self.alt_course)
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 403)
 

--- a/mediathread/reports/tests/test_views.py
+++ b/mediathread/reports/tests/test_views.py
@@ -80,6 +80,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context_data['assignment'],
@@ -102,6 +103,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context_data['num_students'], 3)
@@ -122,6 +124,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(len(response.context_data['students']), 5)
@@ -138,6 +141,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         self.assertTrue('my_feed' in response.context_data)
@@ -163,6 +167,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         the_json = loads(response.content)
@@ -188,6 +193,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 302)
 
@@ -220,6 +226,7 @@ class ReportViewTest(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 302)
 
@@ -353,5 +360,6 @@ class TestAssignmentDetailReport(MediathreadTestMixin, TestCase):
         # as instructor
         self.client.login(username=self.instructor_one.username,
                           password='test')
+        self.switch_course(self.client, self.sample_course)
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ django-reversion==1.9.3
 djangohelpers==0.18.1
 django-contrib-comments==1.7.0
 django-threadedcomments==1.0b1
-django-courseaffils==2.1.4
+django-courseaffils==2.1.5
 django-statsd-mozilla==0.3.16
 raven==5.13.0
 django-appconf==1.0.1  # django_compressor

--- a/terrain.py
+++ b/terrain.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import time
 from urlparse import urlparse
 
@@ -180,6 +181,11 @@ def i_am_username_in_course(step, username, coursename):
 
         form = world.browser.find_element_by_name("login_local")
         form.submit()
+
+        if re.match(r'^instructor', username):
+            course = world.browser.find_element_by_css_selector(
+                'a.choose-course')
+            course.click()
 
         wait = ui.WebDriverWait(world.browser, 5)
         wait.until(lambda driver: world.browser.title.find("Home") > -1)


### PR DESCRIPTION
@sdreher I've addressed all but two unit test failures. To see these two failures, run this:

    ./manage.py test mediathread.projects.tests.test_views

I added a course selection action in terrain.py which seems to let the selenium tests go through, but I haven't run them all yet.