### PR TITLE
Instructor Dashboard basics - PMT #105469

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4362,3 +4362,7 @@ a.btn.btn-default img.left {
     background-color: white;
     color: #337ab7;
 }
+
+.instructor-dashboard-sidebar.affix {
+    position: fixed;
+}

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -80,8 +80,9 @@ class ManageExternalCollectionView(LoggedInCourseMixin, View):
 
         messages.add_message(request, messages.INFO, msg)
 
-        redirect_url = request.POST.get('redirect-url',
-                                        reverse('class-manage-sources'))
+        redirect_url = request.POST.get(
+            'redirect-url',
+            reverse('course-dashboard-sources', args=(request.course.pk,)))
         return HttpResponseRedirect(redirect_url)
 
 

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -5,7 +5,7 @@ import json
 
 from courseaffils.columbia import CourseStringMapper
 from courseaffils.models import Course
-from courseaffils.tests.factories import AffilFactory
+from courseaffils.tests.factories import AffilFactory, CourseFactory
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.core import mail
@@ -105,15 +105,21 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
         self.assertTrue(
             self.client.login(username=self.student_one.username,
                               password='test'))
-        response = self.client.get('/dashboard/migrate/')
+        response = self.client.get(
+            reverse('course-dashboard-migrate',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 403)
 
     def test_not_logged_in(self):
-        response = self.client.get('/dashboard/migrate/')
+        response = self.client.get(
+            reverse('course-dashboard-migrate',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 302)
 
     def test_get_context_data(self):
-        request = RequestFactory().get('/dashboard/migrate/')
+        request = RequestFactory().get(
+            reverse('course-dashboard-migrate',
+                    args=(self.sample_course.pk,)))
         request.user = self.instructor_three
         request.course = self.sample_course
 
@@ -147,7 +153,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
     def test_post_invalidcourse(self):
         data = {'fromCourse': 42}
 
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.superuser
         request.course = self.sample_course
 
@@ -162,7 +170,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
             'on_behalf_of': self.alt_student.id
         }
 
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.superuser
         request.course = self.sample_course
 
@@ -179,7 +189,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
             'on_behalf_of': self.alt_instructor.id
         }
 
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.superuser
         request.course = self.sample_course
 
@@ -197,7 +209,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         # Migrate assets from SampleCourse into Alternate Course
         # test_instructor_three is a member of both courses
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.instructor_three
         request.course = self.alt_course
 
@@ -238,7 +252,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         # Migrate assets from SampleCourse into Alternate Course
         # test_instructor_three is a member of both courses
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.instructor_three
         request.course = self.alt_course
 
@@ -271,7 +287,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         # Migrate assets from SampleCourse into Alternate Course
         # test_instructor_three is a member of both courses
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.instructor_three
         request.course = self.alt_course
 
@@ -304,7 +322,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         # Migrate assets from SampleCourse into Alternate Course
         # test_instructor_three is a member of both courses
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.instructor_three
         request.course = self.alt_course
 
@@ -345,7 +365,9 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         # Migrate assets from SampleCourse into Alternate Course
         # test_instructor_three is a member of both courses
-        request = RequestFactory().post('/dashboard/migrate/', data)
+        request = RequestFactory().post(
+            reverse('course-dashboard-migrate', args=(self.sample_course.pk,)),
+            data)
         request.user = self.instructor_three
         request.course = self.alt_course
 
@@ -570,18 +592,24 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
         self.setup_sample_course()
 
     def test_not_logged_in(self):
-        response = self.client.get('/dashboard/settings/')
+        response = self.client.get(
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 302)
 
     def test_as_student(self):
         self.assertTrue(
             self.client.login(username=self.student_one.username,
                               password='test'))
-        response = self.client.get('/dashboard/settings/')
+        response = self.client.get(
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 403)
 
     def test_get_context_data(self):
-        request = RequestFactory().get('/dashboard/settings/')
+        request = RequestFactory().get(
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)))
         request.user = self.instructor_one
         request.course = self.sample_course
 
@@ -613,7 +641,8 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
             policy='PublicEditorsAreOwners')
 
         self.client.post(
-            '/dashboard/settings/',
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)),
             {course_details.ALLOW_PUBLIC_COMPOSITIONS_KEY: 0})
 
         col = project.get_collaboration()
