### PR TITLE
Remove links to upgrade bookmarklet

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -107,7 +107,6 @@ NON_ANONYMOUS_PATHS = (
     '/reports/',
     '/setting/',
     '/taxonomy/',
-    '/upgrade/',
     '/upload/',
     re.compile(r'^/$'),
 )

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -152,7 +152,6 @@
                                     <!-- Settings Menu -->
                                     <div class="settings_submenu" style="display: none">
                                          <a href="/help/">Knowledge Base</a>
-                                         <a href="/upgrade/">Upgrade Bookmarklet</a>
                                     </div>
                                 {% endblock %}
                             </li>

--- a/mediathread/templates/homepage.html
+++ b/mediathread/templates/homepage.html
@@ -68,7 +68,6 @@
     <!-- Settings Menu -->
     <div class="settings_submenu" style="display: none">
          <a href="/help/">Knowledge Base</a>
-         <a href="/upgrade/">Upgrade Bookmarklet</a>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
The bookmarklet upgrade page has already been removed, so we should
remove these links.