### PR TITLE
Revert "Untangle settings chain"

### DIFF
--- a/mediathread/settings.py
+++ b/mediathread/settings.py
@@ -1,18 +1,6 @@
 # flake8: noqa
 from settings_shared import *
 
-# if you add a 'deploy_specific' directory
-# then you can put a settings.py file and templates/ overrides there
-# otherwise, make sure you specify the correct database settings in your
-# local_settings.py
-try:
-    from mediathread.deploy_specific.settings import *  # noqa
-    if 'EXTRA_INSTALLED_APPS' in locals():
-        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
-except:
-    pass
-
-# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:

--- a/mediathread/settings_production.py
+++ b/mediathread/settings_production.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from settings_shared import *
+from mediathread.settings import *
 from ccnmtlsettings.production import common
 
 locals().update(
@@ -11,24 +11,10 @@ locals().update(
         s3static=False,
     ))
 
-
 TEMPLATE_DIRS.insert(
     0,
     "/var/www/mediathread/mediathread/mediathread/deploy_specific/templates")
 
-
-# if you add a 'deploy_specific' directory
-# then you can put a settings.py file and templates/ overrides there
-# otherwise, make sure you specify the correct database settings in your
-# local_settings.py
-try:
-    from mediathread.deploy_specific.settings import *  # noqa
-    if 'EXTRA_INSTALLED_APPS' in locals():
-        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
-except:
-    pass
-
-# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -197,3 +197,14 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
     )
 
 BLOCKED_EMAIL_DOMAINS = []
+
+# if you add a 'deploy_specific' directory
+# then you can put a settings.py file and templates/ overrides there
+# otherwise, make sure you specify the correct database settings in your
+# local_settings.py
+try:
+    from mediathread.deploy_specific.settings import *  # noqa
+    if 'EXTRA_INSTALLED_APPS' in locals():
+        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
+except:
+    pass

--- a/mediathread/settings_staging.py
+++ b/mediathread/settings_staging.py
@@ -11,24 +11,10 @@ locals().update(
         s3static=False,
     ))
 
-
 TEMPLATE_DIRS.insert(
     0,
     "/var/www/mediathread/mediathread/mediathread/deploy_specific/templates")
 
-
-# if you add a 'deploy_specific' directory
-# then you can put a settings.py file and templates/ overrides there
-# otherwise, make sure you specify the correct database settings in your
-# local_settings.py
-try:
-    from mediathread.deploy_specific.settings import *  # noqa
-    if 'EXTRA_INSTALLED_APPS' in locals():
-        INSTALLED_APPS = INSTALLED_APPS + EXTRA_INSTALLED_APPS  # noqa
-except:
-    pass
-
-# local_settings overrides everything
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
Reverts ccnmtl/mediathread#716

broke staging with:

```
    Traceback (most recent call last):
      File "./manage.py", line 10, in <module>
        execute_from_command_line(sys.argv)
      File "/var/www/mediathread/releases/green/mediathread/ve/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
        utility.execute()
      File "/var/www/mediathread/releases/green/mediathread/ve/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
        django.setup()
      File "/var/www/mediathread/releases/green/mediathread/ve/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
        apps.populate(settings.INSTALLED_APPS)
      File "/var/www/mediathread/releases/green/mediathread/ve/local/lib/python2.7/site-packages/django/apps/registry.py", line 89, in populate
        "duplicates: %s" % app_config.label)
    django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: deploy_specific
```