### PR TITLE
Sequence Assignment: handle peer response viewing

### DIFF
--- a/mediathread/projects/generic/views.py
+++ b/mediathread/projects/generic/views.py
@@ -82,7 +82,7 @@ class AssignmentView(LoggedInCourseMixin, ProjectReadableMixin, TemplateView):
             'assignment': parent,
             'assignment_can_edit': assignment_can_edit,
             'my_response': my_response,
-            'peer_response': peer_response,
+            'the_response': peer_response or my_response,
             'response_can_edit': response_can_edit,
             'response_view_policies': RESPONSE_VIEW_POLICY,
             'submit_policy': PUBLISH_WHOLE_CLASS[0],

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -658,7 +658,7 @@ class SelectionAssignmentViewTest(MediathreadTestMixin, TestCase):
         self.assertFalse(ctx['assignment_can_edit'])
         self.assertFalse(ctx['response_can_edit'])
         self.assertEquals(ctx['my_response'], response)
-        self.assertIsNone(ctx['peer_response'])
+        self.assertEquals(ctx['the_response'], response)
         self.assertEquals(ctx['item'], self.asset)
         self.assertEquals(ctx['response_view_policies'], RESPONSE_VIEW_POLICY)
         self.assertEquals(ctx['submit_policy'], 'CourseProtected')
@@ -684,7 +684,7 @@ class SelectionAssignmentViewTest(MediathreadTestMixin, TestCase):
         self.assertFalse(ctx['assignment_can_edit'])
         self.assertTrue(ctx['response_can_edit'])
         self.assertEquals(ctx['my_response'], response)
-        self.assertEquals(ctx['peer_response'], response)
+        self.assertEquals(ctx['the_response'], response)
 
     def test_get_context_data_for_a_response(self):
         response = ProjectFactory.create(
@@ -705,7 +705,7 @@ class SelectionAssignmentViewTest(MediathreadTestMixin, TestCase):
         self.assertFalse(ctx['assignment_can_edit'])
         self.assertFalse(ctx['response_can_edit'])
         self.assertIsNone(ctx['my_response'])
-        self.assertEquals(ctx['peer_response'], response)
+        self.assertEquals(ctx['the_response'], response)
 
 
 class SelectionAssignmentEditViewTest(MediathreadTestMixin, TestCase):

--- a/mediathread/templates/projects/sequence_assignment_responses.html
+++ b/mediathread/templates/projects/sequence_assignment_responses.html
@@ -1,0 +1,131 @@
+{% load coursetags %}
+
+{% if is_faculty %}
+    <div>
+        <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
+        <strong>
+            {% if responses|length > 0 %}
+                <a href="#" data-toggle="modal" data-target="#unsubmit-response">
+            {% endif %}
+            {{responses|length}} Responses |
+            <span class="feedback-count">{{feedback_count}}</span> Feedback
+            {% if responses|length > 0 %}
+                </a>
+            {% endif %}
+        </strong>
+        <div class="modal fade" id="unsubmit-response" tabindex="-1"
+            role="dialog" aria-labelledby="Cannot Submit Response">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close"
+                            data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <h4 class="modal-title">Unsubmit Response</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>You may allow a student to resubmit their response
+                        by first selecting their name in the drop-down and then clicking
+                        Unsubmit. Once you click Unsubmit, the student's response will return to draft
+                        status, allowing the student to edit and resubmit the response.</p>
+                        <form action="/project/unsubmit/" method="post">
+                            <label for="student-response-id">Select Response</label>
+                            <select name="student-response" class="form-control">
+                                {% for response in responses %}
+                                    {% if response.is_submitted %}
+                                        <option value="{{response.id}}">
+                                            {% public_name for response.author %} (submitted {{ response.modified|date:'m/d/Y h:i a' }})
+                                        </option>
+                                    {% endif %}
+                                {% endfor %}
+                            </select>
+                            <hr />
+                            <div class="right">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                <button type="submit" class="btn btn-primary">
+                                    <span class="glyphicon glyphicon-repeat hidden" aria-hidden="true"></span>
+                                    Unsubmit
+                                </button>
+                            </div>
+                            <div class="clearfix"></div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}
+
+{% if the_response.is_submitted %}
+    <div class="right">
+        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+        <strong>
+            Submitted |
+        </strong> {{the_response.modified|date:"m/d/Y h:i a"}}
+    </div>
+{% else %}{% if the_response and response_can_edit %}
+    <div class="right">
+        <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
+        <strong>
+            Draft
+        </strong>
+    </div>
+
+    <div class="modal fade" id="cannot-submit-project" tabindex="-1"
+        role="dialog" aria-labelledby="Cannot Submit Response">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Submit Response</h4>
+          </div>
+          <div class="modal-body">
+            <div>TBD</div><br />
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal fade" id="submit-project" tabindex="-1"
+        role="dialog" aria-labelledby="Submit Response">
+      <div class="modal-dialog" role="document" data-width="620">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">
+                Submit Response
+            </h4>
+          </div>
+          <div class="modal-body">
+            <form method="post" class="project-response-form"
+                action="{% url 'project-save' the_response.id %}">
+                <div>Please review assignment instructions before submitting.</div>
+                <p>
+                    {% ifequal assignment.response_view_policy 'never' %}
+                        Your response will be visible to instructors.
+                    {% else %}{% ifequal assignment.response_view_policy 'always' %}
+                        Your response will be visible to the whole class.
+                    {% else %}{% ifequal assignment.response_view_policy 'submitted' %}
+                        Your response will be visible to the instructor and other students who have submitted.
+                    {% endifequal %}{% endifequal %}{% endifequal %}
+                </p>
+                <div class="alert alert-danger" role="alert">
+                    <strong>Important!</strong><br /><br />
+                    Once you submit your response, you will not be able to unsubmit or edit it.
+                </div>
+                <input type="hidden" name="publish" value="{{submit_policy}}" />
+                <input type="hidden" name="title" value="{{the_response.title}}" />
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-primary submit-response">Submit</button>
+          </div>
+        </div>
+      </div>
+    </div>
+{% endif %}{% endif %}

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block content %}
-{% with submitted=my_response.is_submitted %}
+
 <div class="sequence-assignment">
     <div style="width: 970px; background-color: red; height: 2px"></div>
     <h2>
