### PR TITLE
:arrow_up: django-cors-headers 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ factory_boy==2.7.0
 django-impersonate==1.0.1
 django-registration-redux==1.4
 django-waffle==0.11.1
-django-cors-headers==1.3.0
+django-cors-headers==1.3.1
 httplib2==0.9.2
 oauth==1.0.1
 oauth2==1.9rc1


### PR DESCRIPTION
Fixes an error I ran into that apparently only occurs in django <1.10:
https://github.com/ottoyiu/django-cors-headers/blob/master/HISTORY.rst#131-2016-11-09