### PR TITLE
Consolidate bootstrap_messages into base.html

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -202,6 +202,8 @@
             <div>
                 {% block pagetitle %}{% endblock %}
 
+                {% bootstrap_messages %}
+
                 {% block content %}{% endblock %}
 
                 <!-- ###### Don't touch this ###### -->

--- a/mediathread/templates/dashboard/class_delete_materials.html
+++ b/mediathread/templates/dashboard/class_delete_materials.html
@@ -33,14 +33,6 @@
 {% endblock %}
 
 {% block dashboard_module %}
-    {% if messages %}
-        <div class="alert alert-info alert-dismissible" role="alert">
-          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          {% for message in messages %}
-                <div{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</div>
-            {% endfor %}
-        </div>
-    {% endif %}
 
     <form action="{% url 'course-delete-materials' %}"
      name="course-clear-form" method="POST"

--- a/mediathread/templates/dashboard/class_manage_sources.html
+++ b/mediathread/templates/dashboard/class_manage_sources.html
@@ -10,15 +10,6 @@
 
 {% block dashboard_module %}
 
-    {% if messages %}
-        <div class="alert alert-info alert-dismissible" role="alert">
-          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          {% for message in messages %}
-                <div{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</div>
-            {% endfor %}
-        </div>
-    {% endif %}
-
     <div class="well">
     <h3>Mediathread Video Uploader</h3>
     <p>Mediathread supports direct uploading of videos from a user's desktop. By default this direct upload feature is turned off.

--- a/mediathread/templates/dashboard/class_roster.html
+++ b/mediathread/templates/dashboard/class_roster.html
@@ -37,17 +37,6 @@
 {% endblock %}
 
 {% block dashboard_module %}
-{% if messages %}
-    <div class="alert alert-info alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <div><b>Action Completed</b></div><br />
-      <ul>
-      {% for message in messages %}
-            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-        {% endfor %}
-        </ul>
-    </div>
-{% endif %}
 
 <div class="roster-container">
     <div>

--- a/mediathread/templates/dashboard/class_settings.html
+++ b/mediathread/templates/dashboard/class_settings.html
@@ -46,15 +46,6 @@
 
 {% block dashboard_module %}
 
-    {% if messages %}
-        <div class="alert alert-info alert-dismissible" role="alert">
-          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          {% for message in messages %}
-                <div{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</div>
-            {% endfor %}
-        </div>
-    {% endif %}
-
     <div class="well">
         <h3>Homepage "From Your Instructor" Title</h3>
         <p>This feature allows faculty to customize the left-hand column title on the Mediathread homepage.

--- a/mediathread/templates/main/course_activate.html
+++ b/mediathread/templates/main/course_activate.html
@@ -5,7 +5,6 @@
 {% block title %}&mdash; Activate Course{% endblock %}
 
 {% block content %}
-    {% bootstrap_messages %}
     <form action="." method="post" class="form col-md-6">
         {% csrf_token %}
         {% bootstrap_form_errors form %}


### PR DESCRIPTION
This fixes a problem where messages weren't appearing on course
activation because it forwards the user to the course list view.