### PR TITLE
Sequence Assignment: respect course-level public composition setting

### DIFF
--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -831,6 +831,7 @@ class SequenceAssignmentViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(ctx['the_response'], response)
         self.assertEquals(ctx['responses'], [response])
         self.assertTrue(ctx['show_instructions'])
+        self.assertFalse(ctx['allow_public_compositions'])
 
     def test_get_context_data_my_response(self):
         response = ProjectFactory.create(

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -38,6 +38,7 @@ from mediathread.sequence.models import SequenceAsset
 from mediathread.taxonomy.api import VocabularyResource
 from mediathread.taxonomy.models import Vocabulary
 from structuredcollaboration.models import Collaboration
+from mediathread.main.course_details import allow_public_compositions
 
 
 class ProjectCreateView(LoggedInCourseMixin, JSONResponseMixin,
@@ -438,7 +439,9 @@ class SequenceAssignmentView(AssignmentView):
         key = 'assignment_instructions_{}'.format(parent.id)
         return {
             'show_instructions': UserSetting.get_setting(
-                self.request.user, key, True)
+                self.request.user, key, True),
+            'allow_public_compositions': allow_public_compositions(
+                self.request.course)
         }
 
 

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -177,7 +177,7 @@
                             Submitted
                         </strong> {{the_response.modified|date:"m/d/Y h:i a"}}
 
-                        {% if response_can_edit %}
+                        {% if response_can_edit and allow_public_compositions %}
                             <a class="btn btn-primary btn-sm" href="#" data-toggle="modal" data-target="#visibility-list">
                                 <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
                                 {% if public_url %}Permalink{% else %}Share{% endif %}


### PR DESCRIPTION
Don't show the "share" button unless the course allows it.