### PR TITLE
Nav menu position fix

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -590,6 +590,7 @@ ul#standardnav {
     padding: 10px 10px 10px 10px;
     z-index: 9998;
     position: absolute;
+    right: 2px;
     margin-top: 5px;    
     border: 1px solid #CCC;
     -webkit-border-radius: 4px;


### PR DESCRIPTION
The nav menu that appears when you click on your name when you're in a class causes my horizontal scroll bar to appear, because of its position. This change fixes the problem.