### PR TITLE
Validate asset update values

### DIFF
--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -880,14 +880,14 @@ class AssetUpdateViewTest(MediathreadTestMixin, TestCase):
             'metadata-uuid': '1234567',
             'metadata-tag': 'update',
             'thumb': 'new thumb',
-            'mp4_pseudo': 'new primary'
+            'mp4_pseudo': ''
         }
 
     def test_get_asset_id(self):
-        url = 'http://mediathread.ccnmtl.columbia.edu/asset/'
+        url = 'http://testserver/asset/'
         self.assertIsNone(AssetUpdateView().get_asset_id(url))
 
-        url = 'http://mediathread.ccnmtl.columbia.edu/asset/53/'
+        url = 'http://testserver/asset/53/'
         aid = AssetUpdateView().get_asset_id(url)
         self.assertEquals(int(aid), 53)
 
@@ -923,8 +923,16 @@ class AssetUpdateViewTest(MediathreadTestMixin, TestCase):
 
     def test_update_primary_and_thumb(self):
         self.params['asset-url'] = reverse('asset-view', args=[self.asset.id])
+
         secrets = {'http://testserver/': self.params['secret']}
         with self.settings(SERVER_ADMIN_SECRETKEYS=secrets):
+            # invalid primary source
+            response = self.client.post(self.url, self.params, follow=True)
+            self.assertEquals(response.status_code, 400)
+
+            # valid primary source
+            self.params['mp4_pseudo'] = 'new primary'
+
             response = self.client.post(self.url, self.params, follow=True)
             self.assertEquals(response.status_code, 200)
 

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -19,7 +19,7 @@ from django.db.models.aggregates import Max
 from django.db.models.query_utils import Q
 from django.http import HttpResponse, HttpResponseForbidden, \
     HttpResponseRedirect, Http404
-from django.http.response import HttpResponseNotFound
+from django.http.response import HttpResponseNotFound, HttpResponseBadRequest
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext, loader
 from django.views.generic.base import View, TemplateView
@@ -289,6 +289,11 @@ class AssetUpdateView(View):
         for key, value in request.POST.items():
             # replace primary source completely. the labels will differ
             if key in Asset.primary_labels:
+                if len(value) < 1:
+                    # don't empty out a primary source
+                    msg = 'Invalid primary source for {}'.format(key)
+                    return HttpResponseBadRequest(msg)
+
                 asset.update_primary(key, value)
             else:
                 # update a secondary source based on label


### PR DESCRIPTION
This PR will prevent the update mechanism from setting an asset's primary source to an empty value.