### PR TITLE
Fix course select filter boldness text

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -780,8 +780,8 @@ div.column-contents {
     float: left;
 }
 
-#coursefilter .ui-state-active {
-    font-weight: bold !important;
+#coursefilter a.active {
+    font-weight: bold;
 }
 
 #create-course-container {


### PR DESCRIPTION
The filter text should be bold when the filter is active, not
when it's being clicked.