### PR TITLE
Sequence Response - layout + selection

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4293,30 +4293,34 @@ a.btn.btn-default img.left {
     width: 75%;
 }
 
-.sequence-assignment .nav {
-    margin-right: 0;
-    margin-left: 0;
-}
-
-.sequence-assignment .nav>li {
-    margin-left: 10px;
-}
-
-.sequence-assignment .nav>li>a {
-    border: 1px solid #ddd;
-    padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
-    border-radius: 3px
-}
-
-.sequence-assignment .nav>li.active>a {
-    border: none;
-}
-
 .sequence-assignment .panel-title a {
     color: #383838;
     font-size: 14px;
+}
+
+.sequence-assignment .btn-tab {
+    line-height: 1;
+    border-radius: 3px;
+    margin-left: 5px;
+    padding: 7px 9px;
+margin-top: 5px;
+}
+
+.sequence-assignment .btn-tab:hover,
+.sequence-assignment .btn-tab:active,
+.sequence-assignment .btn-tab:focus {
+  color: #fff;
+  background-color: #286090;
+  border-color: #204d74;
+}
+
+.sequence-assignment .tab-content {
+    border: 1px solid #ddd;
+    padding: 15px;
+    margin-top: -1px;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 1px 1px rgba(0,0,0,.05);
+    box-shadow: 0 1px 1px rgba(0,0,0,.05);
 }
 
 .affix-top, .affix {

--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4278,6 +4278,16 @@ a.btn.btn-default img.left {
     width: 49%;
 }
 
+.sequence-assignment .assignment-response-title {
+    margin-top: 0;
+    font-size: 22px;
+    font-weight: bold;
+}
+
+.sequence-assignment .assignment-response-author {
+    margin-top: 10px;
+    font-size: 110%;
+}
 .sequence-assignment input[name='title'] {
     display: inline;
     width: 75%;
@@ -4294,10 +4304,19 @@ a.btn.btn-default img.left {
 
 .sequence-assignment .nav>li>a {
     border: 1px solid #ddd;
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px
 }
 
 .sequence-assignment .nav>li.active>a {
     border: none;
+}
+
+.sequence-assignment .panel-title a {
+    color: #383838;
+    font-size: 14px;
 }
 
 .affix-top, .affix {

--- a/mediathread/templates/projects/sequence_assignment_responses.html
+++ b/mediathread/templates/projects/sequence_assignment_responses.html
@@ -1,20 +1,13 @@
 {% load coursetags %}
 
-{% if is_faculty %}
-    <div>
-        <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span>
-        <strong>
-            {% if responses|length > 0 %}
-                <a href="#" data-toggle="modal" data-target="#unsubmit-response">
-            {% endif %}
-            {{responses|length}} Responses |
-            <span class="feedback-count">{{feedback_count}}</span> Feedback
-            {% if responses|length > 0 %}
-                </a>
-            {% endif %}
-        </strong>
-        <div class="modal fade" id="unsubmit-response" tabindex="-1"
-            role="dialog" aria-labelledby="Cannot Submit Response">
+{% if is_faculty or the_response and the_response.is_submitted %}
+{% if responses|length > 0 %}
+    <div class="right">
+        <button class="btn btn-primary btn-sm right" type="button" data-toggle="modal" data-target="#response-list">
+            Responses &nbsp;<span class="badge">{{responses|length}}</span>
+        </button>
+        <div class="modal fade" id="response-list" tabindex="-1"
+            role="dialog" aria-labelledby="Responses">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -22,34 +15,35 @@
                             data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                        <h4 class="modal-title">Unsubmit Response</h4>
+                        <h4 class="modal-title">Responses</h4>
                     </div>
                     <div class="modal-body">
-                        <p>You may allow a student to resubmit their response
-                        by first selecting their name in the drop-down and then clicking
-                        Unsubmit. Once you click Unsubmit, the student's response will return to draft
-                        status, allowing the student to edit and resubmit the response.</p>
-                        <form action="/project/unsubmit/" method="post">
-                            <label for="student-response-id">Select Response</label>
-                            <select name="student-response" class="form-control">
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <tr>
+                                    <th>Author</th>
+                                    <th>Submitted</th>
+                                    {% if is_faculty %}<th>Feedback Given</th>{% endif %}
+                                </tr>
                                 {% for response in responses %}
-                                    {% if response.is_submitted %}
-                                        <option value="{{response.id}}">
-                                            {% public_name for response.author %} (submitted {{ response.modified|date:'m/d/Y h:i a' }})
-                                        </option>
+                                <tr>
+                                    <td>
+                                        <a href="{% url 'project-workspace' response.id %}">
+                                            {% public_name for response.author %}
+                                        </a>
+                                    </td>
+                                    <td>
+                                        {{response.date_submitted|date:'m/d/Y h:i a'}}
+                                    </td>
+                                    {% if is_faculty %}
+                                        <td>
+                                            {{response.feedback_date|date:'m/d/Y h:i a'}}
+                                        </td>
                                     {% endif %}
+                                </tr>
                                 {% endfor %}
-                            </select>
-                            <hr />
-                            <div class="right">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                <button type="submit" class="btn btn-primary">
-                                    <span class="glyphicon glyphicon-repeat hidden" aria-hidden="true"></span>
-                                    Unsubmit
-                                </button>
-                            </div>
-                            <div class="clearfix"></div>
-                        </form>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -57,21 +51,7 @@
     </div>
 {% endif %}
 
-{% if the_response.is_submitted %}
-    <div class="right">
-        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-        <strong>
-            Submitted |
-        </strong> {{the_response.modified|date:"m/d/Y h:i a"}}
-    </div>
-{% else %}{% if the_response and response_can_edit %}
-    <div class="right">
-        <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
-        <strong>
-            Draft
-        </strong>
-    </div>
-
+{% if the_response and response_can_edit and not the_response.is_submitted %}
     <div class="modal fade" id="cannot-submit-project" tabindex="-1"
         role="dialog" aria-labelledby="Cannot Submit Response">
       <div class="modal-dialog" role="document">
@@ -128,4 +108,5 @@
         </div>
       </div>
     </div>
-{% endif %}{% endif %}
+{% endif %}
+{% endif %}

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -138,7 +138,7 @@
 
     {% if the_response %}
         <div class="assignment-response">
-            {% if the_response and response_can_edit and not the_response.is_submitted %}
+            {% if response_can_edit and not the_response.is_submitted %}
                 <div class="right">
                     <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                     <strong>
@@ -165,7 +165,7 @@
                 {% endif %}{% endif %}
             </div>
             <div class="right col-half">
-                {% if the_response and the_response.is_submitted %}
+                {% if the_response.is_submitted %}
                     <div class="right">
                         <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
                         <strong>
@@ -175,46 +175,53 @@
                     <div class="clearfix"></div>
                     <div class="spacer"></div>
                 {% endif %}
-                <ul class="nav nav-pills right">
+
+                <ul class="nav nav-tabs navbar-right" role="tablist">
                     <li role="presentation" class="active editor">
-                        <a href="#">
+                        <a href="#sequence-editor" aria-controls="sequence-editor" role="tab" data-toggle="tab">
                             {% if not the_response.is_submitted and response_can_edit %}
-                                Sequence Editor
-                            {% else %}
-                                The Sequence
-                            {% endif %}
+                                Edit
+                            {% endif %} Sequence
                         </a>
                     </li>
                     <li role="presentation">
-                        <a href="#" class="reflection">Reflection</a>
+                        <a href="#reflection" aria-controls="reflection" role="tab" data-toggle="tab">
+                        {% if not the_response.is_submitted and response_can_edit %}
+                            Edit
+                        {% endif %} Reflection</a>
                     </li>
                     {% if not the_response.is_submitted and response_can_edit %}
                         <li role="presentation">
-                            <a href="#" class="btn-save">Save</a>
+                            <a href="#" class="btn btn-primary btn-tab btn-save">Save</a>
                         </li>
                         <li role="presentation">
-                            <a href="#" class="btn-show-submit">Submit</a>
+                            <a href="#" class="btn btn-primary btn-tab btn-show-submit">Submit</a>
                         </li>
                     {% endif %}
                     {% if is_faculty and the_response.is_submitted %}
                         <li role="presentation">
-                            <a href="#" class="response-feedback">{% if not feedback %}Add {% else %}Edit {% endif %}Feedback</a>
+                            <a href="#feedback" aria-controls="feedback" role="tab" data-toggle="tab">
+                                {% if not feedback %}Add {% else %}Edit {% endif %}Feedback
+                            </a>
                         </li>
                         <li role="presentation">
-                            <a href="#" class="unsubmit">Unsubmit</a>
+                            <a href="#" class="btn btn-primary btn-tab btn-unsubmit">Unsubmit</a>
                         </li>
-                    {% endif %}
-                    {% if is_faculty or response.is_submitted and response_can_edit %}
                     {% endif %}
                 </ul>
             </div>
-        </div>
-
-        <div class="row">
-            <div class="col-md-12">
-                {% if the_response %}
+            <div class="clearfix"></div>
+            <!-- Tab panes -->
+            <div class="tab-content">
+                <div role="tabpanel" class="tab-pane active" id="selection-editor">
                     <div id="jux-container"></div>
-                {% endif %}
+                </div>
+                <div role="tabpanel" class="tab-pane" id="reflection">
+                    <textarea></textarea>
+                </div>
+                <div role="tabpanel" class="tab-pane" id="feedback">
+                    <textarea></textarea>
+                </div>
             </div>
         </div>
     {% endif %}

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -213,7 +213,7 @@
             <div class="clearfix"></div>
             <!-- Tab panes -->
             <div class="tab-content">
-                <div role="tabpanel" class="tab-pane active" id="selection-editor">
+                <div role="tabpanel" class="tab-pane active" id="sequence-editor">
                     <div id="jux-container"></div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="reflection">

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -60,9 +60,9 @@
 {% block content %}
 
 <div class="sequence-assignment">
-    <div style="width: 970px; background-color: red; height: 2px"></div>
+    <div style="width: 970px; background-color: red; height: 2px; display: none"></div>
     <h2>
-        Sequence Assignment: {{assignment.title}}
+        Sequence Assignment <span class="project-view-title">{{assignment.title}}</span>
     </h2>
 
     <div>
@@ -72,32 +72,9 @@
                     <a href="{% url 'sequence-assignment-edit' assignment.id %}">
                         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit Assignment
                     </a>
-                </div>
-                <div class="meta">
-                    <span class="metadata-label"><b>Publication Status</b>:</span>
+                    &nbsp;|&nbsp;
                     <span class="metadata-value">
                         {{assignment.visibility_short}}
-                    </span>
-                </div>
-            {% endif %}
-
-            <div class="meta">
-                <span class="metadata-label"><b>Response Visibility</b>:</span>
-                {% for key, value in response_view_policies %}
-                    {% ifequal key assignment.response_view_policy %}
-                        <span class="metadata-value">{{value}}</span>
-                    {% endifequal %}
-                {% endfor %}
-                </a>
-            </div>
-
-            {% if assignment.due_date %}
-                <div class="meta">
-                    <span class="metadata-label">
-                        <b>Due Date</b>:
-                    </span>
-                    <span class="metadata-value">
-                        {{assignment.due_date|date:'m/d/y'}}
                     </span>
                 </div>
             {% endif %}
@@ -132,6 +109,25 @@
             </div>
             <div id="collapseOne" class="panel-collapse collapse {% if show_instructions %}in{% endif %}" role="tabpanel" aria-labelledby="headingOne">
                 <div class="panel-body">
+                    {% if assignment.due_date %}
+                        <div class="small">
+                            <span class="metadata-label">
+                                <b>Due Date</b>:
+                            </span>
+                            <span class="metadata-value">
+                                {{assignment.due_date|date:'m/d/y'}}
+                            </span>
+                        </div>
+                    {% endif %}
+                    <div class="small">
+                        <span class="metadata-label"><b>Response Visibility</b>:</span>
+                        {% for key, value in response_view_policies %}
+                            {% ifequal key assignment.response_view_policy %}
+                                <span class="metadata-value">{{value}}</span>
+                            {% endifequal %}
+                        {% endfor %}
+                        </a>
+                    </div>
                     <p>{{assignment.body|safe}}</p>
                 </div>
             </div>
@@ -140,27 +136,24 @@
 
     <div class="spacer"></div>
 
-    {% if is_faculty or the_response %}
-        <div class="meta right">
-            {% if response_can_edit %}
-                <span class="metadata-label"><b>Publication status</b>:</span>
-                <span class="metadata-value">
-                    {% if the_response.is_submitted %}
-                        Response submitted
-                    {% else %}
-                        Response not submitted
-                    {% endif %}
-                </span>
+    {% if the_response %}
+        <div class="assignment-response">
+            {% if the_response and response_can_edit and not the_response.is_submitted %}
+                <div class="right">
+                    <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
+                    <strong>
+                        Draft
+                    </strong>
+                </div>
+                <div class="clearfix"></div>
+                <div class="spacer"></div>
             {% endif %}
-        </div>
-
-        <div class="clearfix"></div>
-        <div class="spacer"></div>
-
-        <div>
             <div class="left col-half">
                 {% if the_response.is_submitted %}
-                    <h3>{{the_response.title}}</h3>
+                    <div class="assignment-response-title">{{the_response.title}}</div>
+                    <div class="assignment-response-author">
+                        by {% public_name for the_response.author %}
+                    </div>
                 {% else %}{% if response_can_edit %}
                     <div>
                         <label>Response Title</label>&nbsp;
@@ -172,9 +165,25 @@
                 {% endif %}{% endif %}
             </div>
             <div class="right col-half">
+                {% if the_response and the_response.is_submitted %}
+                    <div class="right">
+                        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                        <strong>
+                            Submitted |
+                        </strong> {{the_response.modified|date:"m/d/Y h:i a"}}
+                    </div>
+                    <div class="clearfix"></div>
+                    <div class="spacer"></div>
+                {% endif %}
                 <ul class="nav nav-pills right">
                     <li role="presentation" class="active editor">
-                        <a href="#">Sequence Editor</a>
+                        <a href="#">
+                            {% if not the_response.is_submitted and response_can_edit %}
+                                Sequence Editor
+                            {% else %}
+                                The Sequence
+                            {% endif %}
+                        </a>
                     </li>
                     <li role="presentation">
                         <a href="#" class="reflection">Reflection</a>
@@ -187,10 +196,15 @@
                             <a href="#" class="btn-show-submit">Submit</a>
                         </li>
                     {% endif %}
-                    {% if is_faculty or response.is_submitted and response_can_edit %}
+                    {% if is_faculty and the_response.is_submitted %}
                         <li role="presentation">
-                            <a href="#" class="response-feedback">Feedback</a>
+                            <a href="#" class="response-feedback">{% if not feedback %}Add {% else %}Edit {% endif %}Feedback</a>
                         </li>
+                        <li role="presentation">
+                            <a href="#" class="unsubmit">Unsubmit</a>
+                        </li>
+                    {% endif %}
+                    {% if is_faculty or response.is_submitted and response_can_edit %}
                     {% endif %}
                 </ul>
             </div>


### PR DESCRIPTION
* This pull request mainly focuses on additional layout details to make the view consistent with the wireframes. There's a lot of html/css flux here.

* The one bit of functionality added: the unsubmit dialog is replaced with a straight responses dialog that allows users to navigate between available peer/student response views.

<img width="974" alt="screen shot 2016-12-08 at 9 53 52 am" src="https://cloud.githubusercontent.com/assets/141369/21014557/8ac25bee-bd2c-11e6-839b-a257771be5a3.png">
