### PR TITLE
remove load from future tag from impersonate template

### DIFF
--- a/mediathread/templates/impersonate/search_users.html
+++ b/mediathread/templates/impersonate/search_users.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 
 
 {% block title %}


### PR DESCRIPTION
to eliminate compress's complaint `impersonate/list_users.html: 'url' is not a valid tag or filter in tag library 'future'`