### PR TITLE
Add permissions to show/hide download item feature

### DIFF
--- a/media/templates/asset_workspace.mustache
+++ b/media/templates/asset_workspace.mustache
@@ -60,9 +60,9 @@
                                 <div class="asset-view-published">
                                     <div id="asset-workspace-videoclipbox" class="videoclipbox" style="display: none;">
                                         <div class="asset-object" style="border: none; background-color: #ededed;"></div>
-                                        {{#context.is_faculty}}
+                                        {{#context.allow_item_download}}
                                             <span class="sherd-flowplayer-download-btn"></span>
-                                        {{/context.is_faculty}}
+                                        {{/context.allow_item_download}}
                                         <div class="asset-display"></div>
                                         <div class="clipstrip-display"></div>
                                     </div>

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -19,6 +19,7 @@ from django.db.models.aggregates import Max
 from django.db.models.query_utils import Q
 from django.http import HttpResponse, HttpResponseForbidden, \
     HttpResponseRedirect, Http404
+from django.http.response import HttpResponseNotFound
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext, loader
 from django.views.generic.base import View, TemplateView
@@ -32,13 +33,13 @@ from mediathread.djangosherd.api import DiscussionIndexResource
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from mediathread.djangosherd.views import create_annotation, edit_annotation, \
     delete_annotation, update_annotation
+from mediathread.main.course_details import allow_item_download
 from mediathread.main.models import UserSetting
 from mediathread.mixins import ajax_required, LoggedInCourseMixin, \
     JSONResponseMixin, AjaxRequiredMixin, RestrictedMaterialsMixin, \
     LoggedInSuperuserMixin
 from mediathread.taxonomy.api import VocabularyResource
 from mediathread.taxonomy.models import Vocabulary
-from django.http.response import HttpResponseNotFound
 
 
 def _parse_domain(url):
@@ -874,6 +875,8 @@ class AssetWorkspaceView(LoggedInCourseMixin, RestrictedMaterialsMixin,
             'context': {
                 'type': 'asset',
                 'is_faculty': self.is_viewer_faculty,
+                'allow_item_download': self.is_viewer_faculty and
+                allow_item_download(request.course)
             },
             'owners': owners,
             'vocabulary': vocabulary,

--- a/mediathread/main/course_details.py
+++ b/mediathread/main/course_details.py
@@ -73,6 +73,16 @@ COURSE_INFORMATION_TITLE_KEY = "course_information_title"
 COURSE_INFORMATION_TITLE_DEFAULT = "From Your Instructor"
 
 
+def allow_item_download(course):
+    value = int(course.get_detail(ALLOW_ITEM_DOWNLOAD_KEY,
+                                  ALLOW_ITEM_DOWNLOAD_DEFAULT))
+    return bool(value)
+
+
+ALLOW_ITEM_DOWNLOAD_KEY = "allow_item_download"
+ALLOW_ITEM_DOWNLOAD_DEFAULT = 0
+
+
 def course_information_title(course):
     return course.get_detail(COURSE_INFORMATION_TITLE_KEY,
                              COURSE_INFORMATION_TITLE_DEFAULT)

--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -221,7 +221,9 @@ class DashboardSettingsForm(forms.ModelForm):
     allow_item_download = forms.BooleanField(
         label='Course instructors see a download item link',
         initial=False,
-        required=False)
+        required=False,
+        help_text='Allow instructors to see a download link on the '
+        'Item View page. This option is off by default.')
     lti_integration = forms.BooleanField(
         label='LTI Integration',
         required=False,

--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -1,15 +1,15 @@
+from courseaffils.models import Course
 from django import forms
 from django.contrib.auth.models import User
 from django.forms.widgets import RadioSelect
 from registration.forms import RegistrationForm
-from courseaffils.models import Course
+
 from lti_auth.models import LTICourseContext
 from mediathread.main import course_details
 from mediathread.main.course_details import (
     allow_public_compositions,
     all_items_are_visible, all_selections_are_visible,
-    course_information_title
-)
+    course_information_title, allow_item_download)
 from mediathread.projects.models import Project
 
 
@@ -218,6 +218,10 @@ class DashboardSettingsForm(forms.ModelForm):
     see_eachothers_selections = forms.BooleanField(
         label='Course members can see each other\'s selections',
         required=False)
+    allow_item_download = forms.BooleanField(
+        label='Course instructors see a download item link',
+        initial=False,
+        required=False)
     lti_integration = forms.BooleanField(
         label='LTI Integration',
         required=False,
@@ -237,6 +241,7 @@ class DashboardSettingsForm(forms.ModelForm):
             'see_eachothers_items': True,
             'see_eachothers_selections': True,
             'lti_integration': False,
+            'allow_item_download': False
         }
 
     def __init__(self, *args, **kwargs):
@@ -249,7 +254,8 @@ class DashboardSettingsForm(forms.ModelForm):
             all_items_are_visible(self.instance)
         self.fields['see_eachothers_selections'].initial = \
             all_selections_are_visible(self.instance)
-
+        self.fields['allow_item_download'].initial = \
+            allow_item_download(self.instance)
         lti_context = LTICourseContext.objects.filter(
             group=self.instance.group.id,
             faculty_group=self.instance.faculty_group.id).first()
@@ -297,12 +303,12 @@ class DashboardSettingsForm(forms.ModelForm):
             int(cleaned_data.get('see_eachothers_items')))
 
         course.add_detail(
-            course_details.ITEM_VISIBILITY_KEY,
-            int(cleaned_data.get('see_eachothers_items')))
-
-        course.add_detail(
             course_details.SELECTION_VISIBILITY_KEY,
             int(cleaned_data.get('see_eachothers_selections')))
+
+        course.add_detail(
+            course_details.ALLOW_ITEM_DOWNLOAD_KEY,
+            int(cleaned_data.get('allow_item_download')))
 
         if not cleaned_data.get('see_eachothers_selections'):
             Project.objects.limit_response_policy(course)

--- a/mediathread/main/tests/test_course_details.py
+++ b/mediathread/main/tests/test_course_details.py
@@ -7,7 +7,8 @@ from mediathread.main.course_details import can_upload, \
     allow_public_compositions, all_selections_are_visible, \
     all_items_are_visible, \
     course_information_title, COURSE_INFORMATION_TITLE_DEFAULT, \
-    cached_course_is_member, cached_course_is_faculty, is_upload_enabled
+    cached_course_is_member, cached_course_is_faculty, is_upload_enabled, \
+    allow_item_download
 
 
 class TestCourseDetails(MediathreadTestMixin, TestCase):
@@ -47,6 +48,10 @@ class TestCourseDetails(MediathreadTestMixin, TestCase):
     def all_items_are_visible(self):
         # default
         self.assertFalse(all_items_are_visible(self.sample_course))
+
+    def allow_item_download(self):
+        # default
+        self.assertFalse(allow_item_download(self.sample_course))
 
     def test_course_information_title(self):
         # default

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -3,9 +3,8 @@
 from datetime import datetime
 import json
 
-import factory
-from courseaffils.lib import get_public_name
 from courseaffils.columbia import CourseStringMapper
+from courseaffils.lib import get_public_name
 from courseaffils.models import Affil, Course
 from courseaffils.tests.factories import AffilFactory, CourseFactory
 from django.conf import settings
@@ -16,10 +15,11 @@ from django.http.response import Http404
 from django.test import TestCase, override_settings
 from django.test.client import Client, RequestFactory
 from django.utils.html import escape
-from threadedcomments.models import ThreadedComment
+import factory
 from freezegun import freeze_time
-from lti_auth.models import LTICourseContext
+from threadedcomments.models import ThreadedComment
 
+from lti_auth.models import LTICourseContext
 from mediathread.assetmgr.models import Asset
 from mediathread.discussions.utils import get_course_discussions
 from mediathread.djangosherd.models import SherdNote
@@ -32,8 +32,7 @@ from mediathread.main import course_details
 from mediathread.main.course_details import (
     allow_public_compositions,
     course_information_title,
-    all_items_are_visible, all_selections_are_visible
-)
+    all_items_are_visible, all_selections_are_visible, allow_item_download)
 from mediathread.main.forms import (
     ContactUsForm, CourseActivateForm, AcceptInvitationForm)
 from mediathread.main.models import CourseInvitation
@@ -1388,6 +1387,7 @@ class InstructorDashboardSettingsViewTest(LoggedInUserTestMixin, TestCase):
                          'new homepage title')
         self.assertEqual(all_items_are_visible(course), False)
         self.assertEqual(all_selections_are_visible(course), False)
+        self.assertEqual(allow_item_download(course), False)
 
         response = self.client.post(
             reverse('course-settings-general'),
@@ -1398,6 +1398,7 @@ class InstructorDashboardSettingsViewTest(LoggedInUserTestMixin, TestCase):
                 'see_eachothers_items': True,
                 'see_eachothers_selections': True,
                 'lti_integration': True,
+                'allow_item_download': True
             },
             follow=True)
         self.assertEqual(response.status_code, 200)
