### PR TITLE
Roster invite by email: configurable domain block

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1037,6 +1037,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
 
         user.first_name = 'John'
         user.last_name = 'Smith'
+        user.email = 'jsmith@example.com'
         user.save()
 
         response = self.client.post(url, {'unis': ' abc123 ,efg456,'})
@@ -1044,7 +1045,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
 
         user = User.objects.get(username='efg456')
         self.assertTrue(self.sample_course.is_true_member(user))
-        self.assertTrue('John Smith is already a course member'
+        self.assertTrue('John Smith (abc123) is already a course member'
                         in response.cookies['messages'].value)
         self.assertTrue('efg456 is now a course member'
                         in response.cookies['messages'].value)
@@ -1056,8 +1057,9 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         self.switch_course(self.client, self.sample_course)
         response = self.client.post(url, {'emails': self.student_one.email})
         self.assertEquals(response.status_code, 302)
-        self.assertTrue('Student One is already a course member'
-                        in response.cookies['messages'].value)
+        self.assertTrue(
+            'Student One (student_one@example.com) is already a course member'
+            in response.cookies['messages'].value)
 
     def test_email_invite_existing_user(self):
         with self.settings(SERVER_EMAIL='mediathread@example.com'):

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -196,6 +196,8 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
         'django.contrib.auth.hashers.MD5PasswordHasher',
     )
 
+BLOCKED_EMAIL_DOMAINS = []
+
 # if you add a 'deploy_specific' directory
 # then you can put a settings.py file and templates/ overrides there
 # otherwise, make sure you specify the correct database settings in your

--- a/mediathread/templates/dashboard/class_roster.html
+++ b/mediathread/templates/dashboard/class_roster.html
@@ -57,47 +57,6 @@
     </div>
     <div class="pull-right">
         <button class="btn btn-default btn-sm"
-            data-toggle="modal" data-target="#add-uni-user">
-            Add by Columbia University Network ID (UNI)
-        </button>
-        <!-- Modal -->
-        <div class="modal fade" id="add-uni-user" tabindex="-1" role="dialog" aria-labelledby="Add User">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Add by Columbia University Network ID (UNI)</h4>
-                    </div>
-                    <div class="modal-body">
-                        <form action="{% url 'course-roster-add-uni' %}" method="POST">
-                            <p>
-                            <b>About Adding Students</b><br />
-                            Normally, an instructor does not need to add users manually to a Mediathread course.
-                            Registered students are added to their affiliated courses automatically when they login
-                            to Mediathread. But, sometimes students or teaching assistants are not formally registered.
-                            This utility will allow you to add them to the course easily.</p>
-
-                            <p><b>How To Add Students</b><br />
-                            To add students or teaching assistants who are not formally registered, enter a list
-                            of UNIs separated by commas. The users will be added to the course
-                            and receive an email with login instructions.</p>
-                            <br />
-                            <div class="form-group">
-                                <label for="uni">UNI</label>
-                                <textarea class="form-control" name="unis" placeholder="UNIs separated by commas"></textarea>
-                                <div class="help-inline">At least one UNI is required.</div>
-                            </div>
-                            <p class="small"><a href="http://cuit.columbia.edu/cuit/manage-my-uni" title="Learn more about UNI" target="_blank">What is a UNI?</a></p>
-                        </form>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                        <button type="button" class="btn btn-primary btn-add-uni-user">Add</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <button class="btn btn-default btn-sm"
             data-toggle="modal" data-target="#invite-email-user">
             Invite by Email Address
         </button>
@@ -121,11 +80,18 @@
                             To invite students, enter a list of email addresses separated by commas. The users will
                             receive an invitation to the course via email.</p>
 
-                            <p><b>Columbia University Students</b><br />
-                            Do not invite students with Columbia University Network ID via email. Their course affiliations
-                            will not be picked up correctly.
+                            {% if blocked %}
+                            <p><b>Blocked Email Domain</b><br />
+                            Some email domains have been blocked for institutional reasons.<br />
+                            <p>Email invitation is <b>blocked</b> for:
+                                <ul>
+                                {% for e in blocked %}
+                                    <li>{{e}}</li>
+                                {% endfor %}
+                                </ul>
+                            </p>
                             <br />
-
+                            {% endif %}
                             <div class="form-group">
                                 <label for="email">Email</label>
                                 <textarea class="form-control" name="emails" placeholder="email addresses separated by commas"></textarea>

--- a/mediathread/templates/dashboard/email_invite_user.txt
+++ b/mediathread/templates/dashboard/email_invite_user.txt
@@ -1,6 +1,6 @@
 Hello,
 
-Your instructor, {{inviter}}, has invited you to join the Mediathread course: {{course.title}}.
+Your instructor has invited you to join the Mediathread course: {{course.title}}.
 
 To create a Mediathread account and join the course, please click the following link, or copy and paste it
 into your web browser:


### PR DESCRIPTION
* Add a mechanism to disallow email invitation for certain domains
* Remove CU specific information from the course_roster template
* Add course_roster.html template with CU customization to deploy_specific
* Block columbia.edu and barnard.edu domains in deploy_specific