@@ -631,7 +660,10 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
             course_details.ALLOW_PUBLIC_COMPOSITIONS_KEY: 1
         }
 
-        response = self.client.post('/dashboard/settings/', data)
+        response = self.client.post(
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)),
+            data)
         self.assertEquals(response.status_code, 302)
         self.assertEquals(course_information_title(self.sample_course), "Foo")
         self.assertTrue(allow_public_compositions(self.sample_course))
@@ -644,7 +676,10 @@ class CourseSettingsViewTest(MediathreadTestMixin, TestCase):
         self.switch_course(self.client, self.sample_course)
         data = {course_details.ITEM_VISIBILITY_KEY: 0}
 
-        response = self.client.post('/dashboard/settings/', data)
+        response = self.client.post(
+            reverse('course-dashboard-settings',
+                    args=(self.sample_course.pk,)),
+            data)
         self.assertEquals(response.status_code, 302)
 
         # unchanged from defaults
@@ -665,18 +700,24 @@ class CourseManageSourcesViewTest(MediathreadTestMixin, TestCase):
         self.superuser = UserFactory(is_staff=True, is_superuser=True)
 
     def test_not_logged_in(self):
-        response = self.client.get('/dashboard/sources/')
+        response = self.client.get(
+            reverse('course-dashboard-sources',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 302)
 
     def test_as_student(self):
         self.assertTrue(
             self.client.login(username=self.student_one.username,
                               password='test'))
-        response = self.client.get('/dashboard/sources/')
+        response = self.client.get(
+            reverse('course-dashboard-sources',
+                    args=(self.sample_course.pk,)))
         self.assertEquals(response.status_code, 403)
 
     def test_get_context(self):
-        request = RequestFactory().get('/dashboard/sources/')
+        request = RequestFactory().get(
+            reverse('course-dashboard-sources',
+                    args=(self.sample_course.pk,)))
         request.user = self.instructor_one
         request.course = self.sample_course
 
@@ -700,7 +741,10 @@ class CourseManageSourcesViewTest(MediathreadTestMixin, TestCase):
             course_details.UPLOAD_PERMISSION_ADMINISTRATOR
         }
 