@@ -69,14 +69,20 @@
         <div class="left small col-half">
             {% if assignment_can_edit %}
                 <div>
-                    <a class="small" href="{% url 'sequence-assignment-edit' assignment.id %}">
+                    <a href="{% url 'sequence-assignment-edit' assignment.id %}">
                         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit Assignment
                     </a>
                 </div>
+                <div class="meta">
+                    <span class="metadata-label"><b>Publication Status</b>:</span>
+                    <span class="metadata-value">
+                        {{assignment.visibility_short}}
+                    </span>
+                </div>
             {% endif %}
-            {% if is_faculty %}
+
             <div class="meta">
-                <span class="metadata-label"><b>Response visibility</b>:</span>
+                <span class="metadata-label"><b>Response Visibility</b>:</span>
                 {% for key, value in response_view_policies %}
                     {% ifequal key assignment.response_view_policy %}
                         <span class="metadata-value">{{value}}</span>
@@ -84,11 +90,11 @@
                 {% endfor %}
                 </a>
             </div>
-            {% endif %}
+
             {% if assignment.due_date %}
                 <div class="meta">
                     <span class="metadata-label">
-                        <b>Due date</b>:
+                        <b>Due Date</b>:
                     </span>
                     <span class="metadata-value">
                         {{assignment.due_date|date:'m/d/y'}}
@@ -96,146 +102,19 @@
                 </div>
             {% endif %}
         </div>
