### PR TITLE
Course activation form changes - PMT #105457

### DIFF
--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib.auth.models import User
 from django.forms.widgets import RadioSelect
+from django.shortcuts import get_object_or_404
 from registration.forms import RegistrationForm
+from courseaffils.models import Affil
 
 
 TERM_CHOICES = (
@@ -188,6 +190,7 @@ class AcceptInvitationForm(forms.Form):
 
 
 class CourseActivateForm(forms.Form):
+    affil = forms.IntegerField(widget=forms.HiddenInput())
     course_name = forms.CharField(label='Course Name')
     consult_or_demo = forms.ChoiceField(
         label='Will you need a consultation or an in-class demo?',
@@ -199,3 +202,13 @@ class CourseActivateForm(forms.Form):
         widget=forms.RadioSelect,
         initial='none'
     )
+
+    def clean(self):
+        cleaned_data = super(CourseActivateForm, self).clean()
+        affil = get_object_or_404(Affil, pk=cleaned_data.get('affil'))
+        affil_dict = affil.to_dict()
+        affil_shortname = affil_dict['dept'].upper() + affil_dict['number']
+        cleaned_data['course_name'] = '{} {}'.format(
+            affil_shortname,
+            cleaned_data.get('course_name'))
+        return cleaned_data

--- a/mediathread/main/templatetags/methtags.py
+++ b/mediathread/main/templatetags/methtags.py
@@ -1,0 +1,18 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def int_to_term(n):
+    """Convert a numerical semester into a string."""
+    try:
+        n = int(n)
+    except ValueError:
+        return None
+
+    if n > 0 and n < 4:
+        return ['Spring', 'Summer', 'Fall'][n - 1]
+    else:
+        return None

--- a/mediathread/main/tests/test_templatetags.py
+++ b/mediathread/main/tests/test_templatetags.py
@@ -1,0 +1,13 @@
+import unittest
+from mediathread.main.templatetags.methtags import int_to_term
+
+
+class IntToTermTests(unittest.TestCase):
+    def test_int_to_term(self):
+        self.assertIsNone(int_to_term('abc'))
+        self.assertEqual(int_to_term(1), 'Spring')
+        self.assertEqual(int_to_term(2), 'Summer')
+        self.assertEqual(int_to_term(3), 'Fall')
+        self.assertIsNone(int_to_term(0))
+        self.assertIsNone(int_to_term(4))
+        self.assertIsNone(int_to_term(6))

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 
 from courseaffils.columbia import CourseStringMapper
-from courseaffils.models import Course
+from courseaffils.models import Affil, Course
 from courseaffils.tests.factories import AffilFactory
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
@@ -15,6 +15,7 @@ from django.test import TestCase, override_settings
 from django.test.client import Client, RequestFactory
 from threadedcomments.models import ThreadedComment
 from waffle.testutils import override_flag
+from freezegun import freeze_time
 
 from mediathread.assetmgr.models import Asset
 from mediathread.discussions.utils import get_course_discussions
@@ -1226,6 +1227,8 @@ class MethCourseListAnonViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
 
+@freeze_time('2016-05-11')
+@override_settings(COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper)
 class MethCourseListViewTest(LoggedInUserTestMixin, TestCase):
     def setUp(self):
         super(MethCourseListViewTest, self).setUp()
@@ -1251,7 +1254,20 @@ class MethCourseListViewTest(LoggedInUserTestMixin, TestCase):
 
     def test_get(self):
         url = reverse('course_list')
-        affil_name = 't1.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
+        affil_name = 't3.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
+        aa = AffilFactory(user=self.u, name=affil_name)
+        with override_flag('course_activation', active=True):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Course Selection')
+        self.assertNotContains(response, aa.coursedirectory_name)
+        self.assertEqual(len(response.context['object_list']), 0)
+        self.assertEqual(len(response.context['activatable_affils']), 1)
+        self.assertEqual(response.context['activatable_affils'][0], aa)
+
+    def test_get_future(self):
+        url = reverse('course_list') + '?semester_view=future'
+        affil_name = 't3.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
         aa = AffilFactory(user=self.u, name=affil_name)
         with override_flag('course_activation', active=True):
             response = self.client.get(url)
@@ -1277,12 +1293,17 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
         self.assertContains(
             response,
             'Course Activation: {}'.format(self.aa.coursedirectory_name))
+        self.assertEqual(
+            response.context['affil_shortname'],
+            self.aa.to_dict()['dept'].upper() +
+            self.aa.to_dict()['number'])
         self.assertEqual(response.context['affil'], self.aa)
 
     def test_post_no_course_name(self):
         self.assertFalse(self.aa.activated)
         response = self.client.post(
             reverse('affil_activate', kwargs={'pk': self.aa.pk}), {
+                'affil': self.aa.pk,
                 'course_name': '',
                 'consult_or_demo': 'consultation',
             })
@@ -1294,6 +1315,7 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
         self.assertFalse(self.aa.activated)
         response = self.client.post(
             reverse('affil_activate', kwargs={'pk': self.aa.pk}), {
+                'affil': self.aa.pk,
                 'course_name': 'My Course',
                 'consult_or_demo': 'consultation',
             })
@@ -1302,23 +1324,33 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
         self.assertTrue(self.aa.activated)
 
         course = Course.objects.last()
-        self.assertEqual(course.title, 'My Course')
-        self.assertEqual(unicode(course.info),
-                         'My Course (Spring 2016) None None-None')
+        shortname = self.aa.to_dict().get('dept').upper() + \
+            self.aa.to_dict().get('number')
+        self.assertEqual(course.title, '%s My Course' % shortname)
+        self.assertEqual(
+            unicode(course.info),
+            '%s My Course (Spring 2016) None None-None' % shortname)
         self.assertEqual(course.info.term, 1)
         self.assertEqual(course.info.year, 2016)
+        self.assertEqual(Affil.objects.count(), 1)
+
+        self.assertTrue(course.is_faculty(self.u))
 
     def test_send_faculty_email(self):
         form = CourseActivateForm({
+            'affil': self.aa.pk,
             'course_name': 'My Course',
             'consult_or_demo': 'consultation',
         })
         self.assertTrue(form.is_valid())
         AffilActivateView.send_faculty_email(form, self.u)
         self.assertEqual(len(mail.outbox), 1)
+
+        shortname = self.aa.to_dict().get('dept').upper() + \
+            self.aa.to_dict().get('number')
         self.assertEqual(
             mail.outbox[0].subject,
-            'Your Mediathread Course Activation: My Course')
+            'Your Mediathread Course Activation: %s My Course' % shortname)
         self.assertEquals(
             mail.outbox[0].from_email,
             settings.SERVER_EMAIL)
