### PR TITLE
Add media_type filter to /api/asset/

### DIFF
--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -589,3 +589,46 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertEquals(lst[5]['count'], 0)
         self.assertEquals(lst[5]['last'], True)
         self.assertEquals(lst[5]['name'], 'video')
+
+    def test_filter_by_media_type(self):
+        self.assertTrue(
+            self.client.login(username=self.student_two.username,
+                              password="test"))
+
+        url = '/api/asset/?media_type=image'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]['primary_type'], 'image')
+
+        url = '/api/asset/?media_type=test'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 0)
+
+        url = '/api/asset/?media_type=video'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]['primary_type'], 'video')
+
+        url = '/api/asset/?media_type=all'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 2)
+
+        url = '/api/asset/?media_type='
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 2)
+
+        url = '/api/asset/'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 2)

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -963,15 +963,14 @@ class AssetDetailView(LoggedInCourseMixin, RestrictedMaterialsMixin,
 
 
 class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
-                          AjaxRequiredMixin, JSONResponseMixin, View):
+                          JSONResponseMixin, View):
     """
     An ajax-only request to retrieve assets for a course or a specified user
     Example:
         /api/asset/user/sld2131/
-        /api/asset/a/
         /api/asset/
     """
-    valid_filters = ['tag', 'modified', 'search_text']
+    valid_filters = ['tag', 'modified', 'search_text', 'media_type']
 
     def get_context(self, request, assets, notes):
         # Allow the logged in user to add assets to his composition

--- a/mediathread/djangosherd/models.py
+++ b/mediathread/djangosherd/models.py
@@ -114,6 +114,15 @@ class SherdNoteQuerySet(models.query.QuerySet):
         return self.filter(Q(added__range=[startdate, enddate]) |
                            Q(modified__range=[startdate, enddate]))
 
+    def filter_by_media_type(self, media_type='all'):
+        if media_type == '' or media_type is None or media_type == 'all':
+            return self
+
+        notes = filter(
+            (lambda n: n.asset.media_type() == media_type), self)
+        note_ids = [note.id for note in notes]
+        return self.filter(id__in=note_ids)
+
     def get_related_notes(self, assets, record_owner, visible_authors=None,
                           all_items_are_visible=False,
                           tag_string=None, modified=None, vocabulary=None):

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -104,6 +104,8 @@ class RestrictedMaterialsMixin(object):
         visible_notes = SherdNote.objects.get_related_notes(
             assets, self.record_owner or None, self.visible_authors,
             self.all_items_are_visible, tag_string, modified, vocabulary)
+        visible_notes = visible_notes.filter_by_media_type(
+            request.GET.get('media_type'))
 
         search_text = request.GET.get('search_text', '').strip().lower()
         if len(search_text) > 0:


### PR DESCRIPTION
This adds a media_type query param to the `/api/asset/` endpoint. It's
implement in an ad-hoc way, outside of [tastypie's built-in filtering system](http://django-tastypie.readthedocs.io/en/latest/resources.html#basic-filtering),
because the way I've implemented it is simple and works for our use
case.

I've also removed the AjaxRequiredMixin from the view, which we can talk
about if you want. I don't believe requiring AJAX is necessary for an
API, and I find it nice to be able to explore the API by just entering
the URL in the browser.