-        <div class="right text-right col-half">
-            {% if is_faculty %}
-                <div>
-                    <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
-                    <strong>
-                        {% if responses|length > 0 %}
-                            <a href="#" data-toggle="modal" data-target="#unsubmit-response">
-                        {% endif %}
-                        {{responses|length}} Responses |
-                        <span class="feedback-count">{{feedback_count}}</span> Feedback
-                        {% if responses|length > 0 %}
-                            </a>
-                        {% endif %}
-                    </strong>
-                    <div class="modal fade" id="unsubmit-response" tabindex="-1"
-                        role="dialog" aria-labelledby="Cannot Submit Response">
-                        <div class="modal-dialog" role="document">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <button type="button" class="close"
-                                        data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                    <h4 class="modal-title">Unsubmit Response</h4>
-                                </div>
-                                <div class="modal-body">
-                                    <p>You may allow a student to resubmit their response
-                                    by first selecting their name in the drop-down and then clicking
-                                    Unsubmit. Once you click Unsubmit, the student's response will return to draft
-                                    status, allowing the student to edit and resubmit the response.</p>
-                                    <form action="/project/unsubmit/" method="post">
-                                        <label for="student-response-id">Select Response</label>
-                                        <select name="student-response" class="form-control">
-                                            {% for response in responses %}
-                                                {% if response.is_submitted %}
-                                                    <option value="{{response.id}}">
-                                                        {% public_name for response.author %} (submitted {{ response.modified|date:'m/d/Y h:i a' }})
-                                                    </option>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </select>
-                                        <hr />
-                                        <div class="right">
-                                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                            <button type="submit" class="btn btn-primary">
-                                                <span class="glyphicon glyphicon-repeat hidden" aria-hidden="true"></span>
-                                                Unsubmit
-                                            </button>
-                                        </div>
-                                        <div class="clearfix"></div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+        <div class="right col-half">
+            {% if not is_faculty and not the_response %}
+                <div class="text-right">
+                    <form action="/project/create/" method="post">
+                        <input type="hidden" name="parent" value="{{assignment.id}}" />
+                        <input type="hidden" name="project_type" value="composition" />
+                        <input type="hidden" name="title" value="My Response" />
+                        <input class="btn btn-success" type="submit" value="Respond to Assignment" />
+                    </form>
                 </div>
-            {% else %}{% if not assignment_can_edit  %}
-                {% if my_response.is_submitted %}
-                    <div class="right">
-                        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                        <strong>
-                            Submitted |
-                        </strong> {{my_response.modified|date:"m/d/Y h:i a"}}
-                    </div>
-                {% else %}{% if my_response %}
-                    <div>
-                        <div class="left">
-                            <!-- Submit -->
-                            <button type="button" class="btn btn-primary btn-show-submit" style="display: inline">
-                                Submit Response
-                            </button>
-                        </div>
-                        <div class="right">
-                            <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
-                            <strong>
-                                Draft
-                            </strong>
-                        </div>
-                    </div>
-
-                    <div class="modal fade" id="cannot-submit-project" tabindex="-1"
-                        role="dialog" aria-labelledby="Cannot Submit Response">
-                      <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                          <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title">Submit Response</h4>
-                          </div>
-                          <div class="modal-body">
-                            <div>TBD</div><br />
-                          </div>
-                          <div class="modal-footer">
-                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="modal fade" id="submit-project" tabindex="-1"
-                        role="dialog" aria-labelledby="Submit Project">
-                      <div class="modal-dialog" role="document" data-width="620">
-                        <div class="modal-content">
-                          <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title">
-                                Submit Response &mdash;
-                                <span class="project-submit-count"></span>
-                                <span class="project-submit-count-label"></span>
-                            </h4>
-                          </div>
-                          <div class="modal-body">
-                            <form method="post" class="project-response-form"
-                                action="{% url 'project-save' my_response.id %}">
-                                <div>Please review assignment instructions before submitting.</div>
-                                <p>
-                                    {% ifequal assignment.response_view_policy 'never' %}
-                                        Your response will be visible to instructors.
-                                    {% else %}{% ifequal assignment.response_view_policy 'always' %}
-                                        Your response will be visible to the whole class.
-                                    {% else %}{% ifequal assignment.response_view_policy 'submitted' %}
-                                        Your response will be visible to the instructor and other students who have submitted.
-                                    {% endifequal %}{% endifequal %}{% endifequal %}
-                                </p>
-                                <div class="alert alert-danger" role="alert">
-                                    <strong>Important!</strong><br /><br />
-                                    Once you submit your response, you will not be able to unsubmit or edit it.
-                                </div>
-                                <input type="hidden" name="publish" value="{{submit_policy}}" />
-                                <input type="hidden" name="title" value="{{my_response.title}}" />
-                            </form>
-                          </div>
-                          <div class="modal-footer">
-                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                            <button type="button" class="btn btn-primary submit-response">Submit</button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                {% endif %}{% endif %}
-            {% endif %}{% endif %}
+            {% else %}
+                {% include "projects/sequence_assignment_responses.html" %}
+            {% endif %}
         </div>
     </div>
 