-        self.client.post('/dashboard/sources/', data)
+        self.client.post(
+            reverse('course-dashboard-sources',
+                    args=(self.sample_course.pk,)),
+            data)
         self.assertTrue(course_details.can_upload(self.superuser,
                                                   self.sample_course))
         self.assertFalse(course_details.can_upload(self.instructor_one,
@@ -952,7 +996,7 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
 
     def setUp(self):
         self.setup_sample_course()
-        self.url = reverse('course-roster')
+        self.url = reverse('course-roster', args=(self.sample_course.pk,))
 
     def test_get(self):
         self.client.login(username=self.instructor_one.username,
@@ -1343,3 +1387,20 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
         self.assertEquals(
             mail.outbox[0].to,
             [settings.SERVER_EMAIL])
+
+
+class CourseInstructorDashboardViewTest(LoggedInUserTestMixin, TestCase):
+    def setUp(self):
+        super(CourseInstructorDashboardViewTest, self).setUp()
+        self.course = CourseFactory()
+
+    def test_get(self):
+        response = self.client.get(reverse(
+            'course-instructor-dashboard', kwargs={
+                'pk': self.course.pk
+            }))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'Instructor Dashboard: {}'.format(self.course.title))
+        self.assertEqual(response.context['object'], self.course)

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -2,6 +2,7 @@ import csv
 import json
 
 from courseaffils.lib import in_course_or_404
+from courseaffils.models import Course
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -181,6 +182,10 @@ class LoggedInCourseMixin(object):
 class LoggedInFacultyMixin(object):
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
+        if self.request.course is None and kwargs.get('pk') is not None:
+            self.request.course = get_object_or_404(
+                Course, pk=kwargs.get('pk'))
+
         if not cached_course_is_faculty(self.request.course,
                                         self.request.user):
             return HttpResponseForbidden("forbidden")

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -95,27 +95,34 @@
                             </li>
 
                             {% if role_in_course == 'instructor' %}
-                            <li>
-                                <div class="settings_menu manage closed">
-                                    <div class="right ui-icon-reverse ui-icon-triangle-1-s"></div>
-                                    <div class="left settings_menu_title">Manage</div>
-                                </div>
-                                <div class="visualclear"></div>
-                                <!-- Settings Menu -->
-                                <div class="settings_submenu" style="display: none">
-                                    <a href="/dashboard/settings/">Settings</a>
-                                    <a href="/dashboard/sources/">Sources</a>
-                                    <a href="/dashboard/migrate/">Migrations</a>
-                                    <a href="/taxonomy/">Vocabulary</a>
-                                    {% flag "roster_view" %}
-                                        <a href="/dashboard/roster/">Roster</a>
+                                <li>
+                                    {% flag 'instructor_dashboard' %}
+                                    <a href="{% url 'course-instructor-dashboard' course.pk %}">
+                                        Instructor Dashboard
+                                    </a>
+                                    {% else %}
+                                    <div class="settings_menu manage closed">
+                                        <div class="right ui-icon-reverse ui-icon-triangle-1-s"></div>
+                                        <div class="left settings_menu_title">Manage</div>
+                                    </div>
+                                    <div class="visualclear"></div>
+                                    <!-- Settings Menu -->
+                                    <div class="settings_submenu" style="display: none">
+                                        <a href="{% url 'course-dashboard-settings' course.pk %}">Settings</a>
+                                        <a href="{% url 'course-dashboard-sources' course.pk %}">Sources</a>
+                                        <a href="{% url 'course-dashboard-migrate' course.pk %}">Migrations</a>
+                                        <a href="{% url 'taxonomy-workspace' %}">Vocabulary</a>
+                                        {% flag "roster_view" %}
+                                        <a href="{% url 'course-roster' course.pk %}">Roster</a>
+                                        {% endflag %}
+
+                                        {% if user.is_staff %}
+                                            <hr />
+                                            <a href="/dashboard/delete/materials/">Materials</a>
+                                        {% endif %}
+                                    </div>
                                     {% endflag %}
 
-                                    {% if user.is_staff %}
-                                        <hr />
-                                        <a href="/dashboard/delete/materials/">Materials</a>
-                                    {% endif %}
-                                </div>
                             </li>
                             <li>
                                 <div class="settings_menu reports closed">

--- a/mediathread/templates/dashboard/class_manage_sources.html
+++ b/mediathread/templates/dashboard/class_manage_sources.html
@@ -25,7 +25,7 @@
     You may enable it for just yourself, or enable it for all members of your class.</p>
 
     {% if uploader %}
-        <form name="form-upload-permission" action="{% url 'class-manage-sources' %}" method="POST">
+        <form name="form-upload-permission" action="{% url 'course-dashboard-sources' course.pk %}" method="POST">
             <div class="form-group">
             <label>Set Upload Permission Settings</label>: &nbsp;
             <select name="upload_permission" class="form-control">
@@ -39,7 +39,7 @@
         </form>
         <div class="clearfix"></div>
         <form action="{% url 'collection-add-or-remove' %}" method="POST">
-            <input type="hidden" name="redirect-url" value="{% url 'class-manage-sources' %}">
+            <input type="hidden" name="redirect-url" value="{% url 'course-dashboard-sources' course.pk %}">
             <input type="hidden" name="collection_id" value="{{uploader.id}}" />
             <input class="btn btn-default left" name="remove" type="submit" value="Disable Video Upload" />
          </form>
@@ -52,7 +52,7 @@
             <input type="hidden" name="uploader" value="1">
             <input type="hidden" name="url" value="https://wardenclyffe.ccnmtl.columbia.edu/mediathread/">
             <input type="hidden" name="thumb" value="https://wardenclyffe.ccnmtl.columbia.edu/media/img/bg_header.jpg">
-            <input type="hidden" name="redirect-url" value="{% url 'class-manage-sources' %}">
+            <input type="hidden" name="redirect-url" value="{% url 'course-dashboard-sources' course.pk %}">
          </form>
          <div class="visualclear"></div>
      {% endif %}

--- a/mediathread/templates/dashboard/class_settings.html
+++ b/mediathread/templates/dashboard/class_settings.html
@@ -59,7 +59,7 @@
         <h3>Homepage "From Your Instructor" Title</h3>
         <p>This feature allows faculty to customize the left-hand column title on the Mediathread homepage.
         Titles should be less than 25 characters long.</p>
-        <form action="{% url 'course-settings' %}" name="course-information-title-form" method="POST">
+        <form action="{% url 'course-dashboard-settings' course.pk %}" name="course-information-title-form" method="POST">
             <input class="form-control" type="text" name="course_information_title" value="{{course_information_title}}" />
             <br />
             <input class="btn btn-default right" type="submit" value="Save Title"></input>
@@ -71,7 +71,7 @@
     <h3>"Publish To The World" Compositions</h3>
     <p>This feature allows authors to publish compositions at
     a public level, via a link that does not require logging into Mediathread.</p>
-        <form action="{% url 'course-settings' %}" method="POST">
+        <form action="{% url 'course-dashboard-settings' course.pk %}" method="POST">
             <h4 style="display: inline">Enabled:</h4>&nbsp;&nbsp;
             <label>
                 <input type="radio" name="allow_public_compositions" id="allow_public_compositions_yes" value="1" {% if allow_public_compositions %}checked{% endif %} /> Yes
@@ -91,7 +91,7 @@
         collections views. Students can still view an item or selection embedded
         in a visible composition. Faculty always can view all items and selections.</p>
 
-        <form action="{% url 'course-settings' %}" method="POST">
+        <form action="{% url 'course-dashboard-settings' course.pk %}" method="POST">
             <h4 style="display: inline">Course members can see each other's items</h4>: &nbsp;
             <label>
             <input type="radio" name="item_visibility" id="item_visibility_yes" value="1" {% if item_visibility %}checked{% endif %} /> Yes
@@ -133,11 +133,14 @@
                 </ol>
             {% endif %}
 
-            <input type="hidden" name="next" value="{% url 'course-settings' %}" />
+            <input type="hidden" name="next" value="{% url 'course-dashboard-settings' course.pk %}" />
             <input type="hidden" name="group" value="{{course.group.id}}" />
             <input type="hidden" name="faculty_group" value="{{course.faculty_group.id}}" />
             <div><input class="btn btn-default" type="submit" value="Save"></input></div>
         </form>
         <div class="visualclear"></div>
+    </div>
+    <div class="col-md-3" role="complementary">
+        {% include 'main/course_instructor_dashboard_menu.html' %}
     </div>
 {% endblock %}

--- a/mediathread/templates/main/course_instructor_dashboard.html
+++ b/mediathread/templates/main/course_instructor_dashboard.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load waffle_tags %}
+
+{% block title %}
+    | Instructor Dashboard: {{object.title}}
+{% endblock %}
+
+{% block coursetitle %}
+    <a href=".">Instructor Dashboard: {{object.title}}</a>
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-9" role="main">
+        <h2><a href="{% url 'course-dashboard-settings' object.pk %}">Settings</a></h2>
+        <h2><a href="{% url 'course-dashboard-sources' object.pk %}">Sources</a></h2>
+        <h2><a href="{% url 'course-dashboard-migrate' object.pk %}">Migrations</a></h2>
+        <h2><a href="{% url 'taxonomy-workspace' %}">Vocabulary</a></h2>
+        {% flag "roster_view" %}
+        <h2><a href="{% url 'course-roster' object.pk %}">Roster</a></h2>
+        {% endflag %}
+    </div>
+    <div class="col-md-3" role="complementary">
+        {% include 'main/course_instructor_dashboard_menu.html' %}
+    </div>
+{% endblock %}

--- a/mediathread/templates/main/course_instructor_dashboard_menu.html
+++ b/mediathread/templates/main/course_instructor_dashboard_menu.html
@@ -1,0 +1,13 @@
+{% load waffle_tags %}
+
+<nav class="affix instructor-dashboard-sidebar">
+    <ul class="nav">
+        <li><a href="{% url 'course-dashboard-settings' object.pk %}">Settings</a></li>
+        <li><a href="{% url 'course-dashboard-sources' object.pk %}">Sources</a></li>
+        <li><a href="{% url 'course-dashboard-migrate' object.pk %}">Migrations</a></li>
+        <li><a href="{% url 'taxonomy-workspace' %}">Vocabulary</a></li>
+        {% flag "roster_view" %}
+        <li><a href="{% url 'course-roster' object.pk %}">Roster</a></li>
+        {% endflag %}
+    </ul>
+</nav>

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -17,7 +17,7 @@ from mediathread.assetmgr.views import (
     AssetCreateView, BookmarkletMigrationView)
 from mediathread.main.forms import CustomRegistrationForm
 from mediathread.main.views import (
-    MethCourseListView, AffilActivateView,
+    MethCourseListView, CourseInstructorDashboardView, AffilActivateView,
     ContactUsView, RequestCourseView, IsLoggedInView, IsLoggedInDataView,
     MigrateMaterialsView, MigrateCourseView, CourseManageSourcesView,
     CourseSettingsView, CourseDeleteMaterialsView, course_detail_view,
@@ -138,6 +138,8 @@ urlpatterns = patterns(
     (r'^contact/success/$',
      TemplateView.as_view(template_name='main/contact_success.html')),
     (r'^contact/$', ContactUsView.as_view()),
+
+    # Course forms
     (r'^course/request/success/$',
      TemplateView.as_view(template_name='main/course_request_success.html')),
     (r'^course/request/', RequestCourseView.as_view()),
@@ -164,8 +166,7 @@ urlpatterns = patterns(
 
     url(r'^dashboard/migrate/materials/(?P<course_id>\d+)/$',
         MigrateMaterialsView.as_view(), {}, 'dashboard-migrate-materials'),
-    url(r'^dashboard/migrate/$', MigrateCourseView.as_view(),
-        {}, 'dashboard-migrate'),
+
     url(r'^dashboard/roster/promote/', CoursePromoteUserView.as_view(),
         name='course-roster-promote'),
     url(r'^dashboard/roster/demote/', CourseDemoteUserView.as_view(),
@@ -178,13 +179,7 @@ urlpatterns = patterns(
         name='course-roster-invite-email'),
     url(r'^dashboard/roster/resend/email/', CourseResendInviteView.as_view(),
         name='course-roster-resend-email'),
-    url(r'^dashboard/roster/', CourseRosterView.as_view(),
-        name='course-roster'),
 
-    url(r'^dashboard/sources/', CourseManageSourcesView.as_view(),
-        name='class-manage-sources'),
-    url(r'^dashboard/settings/', CourseSettingsView.as_view(),
-        name='course-settings'),
     url(r'^dashboard/delete/materials/', CourseDeleteMaterialsView.as_view(),
         name='course-delete-materials'),
 
@@ -213,7 +208,24 @@ urlpatterns = patterns(
     # Composition Space
     (r'^project/', include('mediathread.projects.urls')),
 
-    # Instructor Dashboard & reporting
+    # Instructor Dashboard
+    url(r'^course/(?P<pk>\d+)/dashboard/$',
+        CourseInstructorDashboardView.as_view(),
+        name='course-instructor-dashboard'),
+    url(r'^course/(?P<pk>\d+)/dashboard/settings/',
+        CourseSettingsView.as_view(),
+        name='course-dashboard-settings'),
+    url(r'^course/(?P<pk>\d+)/dashboard/sources/',
+        CourseManageSourcesView.as_view(),
+        name='course-dashboard-sources'),
+    url(r'^course/(?P<pk>\d+)/dashboard/migrate/$',
+        MigrateCourseView.as_view(),
+        {}, 'course-dashboard-migrate'),
+    url(r'^course/(?P<pk>\d+)/dashboard/roster/',
+        CourseRosterView.as_view(),
+        name='course-roster'),
+
+    # Reporting
     (r'^reports/', include('mediathread.reports.urls')),
 
     # Bookmarklet, Wardenclyffe, Staff custom asset entry


### PR DESCRIPTION
* Each dashboard view (e.g. settings, sources) now has an absolute url
  containing the course ID
* The "Manage" menu will change to an "Instructor Dashboard" link with
  the instructor_dashboard flag enabled.

The Instructor Dashboard page itself if plain so far - just linking out
to the various functionality. I'll clean this up in future PRs.