### PR TITLE
Validate ProjectSequenceAsset duplicate only on create

### DIFF
--- a/mediathread/sequence/serializers.py
+++ b/mediathread/sequence/serializers.py
@@ -64,18 +64,17 @@ class SequenceAssetSerializer(serializers.ModelSerializer):
         prevent_overlap(text_elements)
         prevent_overlap(media_elements)
 
-        if data.get('project'):
-            project = Project.objects.get(pk=data.get('project'))
-            if ProjectSequenceAsset.objects.filter(
-                    sequence_asset__author=data.get('author'),
-                    project=project).exists():
-                raise serializers.ValidationError(
-                    'A SequenceAsset already exists for this project '
-                    'and user.')
-
         return data
 
     def create(self, validated_data):
+        project = Project.objects.get(pk=validated_data.get('project'))
+        if ProjectSequenceAsset.objects.filter(
+                sequence_asset__author=validated_data.get('author'),
+                project=project).exists():
+            raise serializers.ValidationError(
+                'A SequenceAsset already exists for this project '
+                'and user.')
+
         instance = SequenceAsset.objects.create(
             author=validated_data.get('author'),
             course=validated_data.get('course'),

--- a/mediathread/sequence/tests/test_apiviews.py
+++ b/mediathread/sequence/tests/test_apiviews.py
@@ -7,6 +7,7 @@ from mediathread.sequence.models import (
     SequenceAsset, SequenceTextElement, SequenceMediaElement
 )
 from mediathread.sequence.tests.mixins import LoggedInTestMixin
+from mediathread.projects.tests.factories import ProjectSequenceAssetFactory
 from mediathread.sequence.tests.factories import (
     SequenceAssetFactory, SequenceTextElementFactory,
     SequenceMediaElementFactory
@@ -250,11 +251,13 @@ class AssetViewSetTest(LoggedInTestMixin, APITestCase):
 
     def test_update(self):
         sa = SequenceAssetFactory(author=self.u)
+        psa = ProjectSequenceAssetFactory(sequence_asset=sa)
         note = SherdNoteFactory()
         r = self.client.put(
             reverse('sequenceasset-detail', args=(sa.pk,)),
             {
                 'course': sa.course.pk,
+                'project': psa.project.pk,
                 'spine': note.pk,
                 'media_elements': [],
                 'text_elements': [],
@@ -266,15 +269,19 @@ class AssetViewSetTest(LoggedInTestMixin, APITestCase):
         self.assertEqual(sa.course, sa.course)
         self.assertEqual(sa.author, self.u)
         self.assertEqual(sa.spine, note)
+        self.assertEqual(SequenceAsset.objects.count(), 1)
+        self.assertEqual(ProjectSequenceAsset.objects.count(), 1)
 
     def test_update_with_track_elements(self):
         sa = SequenceAssetFactory(author=self.u)
+        psa = ProjectSequenceAssetFactory(sequence_asset=sa)
         note = SherdNoteFactory()
         element_note = SherdNoteFactory()
         r = self.client.put(
             reverse('sequenceasset-detail', args=(sa.pk,)),
             {
                 'course': sa.course.pk,
+                'project': psa.project.pk,
                 'spine': note.pk,
                 'media_elements': [
                     {


### PR DESCRIPTION
On update, the ProjectSequenceAsset will already have been created, and
since we're not creating one here we don't need to include this logic.