### PR TITLE
Don't send course activation staff email from faculty user's addr

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1315,7 +1315,7 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
             'Mediathread Course Activated: English for Cats')
         self.assertEquals(
             mail.outbox[0].from_email,
-            'test_user@example.com')
+            settings.SERVER_EMAIL)
         self.assertEquals(
             mail.outbox[0].to,
             [settings.SERVER_EMAIL])

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -866,7 +866,7 @@ Faculty: {} <{}>
         send_mail(
             subject,
             body,
-            faculty_user.email,
+            settings.SERVER_EMAIL,
             [settings.SERVER_EMAIL])
 
     def create_course(self, form, affil):


### PR DESCRIPTION
addresses sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/1151/