### PR TITLE
Always default to current term for course list view

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1254,7 +1254,20 @@ class MethCourseListViewTest(LoggedInUserTestMixin, TestCase):
 
     def test_get(self):
         url = reverse('course_list')
-        affil_name = 't3.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
+        affil_name = 't1.y2016.s001.cf1000.scnc.fc.course:columbia.edu'
+        aa = AffilFactory(user=self.u, name=affil_name)
+        with override_flag('course_activation', active=True):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Course Selection')
+        self.assertContains(response, aa.coursedirectory_name)
+        self.assertEqual(len(response.context['object_list']), 0)
+        self.assertEqual(len(response.context['activatable_affils']), 1)
+        self.assertEqual(response.context['activatable_affils'][0], aa)
+
+    def test_get_past_affil(self):
+        url = reverse('course_list')
+        affil_name = 't1.y2015.s001.cf1000.scnc.fc.course:columbia.edu'
         aa = AffilFactory(user=self.u, name=affil_name)
         with override_flag('course_activation', active=True):
             response = self.client.get(url)

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -808,15 +808,13 @@ class MethCourseListView(LoggedInMixin, CourseListView):
             return context
 
         courses = list(context.get('courses'))
-        semester_view = self.request.GET.get('semester_view')
+        semester_view = self.request.GET.get('semester_view', 'current')
         affils = Affil.objects.filter(user=self.request.user, activated=False)
         for affil in affils:
             affil_semester = affil.past_present_future
-            if affil_semester == -1 and semester_view == 'past':
-                courses.insert(0, affil)
-            elif affil_semester == 0 and semester_view == 'current':
-                courses.insert(0, affil)
-            elif affil_semester == 1 and semester_view == 'future':
+            if (affil_semester == -1 and semester_view == 'past') or \
+               (affil_semester == 0 and semester_view == 'current') or \
+               (affil_semester == 1 and semester_view == 'future'):
                 courses.insert(0, affil)
 
         context.update({


### PR DESCRIPTION
fixes bug where affil is not visible unless the GET param
is present.