### PR TITLE
Allow add unis per line

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1157,7 +1157,7 @@ class UnisListTest(TestCase):
     def test_whitespace(self):
         self.assertEqual(unis_list("\tfoo,   bar, \n"), ["foo", "bar"])
 
-    def test_newlines(self)
+    def test_newlines(self):
         self.assertEqual(unis_list("foo\nbar\n\rbaz"), ["foo", "bar", "baz"])
 
 

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -42,7 +42,9 @@ from mediathread.main.views import (
     AffilActivateView,
     MigrateCourseView, ContactUsView,
     RequestCourseView, CourseManageSourcesView,
-    CourseRosterView, CourseAddUserByUNIView, CourseAcceptInvitationView)
+    CourseRosterView, CourseAddUserByUNIView, CourseAcceptInvitationView,
+    unis_list,
+)
 from mediathread.projects.models import Project
 
 
@@ -964,6 +966,21 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
         self.assertTrue('efg456 is now a course member'
                         in response.cookies['messages'].value)
 
+    def test_uni_invite_post_newlines(self):
+        self.client.login(username=self.instructor_one.username,
+                          password='test')
+        self.switch_course(self.client, self.sample_course)
+
+        url = reverse('course-roster-add-uni')
+        # sometimes they enter a newline instead of a comma
+        response = self.client.post(url, {'unis': ' abc123\nefg456,'})
+        self.assertEquals(response.status_code, 302)
+
+        user = User.objects.get(username='efg456')
+        self.assertTrue(self.sample_course.is_true_member(user))
+        self.assertTrue('efg456 is now a course member'
+                        in response.cookies['messages'].value)
+
     def test_email_invite_existing_course_member(self):
         url = reverse('course-roster-invite-email')
         self.client.login(username=self.instructor_one.username,
@@ -1131,6 +1148,17 @@ class CourseRosterViewsTest(MediathreadTestMixin, TestCase):
             self.assertEquals(mail.outbox[0].from_email,
                               'mediathread@example.com')
             self.assertTrue(mail.outbox[0].to, [invite.email])
+
+
+class UnisListTest(TestCase):
+    def test_commas(self):
+        self.assertEqual(unis_list("foo,bar"), ["foo", "bar"])
+
+    def test_whitespace(self):
+        self.assertEqual(unis_list("\tfoo,   bar, \n"), ["foo", "bar"])
+
+    def test_newlines(self)
+        self.assertEqual(unis_list("foo\nbar\n\rbaz"), ["foo", "bar", "baz"])
 
 
 class MethCourseListAnonViewTest(TestCase):

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -540,6 +540,9 @@ class CourseRemoveUserView(LoggedInFacultyMixin, View):
 
 
 def unis_list(unis):
+    # sometimes people enter line breaks instead of commas. allow it by
+    # normalizing everything to commas
+    unis = re.sub(r'\s+', ',', unis)
     return [u.strip() for u in unis.split(",") if len(u.strip()) > 0]
 
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -540,7 +540,7 @@ class CourseRemoveUserView(LoggedInFacultyMixin, View):
 
 
 def unis_list(unis):
-    return unis.split(",")
+    return [u.strip() for u in unis.split(",") if len(u.strip()) > 0]
 
 
 class CourseAddUserByUNIView(LoggedInFacultyMixin, View):
@@ -572,23 +572,21 @@ class CourseAddUserByUNIView(LoggedInFacultyMixin, View):
         }
 
         for uni in unis_list(unis):
-            uni = uni.strip()
-            if len(uni) > 0:
-                user = self.get_or_create_user(uni)
-                display_name = user_display_name(user)
-                if self.request.course.is_true_member(user):
-                    msg = '{} ({}) is already a course member'.format(
-                        display_name, uni)
-                    messages.add_message(request, messages.WARNING, msg)
-                else:
-                    email = '{}@columbia.edu'.format(uni)
-                    self.request.course.group.user_set.add(user)
-                    send_template_email(subj, self.email_template, ctx, email)
-                    msg = (
-                        '{} is now a course member. An email was sent to '
-                        '{} notifying the user.').format(display_name, email)
+            user = self.get_or_create_user(uni)
+            display_name = user_display_name(user)
+            if self.request.course.is_true_member(user):
+                msg = '{} ({}) is already a course member'.format(
+                    display_name, uni)
+                messages.add_message(request, messages.WARNING, msg)
+            else:
+                email = '{}@columbia.edu'.format(uni)
+                self.request.course.group.user_set.add(user)
+                send_template_email(subj, self.email_template, ctx, email)
+                msg = (
+                    '{} is now a course member. An email was sent to '
+                    '{} notifying the user.').format(display_name, email)
 
-                    messages.add_message(request, messages.INFO, msg)
+                messages.add_message(request, messages.INFO, msg)
 
         return HttpResponseRedirect(reverse('course-roster'))
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -539,6 +539,10 @@ class CourseRemoveUserView(LoggedInFacultyMixin, View):
         return HttpResponseRedirect(reverse('course-roster'))
 
 
+def unis_list(unis):
+    return unis.split(",")
+
+
 class CourseAddUserByUNIView(LoggedInFacultyMixin, View):
 
     email_template = 'dashboard/email_add_uni_user.txt'
@@ -567,7 +571,7 @@ class CourseAddUserByUNIView(LoggedInFacultyMixin, View):
             'domain': get_current_site(self.request).domain
         }
 
-        for uni in unis.split(','):
+        for uni in unis_list(unis):
             uni = uni.strip()
             if len(uni) > 0:
                 user = self.get_or_create_user(uni)


### PR DESCRIPTION
both of these recent sentry errors: 

* https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/1131/
* https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/1132/

Seem to come from someone entering unis one per line rather than comma separated. This PR adds support for that. The UI still says to use commas, but I think it's OK to have it silently support linebreaks as well since it's pretty clear what the user's intent was (it actually supports any whitespace as a valid separator). We could go the other way and be stricter about requiring commas, but to do that properly, I think it would have to be done with client-side validation and would be a bit more work.