@@ -1328,15 +1360,18 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
 
     def test_send_staff_email(self):
         form = CourseActivateForm({
+            'affil': self.aa.pk,
             'course_name': 'My Course',
             'consult_or_demo': 'consultation',
         })
         self.assertTrue(form.is_valid())
         AffilActivateView.send_staff_email(form, self.u)
         self.assertEqual(len(mail.outbox), 1)
+        shortname = self.aa.to_dict().get('dept').upper() + \
+            self.aa.to_dict().get('number')
         self.assertEqual(
             mail.outbox[0].subject,
-            'Mediathread Course Activated: My Course')
+            'Mediathread Course Activated: %s My Course' % shortname)
         self.assertEquals(
             mail.outbox[0].from_email,
             'test_user@example.com')

--- a/mediathread/templates/courseaffils/course_row.html
+++ b/mediathread/templates/courseaffils/course_row.html
@@ -1,0 +1,43 @@
+{% load methtags %}
+
+<tr>
+    <td class="course-choice">
+        <a class="choose-course"
+           {% if not course.is_course %}
+           href="{% url 'affil_activate' course.pk %}"
+           {% else %}
+           href="?set_course={{course.group.name|urlencode}}{{next_redirect}}"
+           {% endif %}
+        >{% firstof course.title course.coursedirectory_name %}</a>
+    </td>
+    {% if course.info.termyear %}
+        <td>{{course.info.termyear}}</td>
+    {% elif course.to_dict %}
+        <td>{{course.to_dict.term|int_to_term}} {{course.to_dict.year}}</td>
+    {% endif %}
+    <td>
+        {% if course.details.instructor %}
+            {{course.details.instructor.value}}
+        {% elif course.to_dict %}
+            {% firstof request.user.get_full_name request.user.username %}
+        {% endif %}
+    </td>
+    <td>
+        {% if course in as_instructor %}
+            Instructor
+        {% elif course in as_student %}
+            Student
+        {% elif not course.is_course %}
+            Instructor
+        {% else %}
+            Non-member
+        {% endif %}
+    </td>
+    {% if add_privilege %}
+        <td class="manage-course">
+            <a class="project"
+               href="{% url 'admin:courseaffils_course_change' course.id %}"
+            >manage</a>
+        </td>
+    {% endif %}
+</tr>

