### PR TITLE
Increase number of decimals for jux models

### DIFF
--- a/mediathread/juxtapose/migrations/0002_auto_20161018_1601.py
+++ b/mediathread/juxtapose/migrations/0002_auto_20161018_1601.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('juxtapose', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='juxtaposemediaelement',
+            name='end_time',
+            field=models.DecimalField(max_digits=12, decimal_places=5),
+        ),
+        migrations.AlterField(
+            model_name='juxtaposemediaelement',
+            name='start_time',
+            field=models.DecimalField(max_digits=12, decimal_places=5),
+        ),
+        migrations.AlterField(
+            model_name='juxtaposetextelement',
+            name='end_time',
+            field=models.DecimalField(max_digits=12, decimal_places=5),
+        ),
+        migrations.AlterField(
+            model_name='juxtaposetextelement',
+            name='start_time',
+            field=models.DecimalField(max_digits=12, decimal_places=5),
+        ),
+    ]

--- a/mediathread/juxtapose/models.py
+++ b/mediathread/juxtapose/models.py
@@ -18,9 +18,9 @@ class JuxtaposeMediaElement(models.Model):
     modified = models.DateTimeField(auto_now=True)
     juxtaposition = models.ForeignKey(JuxtaposeAsset)
     start_time = models.DecimalField(
-        max_digits=8, decimal_places=5)
+        max_digits=12, decimal_places=5)
     end_time = models.DecimalField(
-        max_digits=8, decimal_places=5)
+        max_digits=12, decimal_places=5)
     media = models.ForeignKey(SherdNote)
 
 
@@ -29,7 +29,7 @@ class JuxtaposeTextElement(models.Model):
     modified = models.DateTimeField(auto_now=True)
     juxtaposition = models.ForeignKey(JuxtaposeAsset)
     start_time = models.DecimalField(
-        max_digits=8, decimal_places=5)
+        max_digits=12, decimal_places=5)
     end_time = models.DecimalField(
-        max_digits=8, decimal_places=5)
+        max_digits=12, decimal_places=5)
     text = models.TextField()

--- a/mediathread/juxtapose/tests/factories.py
+++ b/mediathread/juxtapose/tests/factories.py
@@ -32,6 +32,6 @@ class JuxtaposeTextElementFactory(factory.DjangoModelFactory):
         model = JuxtaposeTextElement
 
     juxtaposition = factory.SubFactory(JuxtaposeAssetFactory)
-    start_time = fuzzy.FuzzyDecimal(0.0, 3.0)
-    end_time = fuzzy.FuzzyDecimal(3.01, 6.0)
+    start_time = fuzzy.FuzzyDecimal(5.0, 105.0)
+    end_time = fuzzy.FuzzyDecimal(1000.01, 6000.0)
     text = fuzzy.FuzzyText()


### PR DESCRIPTION
The settings I had only allowed the times to go up to 999 seconds,
or 16 minutes. This change will provide more than enough range.