### PR TITLE
Fix playhead CSS

### DIFF
--- a/media/juxtapose/css/playhead.css
+++ b/media/juxtapose/css/playhead.css
@@ -38,7 +38,6 @@ input[type=range] {
     width: 100%;
     cursor: col-resize;
     position: relative;
-    top: 100px;
     margin: 0;
     border: 0;
 }


### PR DESCRIPTION
Removing `float: left;` from the track container affected the ability to drag the playhead. This change fixes that problem.