### PR TITLE
allow messages override

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -202,7 +202,9 @@
             <div>
                 {% block pagetitle %}{% endblock %}
 
+                {% block messages %}
                 {% bootstrap_messages %}
+                    {% endblock %}
 
                 {% block content %}{% endblock %}
 


### PR DESCRIPTION
The ColumbiaU specific class_roster.html template needs to handle message display a bit differently.