### PR TITLE
revive the docker/docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.tx
 && rm -rf /wheelhouse
 WORKDIR /app
 COPY . /app/
-#RUN /ve/bin/python manage.py test
+RUN /ve/bin/python manage.py test
 EXPOSE 8000
 ADD docker-run.sh /run.sh
 ENV APP mediathread

--- a/README.markdown
+++ b/README.markdown
@@ -95,9 +95,9 @@ If you have docker set up and docker-compose installed, you can get a
 development environment up and running very quickly. To initialize it,
 the following steps are recommended:
 
-    $ docker pull ccnmtl/mediathread
-    $ docker-compose run web manage syncdb # create a superuser when asked to
-	$ docker-compose run web migrate
+    $ make build
+    $ docker-compose run web migrate
+    $ docker-compose run web manage createsuperuser
 
 After that, a simple:
 
@@ -106,6 +106,32 @@ After that, a simple:
 will bring up a development server on port 8000 (if you are running
 boot2docker, it may end up on a different port) backed by a PostgreSQL
 database.
+
+If requirements have been updated, you can rebuild the image by
+re-running `make build`. Eventually, we'll be automatically publishing
+the Mediathread Docker image to the Docker Hub and you will instead
+be able to just run `docker pull ccnmtl/mediathread` to update.
+
+The usual Django `manage.py` commands can be run inside the docker
+compose container like so:
+
+    $ docker-compose run web manage help
+    $ docker-compose run web manage shell
+
+(Note that it's with `manage`, not `manage.py`; this is the custom
+entrypoint script (`docker-run.sh`) at work.)
+
+You can run the unit tests inside the container with the following
+command:
+
+    $ docker-compose run web manage test --settings=mediathread.settings
+
+That one's a *little* tricky and unintuitive. Normally, running
+Mediathread inside the container via docker compose, it will use the
+`settings_compose.py` settings file, which contains the configuration
+for connecting to the PostgreSQL instance running in the other
+container. For unit tests, you don't want that though, so the command
+above explicitly sets it back to the default dev settings.
 
 Production deployment with Docker is also possible, though even less
 tested than development. The `settings_docker.py` file has the default

--- a/mediathread/settings_compose.py
+++ b/mediathread/settings_compose.py
@@ -14,6 +14,7 @@ DATABASES = {
 }
 
 EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 
 try:
     from local_settings import *


### PR DESCRIPTION
I had previously commented out the test running step of building the
docker container because Mediathread's tests (for some undetermined
reason) would consistently fail on my desktop, so it was the only way I
could get it to build. That issue has resolved itself though, so I put
that back in as a nice sanity check within the container.

I've also updated the documentation a bit with more details on how to
use docker-compose to run a development environment.

Lastly, I tend to run into issues with running Mediathread locally
because of the Pickle session serializer, which always breaks because my
browser generally already has a (JSON) session cookie for my local
setup. Clearing out the cookies is a pain, so I set the serializer in
the compose settings to JSON serializer to make it convenient to do
development against it. Since no one else is using the compose setup yet
that I know of, it shouldn't break anyone else's setup.