@@ -1411,6 +1412,7 @@ class InstructorDashboardSettingsViewTest(LoggedInUserTestMixin, TestCase):
                          'new homepage title')
         self.assertEqual(all_items_are_visible(course), True)
         self.assertEqual(all_selections_are_visible(course), True)
+        self.assertEqual(allow_item_download(course), True)
         lti_ctx = LTICourseContext.objects.get(
             group=course.group,
             faculty_group=course.faculty_group)
@@ -1425,6 +1427,7 @@ class InstructorDashboardSettingsViewTest(LoggedInUserTestMixin, TestCase):
                 'see_eachothers_items': True,
                 'see_eachothers_selections': True,
                 'lti_integration': False,
+                'allow_item_download': False
             },
             follow=True)
         lti_ctx.refresh_from_db()

--- a/mediathread/templates/courseaffils/course_update_form.html
+++ b/mediathread/templates/courseaffils/course_update_form.html
@@ -35,10 +35,6 @@
         <div class="well">
             <h3>Item Download</h3>
             {% bootstrap_field form.allow_item_download %}
-            <span class="help-block">
-                Allow instructors to see a download link on the Item View page.
-                This option is off by default.
-            </span>
         </div>
         {% endif %}
         <div class="well">

--- a/mediathread/templates/courseaffils/course_update_form.html
+++ b/mediathread/templates/courseaffils/course_update_form.html
@@ -31,6 +31,16 @@
                 default.
             </span>
         </div>
+        {% if user.is_staff%}
+        <div class="well">
+            <h3>Item Download</h3>
+            {% bootstrap_field form.allow_item_download %}
+            <span class="help-block">
+                Allow instructors to see a download link on the Item View page.
+                This option is off by default.
+            </span>
+        </div>
+        {% endif %}
         <div class="well">
             <h3>LTI</h3>
             {% bootstrap_field form.lti_integration %}


### PR DESCRIPTION
* only staff can set a course to allow downloading.
* only instructors can download when it is on.