### PR TITLE
Vocabulary-related bugs

### DIFF
--- a/media/js/app/assetmgr/collection.js
+++ b/media/js/app/assetmgr/collection.js
@@ -116,7 +116,7 @@ var CollectionList = function(config) {
         });
 
     self.$el.on(
-        'change select2-removed', 'select.vocabulary', function(evt) {
+        'change', 'select.vocabulary', function(evt) {
             var option = evt.added || evt.removed;
             var vocab = jQuery(option.element).parent().attr('data-id');
             if (!self.current_records.active_filters.hasOwnProperty(vocab)) {
@@ -134,7 +134,7 @@ var CollectionList = function(config) {
         });
 
     self.$el.on(
-        'change select2-removed', 'select.course-tags', function() {
+        'change', 'select.course-tags', function() {
             var $elt = self.$el.find('select.course-tags');
             self.current_records.active_filters.tag = $elt.val();
             return self.filter();

--- a/mediathread/taxonomy/api.py
+++ b/mediathread/taxonomy/api.py
@@ -1,5 +1,4 @@
 # pylint: disable-msg=R0904
-from courseaffils.models import Course
 from django.db.models import Count
 from tastypie.fields import ToManyField
 from tastypie.resources import ModelResource
@@ -43,7 +42,7 @@ class VocabularyValidation(Validation):
 
         a = Vocabulary.objects.filter(
             display_name=bundle.data['display_name'],
-            course__id=bundle.data['object_id'])
+            course=bundle.request.course)
 
         if len(a) > 0:  # vocabulary exists with this name
             if 'pk' not in bundle.data or a[0].pk != int(bundle.data['pk']):
@@ -86,7 +85,7 @@ class VocabularyResource(ModelResource):
         return to_be_serialized
 
     def hydrate(self, bundle):
-        bundle.obj.course = Course.objects.get(id=bundle.data['object_id'])
+        bundle.obj.course = bundle.request.course
         return bundle
 
     def render_one(self, request, vocabulary):
@@ -116,6 +115,7 @@ class VocabularyResource(ModelResource):
         for rel in related:
             if rel.term.vocabulary.id not in ctx:
                 vocab_ctx = {'id': rel.term.vocabulary.id,
+                             'vocabulary_id': rel.term.vocabulary.id,
                              'display_name': rel.term.vocabulary.display_name,
                              'term_set': [],
                              'terms': []}

--- a/mediathread/taxonomy/tests/test_api.py
+++ b/mediathread/taxonomy/tests/test_api.py
@@ -213,10 +213,13 @@ class TaxonomyApiTest(MediathreadTestMixin, TestCase):
 
     def test_vocabulary_validation(self):
         vv = VocabularyValidation()
+        request = RequestFactory()
+        request.course = self.sample_course
 
         mock_bundle = Bundle()
         mock_bundle.data['display_name'] = 'Shapes'
-        mock_bundle.data['object_id'] = self.sample_course.id
+        mock_bundle.request = request
+
         errors = vv.is_valid(mock_bundle)
         self.assertTrue('error_message' in errors)
         self.assertTrue(
@@ -225,5 +228,6 @@ class TaxonomyApiTest(MediathreadTestMixin, TestCase):
         mock_bundle = Bundle()
         mock_bundle.data['display_name'] = 'Patterns'
         mock_bundle.data['object_id'] = self.sample_course.id
+        mock_bundle.request = request
         errors = vv.is_valid(mock_bundle)
         self.assertFalse('error_message' in errors)


### PR DESCRIPTION
* Vocabulary add/rename: fix course reference
* listening for select2-removed event is redundant in new version. change covers both cases now.
