### PR TITLE
Untangle settings chain

### DIFF
--- a/mediathread/settings.py
+++ b/mediathread/settings.py
@@ -1,6 +1,18 @@
 # flake8: noqa
 from settings_shared import *
 
+# if you add a 'deploy_specific' directory
+# then you can put a settings.py file and templates/ overrides there
+# otherwise, make sure you specify the correct database settings in your
+# local_settings.py
+try:
+    from mediathread.deploy_specific.settings import *  # noqa
+    if 'EXTRA_INSTALLED_APPS' in locals():
+        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
+except:
+    pass
+
+# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:

--- a/mediathread/settings_production.py
+++ b/mediathread/settings_production.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from mediathread.settings import *
+from settings_shared import *
 from ccnmtlsettings.production import common
 
 locals().update(
@@ -11,10 +11,24 @@ locals().update(
         s3static=False,
     ))
 
+
 TEMPLATE_DIRS.insert(
     0,
     "/var/www/mediathread/mediathread/mediathread/deploy_specific/templates")
 
+
+# if you add a 'deploy_specific' directory
+# then you can put a settings.py file and templates/ overrides there
+# otherwise, make sure you specify the correct database settings in your
+# local_settings.py
+try:
+    from mediathread.deploy_specific.settings import *  # noqa
+    if 'EXTRA_INSTALLED_APPS' in locals():
+        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
+except:
+    pass
+
+# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -197,14 +197,3 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
     )
 
 BLOCKED_EMAIL_DOMAINS = []
-
-# if you add a 'deploy_specific' directory
-# then you can put a settings.py file and templates/ overrides there
-# otherwise, make sure you specify the correct database settings in your
-# local_settings.py
-try:
-    from mediathread.deploy_specific.settings import *  # noqa
-    if 'EXTRA_INSTALLED_APPS' in locals():
-        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
-except:
-    pass

--- a/mediathread/settings_staging.py
+++ b/mediathread/settings_staging.py
@@ -11,10 +11,24 @@ locals().update(
         s3static=False,
     ))
 
+
 TEMPLATE_DIRS.insert(
     0,
     "/var/www/mediathread/mediathread/mediathread/deploy_specific/templates")
 
+
+# if you add a 'deploy_specific' directory
+# then you can put a settings.py file and templates/ overrides there
+# otherwise, make sure you specify the correct database settings in your
+# local_settings.py
+try:
+    from mediathread.deploy_specific.settings import *  # noqa
+    if 'EXTRA_INSTALLED_APPS' in locals():
+        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
+except:
+    pass
+
+# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
The Mediathread settings inclusion chain is complicated by the presence of a _deploy_specific_ directory. deploy_specific is intended for more extensive settings and template overrides than can be accomplished in local_settings. We can debate the overall approach, but for now: This pull request fixes an import inconsistency and untangles the inclusion chain to ensure settings are included in the same way in all environments.

1. Fixing settings_production.py inconsistency. mediathread.settings was included rather than mediathread.settings_shared.

2. Not counting the bug in #1, the settings inclusion chain looked like this. The database overrides in ccnmtlsettings.production are particularly troublesome for our external clients who had overridden the database in prior releases.

* mediathread.settings_production  
  * mediathread.settings_shared
    * mediathread.deploy_specific.settings
  * ccnmtlsettings.production
  * mediathread.local_settings

and now it looks like so for settings_production, settings_staging and settings.

* mediathread.settings_production or settings_staging or settings  
  * mediathread.settings_shared
  * ccnmtlsettings.production
  * mediathread.deploy_specific.settings
  * mediathread.local_settings