@@ -261,57 +140,70 @@
 
     <div class="spacer"></div>
 
-    <div class="meta right">
-        {% if assignment_can_edit %}
-            <span class="metadata-label"><b>Publication status</b>:</span>
-            <span class="metadata-value">
-                {{assignment.visibility_short}}
-            </span>
-        {% else %}{% if my_response %}
-            <span class="metadata-label"><b>Publication status</b>:</span>
-            <span class="metadata-value">
-                {% if my_response.is_submitted %}
-                    Response submitted
-                {% else %}
-                    Response not submitted
+    {% if is_faculty or the_response %}
+        <div class="meta right">
+            {% if response_can_edit %}
+                <span class="metadata-label"><b>Publication status</b>:</span>
+                <span class="metadata-value">
+                    {% if the_response.is_submitted %}
+                        Response submitted
+                    {% else %}
+                        Response not submitted
+                    {% endif %}
+                </span>
+            {% endif %}
+        </div>
+
+        <div class="clearfix"></div>
+        <div class="spacer"></div>
+
+        <div>
+            <div class="left col-half">
+                {% if the_response.is_submitted %}
+                    <h3>{{the_response.title}}</h3>
+                {% else %}{% if response_can_edit %}
+                    <div>
+                        <label>Response Title</label>&nbsp;
+                        <input type="text" name="title"
+                            value="{{the_response.title}}" maxlength="80"
+                            placeholder="Specify a title"
+                            class="project-title form-control" />
+                    </div>
+                {% endif %}{% endif %}
+            </div>
+            <div class="right col-half">
+                <ul class="nav nav-pills right">
+                    <li role="presentation" class="active editor">
+                        <a href="#">Sequence Editor</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#" class="reflection">Reflection</a>
+                    </li>
+                    {% if not the_response.is_submitted and response_can_edit %}
+                        <li role="presentation">
+                            <a href="#" class="btn-save">Save</a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#" class="btn-show-submit">Submit</a>
+                        </li>
+                    {% endif %}
+                    {% if is_faculty or response.is_submitted and response_can_edit %}
+                        <li role="presentation">
+                            <a href="#" class="response-feedback">Feedback</a>
+                        </li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                {% if the_response %}
+                    <div id="jux-container"></div>
                 {% endif %}
-            </span>
-        {% endif %}{% endif %}
-    </div>
-
-    <div class="clearfix"></div>
-    <div class="spacer"></div>
-
-    <div>
-        <div class="left col-half">
-            {% if submitted %}
-                <h3>{{the_response.title}}</h3>
-            {% else %}
-                <div>
-                    <label>Response Title</label>&nbsp;
-                    <input type="text" name="title" value="{{my_response.title}}" maxlength="80"
-                        placeholder="Specify a title"
-                        class="project-title form-control" />
-                </div>
-            {% endif %}
+            </div>
         </div>
-        <div class="right col-half">
-            <ul class="nav nav-pills right">
-              <li role="presentation" class="active"><a href="#">Sequence Editor</a></li>
-              <li role="presentation"><a href="#">Reflection</a></li>
-              <li role="presentation"><a href="#">Save</a></li>
-              <li role="presentation"><a href="#">Submit</a></li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            {% if my_response %}
-                <div id="jux-container"></div>
-            {% endif %}
-        </div>
-    </div>
+    {% endif %}
 </div>
-{% endwith %}
+
 {% endblock %}


### PR DESCRIPTION
Unlike the selection assignment, the sequence assignment displays only a
single response at a time. Tune the view to display the assignment plus
an identified response based on user role (author, instructor viewer,
student viewer)