### PR TITLE
User username instead of user id when passing data to PMT

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1223,7 +1223,7 @@ class MethCourseListViewTest(LoggedInUserTestMixin, TestCase):
     TASK_ASSIGNMENT_DESTINATION='https://pmt.ccnmtl.columbia.edu/drf/'
     'external_add_item/')
 @override_settings(MEDIATHREAD_PMT_MILESTONE_ID=12)
-@override_settings(MEDIATHREAD_PMT_OWNER_ID=12)
+@override_settings(MEDIATHREAD_PMT_OWNER_USERNAME='pmt_user')
 class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
     def setUp(self):
         super(AffilActivateViewTest, self).setUp()

--- a/mediathread/main/util.py
+++ b/mediathread/main/util.py
@@ -33,7 +33,7 @@ def user_display_name(user):
     return user.get_full_name() or user.username
 
 
-def make_pmt_item(milestone_id, owner_id, data):
+def make_pmt_item(data):
     """Make a PMT item containing the given data.
 
     This function requires TASK_ASSIGNMENT_DESTINATION to be set.

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -908,9 +908,9 @@ The Mediathread Team
         """
         milestone_id = getattr(
             settings, 'MEDIATHREAD_PMT_MILESTONE_ID', None)
-        owner_id = getattr(
-            settings, 'MEDIATHREAD_PMT_OWNER_ID', None)
-        if milestone_id and owner_id:
+        owner_username = getattr(
+            settings, 'MEDIATHREAD_PMT_OWNER_USERNAME', None)
+        if milestone_id and owner_username:
             # Prepare data entry into PMT. See
             # dmt.views.api.ExternalAddItemView.
             data = form.cleaned_data
@@ -925,15 +925,15 @@ The Mediathread Team
 
             pmt_data = {
                 'mid': milestone_id,
-                'owner': owner_id,
-                'assigned_to': owner_id,
+                'owner': owner_username,
+                'assigned_to': owner_username,
                 'type': 'action item',
                 'title': 'Course Activated: {}'.format(
                     data.get('course_name')),
                 'description': description,
             }
             try:
-                return make_pmt_item(milestone_id, owner_id, pmt_data)
+                return make_pmt_item(pmt_data)
             except ImproperlyConfigured:
                 # If the PMT item creation fails, we'll have the staff email.
                 pass


### PR DESCRIPTION
PMT's ExternalAddItemView expects usernames, not user ids.