### PR TITLE
Collection: create standalone widget

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4422,3 +4422,22 @@ ul.section-tabs>li>a.active {
 .collection-widget table, .collection-widget tr, .collection-widget td {
     border: none;
 }
+
+.mce-i-icon-collection {
+    width:100px;
+    display:block;
+    height:20px;
+    background:black;
+    color:white;
+    text-decoration:none;
+    padding-left:20px;
+}
+.mce-i-icon-collection:before{
+    content: '';
+    background: url('../img/viewfullcollection.png');
+    background-size:cover;
+    position:absolute;
+    width: 12px;
+    height: 12px;
+    margin-top: 2px;
+}

--- a/media/js/app/projects/projectpanel.js
+++ b/media/js/app/projects/projectpanel.js
@@ -4,6 +4,14 @@
 /* global tinymce: true, tinymceSettings: true */
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
+/**
+ * Listens For:
+ * asset.select > when an asset is selected
+ *
+ * Signals:
+ * collection.open
+ */
+
 var ProjectPanelHandler = function(el, $parent, panel, space_owner) {
     var self = this;
 
@@ -103,6 +111,10 @@ ProjectPanelHandler.prototype.initAfterTemplateLoad = function(
         self.setDirty(true);
     });
 
+    document.addEventListener('asset.select', function(event) {
+        self.insertCitation(event.detail);
+    });
+
     // Setup the media display window.
     self.citationView = new CitationView();
     self.citationView.init({
@@ -128,6 +140,17 @@ ProjectPanelHandler.prototype.initAfterTemplateLoad = function(
                 ed.on('change', function(e) {
                     self.setDirty(true);
                 });
+
+                if (MediaThread.flags.indexOf('collection-widget') > -1) {
+                    ed.addButton('opencollection', {
+                        text: 'Open Collection',
+                        icon: 'icon-collection',
+                        tooltip: 'Open Collection',
+                        onclick: function() {
+                            jQuery(window).trigger('collection.open', []);
+                        }
+                    });
+                }
             },
             selector: '#' + panel.context.project.id + '-project-content'
         });
@@ -883,4 +906,18 @@ ProjectPanelHandler.prototype._validTitle = function(interactive) {
     } else {
         return true;
     }
+};
+
+ProjectPanelHandler.prototype.insertCitation = function(annotation) {
+    var klass = 'materialCitation';
+    var rv = ' <a href="' + annotation.annotation + '" class="' + klass + '';
+    if (annotation.type) {
+        rv += ' asset-' + annotation.type;
+    }
+    if (annotation.range1 === 0) {
+        rv += ' asset-whole';
+    }
+    rv += '">' + decodeURI(annotation.title) + '</a> ';
+
+    tinymce.activeEditor.insertContent(rv);
 };

--- a/media/js/app/tinymce_init.js
+++ b/media/js/app/tinymce_init.js
@@ -9,6 +9,6 @@ var tinymceSettings = {
     'selector': '.mceEditor',
     'toolbar': 'bold, italic, underline, spacer, bullist, numlist, ' +
         'spacer, outdent, indent, spacer, undo, redo, spacer, link, ' +
-        'unlink, image, spacer, code, pasteword',
-    'content_css': STATIC_URL + 'css/project.css'
+        'unlink, image, spacer, code, spacer, opencollection',
+    'content_css': STATIC_URL + 'css/project.css',
 };

--- a/media/templates/collectionwidget.mustache
+++ b/media/templates/collectionwidget.mustache
@@ -6,11 +6,6 @@
         <div>Refreshing the collection</div>
         </div>
     </div>
-    <div class="pull-right">
-        <button name="close-modal">
-            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-        </button>
-    </div>
     <div class="media-column" >
         <div class="filter-widget" style="display: none">
             <div class="collection-col-3">

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -1,4 +1,4 @@
-{% load cache user_projects coursetags compress static bootstrap3 %}
+{% load cache user_projects coursetags compress static bootstrap3 waffle_tags %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -199,6 +199,24 @@
         </div><!-- id="footer" -->
     {% endblock %}
 
+    {% flag "collection-widget" %}
+    <!-- Collection Modal -->
+    <div id="collection-modal" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Collection</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="quick-edit" style="display: none"></div>
+                    <div class="collection-view"></div>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+    {% endflag %}
+
     <script type="text/javascript">
         var STATIC_URL = '{{STATIC_URL}}';
 
@@ -213,6 +231,11 @@
                 this.current_user = {{request.user.id}};
                 this.current_username = "{{request.user.username}}";
                 this.user_full_name = "{%public_name for request.user %}";
+                this.flags = [
+                    {% flag "collection-widget" %}
+                        'collection-widget'
+                    {% endflag %}
+                ]
             {% endif %}
         })();
     </script>
@@ -231,6 +254,7 @@
         <script type="text/javascript" src='{% static "js/app/assetmgr/asset.js" %}'></script>
         <script type="text/javascript" src='{% static "js/app/assetmgr/assetpanel.js" %}'></script>
         <script type="text/javascript" src='{% static "js/app/assetmgr/collection.js" %}'></script>
+        <script type="text/javascript" src='{% static "js/app/assetmgr/collectionwidget.js" %}'></script>
 
         <!--  Discussion related -->
         <script type="text/javascript" src='{% static "js/app/discussion/discussionpanel.js" %}'></script>
@@ -241,6 +265,10 @@
 
         <script type="text/javascript">
             jQuery(document).ready(function() {
+                if (typeof djangosherd !== 'undefined') {
+                    MediaThread.collection = new CollectionWidget();
+                }
+
                 // setup some ajax progress indicator
                 jQuery("html").ajaxStart(function() {
                    jQuery(this).addClass("busy");


### PR DESCRIPTION
This PR further refactors the Mediathread Collection space into a standalone widget, and works to integrate the collection into the TinyMCE editing space. The goal is to distill multiple collection views into a common component.

* The CollectionWidget is now always present in the background
   * Visibility is triggered by an event `jQuery(window).trigger('collection.open', []);`

* On Item or Selection citation click, the CollectionWidget now decodes the citation div and sends additional information in the triggered event detail. Code taken from the [TinyMCE-Citation-plugin](https://github.com/ccnmtl/TinyMCE-Citation-plugin).
    * `{annotation: '<annotation url>', title: '<annotation title>', type: '<primary source type>'`}

* TinyMCE configued with an additional `opencollection` button that opens the collection on click. The appearance of this button is controlled by a waffle-flag `collection-widget`.
   * Item or Selection citation insert is handled within the view embedding the TinyMCE editor. Again, code taken from the [TinyMCE-Citation-plugin](https://github.com/ccnmtl/TinyMCE-Citation-plugin).