--- a/mediathread/templates/main/course_activate.html
+++ b/mediathread/templates/main/course_activate.html
@@ -1,13 +1,18 @@
 {% extends 'base.html' %}
 {% load bootstrap3 %}
+{% load methtags %}
 
 {% block title %}&mdash; Activate Course{% endblock %}
 
 {% block content %}
+    {% bootstrap_messages %}
     <form action="." method="post" class="form col-md-6">
         {% csrf_token %}
-        <h1>Course Activation: {{affil.coursedirectory_name}}</h1>
-        {% bootstrap_form form %}
+        {% bootstrap_form_errors form %}
+        <h1>Course Activation: {{affil.coursedirectory_name}} ({{term|int_to_term}} {{year}})</h1>
+        <input id="id_affil" name="affil" type="hidden" value="{{affil.pk}}">
+        {% bootstrap_field form.course_name addon_before=affil_shortname %}
+        {% bootstrap_field form.consult_or_demo %}
         {% buttons submit='Submit' %}{% endbuttons %}
     </form>
 {% endblock %}

--- a/mediathread/templates/main/course_list.html
+++ b/mediathread/templates/main/course_list.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% load coursetags %}
 {% load static %}
-{% load waffle_tags %}
 
 {% block title %}&mdash; Homepage{% endblock %}
 
@@ -38,7 +37,6 @@
 {% endblock %}
 
 {% block content %}
-    {% flag 'course_activation' %}
     <div id="course-list">
         <div id="coursefilter">
             <span class="h5">View courses for:</span>
@@ -75,7 +73,7 @@
         <h2>Current Courses</h2>
     {% endif %}
 
-    {% if object_list|length > 0 %}
+    {% if courses|length > 0 %}
         <table class="table course-choices tablesorter">
             <thead>
                 <tr>
@@ -89,7 +87,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for course in object_list %}
+                {% for course in courses %}
                     {% include 'courseaffils/course_row.html' %}
                 {% endfor %}
             </tbody>
@@ -119,22 +117,6 @@
         </table>
     {% endif %}
 
-    {% if activatable_affils|length > 0 %}
-        <h2>Activatable Courses</h2>
-        <ul>
-            {% for affil in activatable_affils %}
-                <li>
-                    {{affil.coursedirectory_name}}
-                    <a class="btn btn-default btn-xs"
-                       href="{% url 'affil_activate' affil.id %}" role="button"
-                    >Activate</a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
     </div>
-    {% else %}
-    The course_activation flag isn't enabled for this user.
-    {% endflag %}
 
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ django-reversion==1.9.3
 djangohelpers==0.18.1
 django-contrib-comments==1.7.1
 django-threadedcomments==1.0b1
-django-courseaffils==2.1.5
+django-courseaffils==2.1.6
 django-statsd-mozilla==0.3.16
 raven==5.15.0
 django-appconf==1.0.2  # django_compressor


### PR DESCRIPTION
Based on feedback from last week's Mediathread meeting:
- Put activatable courses in Current Courses table
- Display term/year on affil activation page
- activate courses with standard format (pre-pending name with
  dept/number)