### PR TITLE
Add missing migration for Project.policy_view_record

### DIFF
--- a/mediathread/projects/migrations/0015_auto_20161019_1337.py
+++ b/mediathread/projects/migrations/0015_auto_20161019_1337.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0014_auto_20151104_1513'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='response_view_policy',
+            field=models.TextField(
+                default=b'always',
+                choices=[
+                    (b'never', b'Never - Responses visible only to '
+                     b'instructors'),
+                    (b'always', b'Always - Response not required to view '
+                     b'other student responses'),
+                    (b'submitted', b'After Submission - Response required to '
+                     b'view other student responses before due date. All '
+                     b'responses visible after assignment due date passes.')]),
+        ),
+    ]


### PR DESCRIPTION
Commit c683c4811ba5629bbaccb405eaa161c69648ed06 changed the
Project.policy_view_record model (view the RESPONSE_VIEW_SUBMITTED
variable) which requires a database migration.

I ran into this when trying to add the ProjectJuxtaposition model.