### PR TITLE
LTI - explicitly set course

### DIFF
--- a/lti_auth/tests/test_views.py
+++ b/lti_auth/tests/test_views.py
@@ -44,7 +44,8 @@ class LTIViewTest(TestCase):
             self.assertFalse(request.session[LTI_SESSION_KEY])
 
     def test_launch(self):
-        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS}):
+        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS},
+                           LTI_EXTRA_PARAMETERS=['lti_version']):
             ctx = LTICourseContextFactory(enable=True)
             request = generate_lti_request(ctx)
 
@@ -53,7 +54,9 @@ class LTIViewTest(TestCase):
 
             response = view.dispatch(request)
             self.assertEquals(response.status_code, 302)
-            self.assertEquals(response.url, '/')
+            self.assertEquals(
+                response.url,
+                '/?lti_version=LTI-1p0&'.format(ctx.uuid))
 
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user
@@ -64,7 +67,8 @@ class LTIViewTest(TestCase):
             self.assertTrue(user in ctx.faculty_group.user_set.all())
 
     def test_launch_custom_landing_page(self):
-        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS}):
+        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS},
+                           LTI_EXTRA_PARAMETERS=['lti_version']):
             ctx = LTICourseContextFactory(enable=True)
             request = generate_lti_request(ctx, 'canvas')
 
@@ -73,7 +77,9 @@ class LTIViewTest(TestCase):
 
             response = view.dispatch(request)
             self.assertEquals(response.status_code, 302)
-            self.assertTrue(response.url.endswith('landing/'))
+            self.assertTrue(
+                response.url,
+                'http://testserver/landing/?lti_version=LTI-1p0&')
 
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user
@@ -84,7 +90,8 @@ class LTIViewTest(TestCase):
             self.assertTrue(user in ctx.faculty_group.user_set.all())
 
     def test_embed(self):
-        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS}):
+        with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS},
+                           LTI_EXTRA_PARAMETERS=['lti_version']):
             ctx = LTICourseContextFactory(enable=True)
             request = generate_lti_request(ctx, 'canvas', 'embed')
 
@@ -95,7 +102,8 @@ class LTIViewTest(TestCase):
             self.assertEquals(response.status_code, 302)
             self.assertEquals(
                 response.url,
-                'http://testserver/asset/embed/?return_url=/asset/')
+                'http://testserver/asset/embed/?return_url=/asset/'
+                '&lti_version=LTI-1p0&')
 
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user

--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -67,6 +67,20 @@ class LTIRoutingView(LTIAuthMixin, View):
         provider = self.request.POST.get(key, '').lower()
         return 'canvas' in provider or 'blackboard' in provider
 
+    def add_extra_parameters(self, url):
+        if not hasattr(settings, 'LTI_EXTRA_PARAMETERS'):
+            return
+
+        if '?' not in url:
+            url += '?'
+        else:
+            url += '&'
+
+        for key in settings.LTI_EXTRA_PARAMETERS:
+            url += '{}={}&'.format(key, self.request.POST.get(key, ''))
+
+        return url
+
     def post(self, request):
         if request.POST.get('ext_content_intended_use', '') == 'embed':
             domain = self.request.get_host()
@@ -80,6 +94,8 @@ class LTIRoutingView(LTIAuthMixin, View):
             url = reverse('lti-landing-page')
         else:
             url = '/'
+
+        url = self.add_extra_parameters(url)
 
         return HttpResponseRedirect(url)
 

--- a/mediathread/main/middleware.py
+++ b/mediathread/main/middleware.py
@@ -1,11 +1,24 @@
+from courseaffils.middleware import CourseManagerMiddleware, SESSION_KEY
+from courseaffils.models import Course
 import waffle
-from courseaffils.middleware import CourseManagerMiddleware
+
+from lti_auth.models import LTICourseContext
 from mediathread.main.views import MethCourseListView
 
 
 class MethCourseManagerMiddleware(CourseManagerMiddleware):
     def process_request(self, request):
         override_view = None
+
+        # 'custom_course_context' comes through from lti. set the course.
+        uuid = request.GET.get('custom_course_context', None)
+        if uuid is not None:
+            ctx = LTICourseContext.objects.get(uuid=uuid)
+            course = Course.objects.get(group=ctx.group,
+                                        faculty_group=ctx.faculty_group)
+            request.session[SESSION_KEY] = course
+            self.decorate_request(request, course)
+            return None
 
         # When course_activation is turned on, use the MethCourseListView
         # which has the course activation feature instead of courseaffils'

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -186,8 +186,9 @@ LTI_TOOL_CONFIGURATION = {
     'launch_url': 'lti/',
     'embed_url': 'asset/embed/',
     'embed_icon_url': 'media/img/icons/icon-16.png',
-    'embed_tool_id': 'mediathread',
+    'embed_tool_id': 'mediathread'
 }
+LTI_EXTRA_PARAMETERS = ['custom_course_context']
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
 


### PR DESCRIPTION
The LTI link bypasses courseaffils logic and takes the user directly to the course.