### PR TITLE
Reposition media TrackElementManager button above element

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -40,8 +40,15 @@ button.jux-play span.glyphicon {
 .jux-track-manager-button {
     cursor: pointer;
     position: relative;
-    top: 42px;
     width: 0;
+}
+
+.jux-media .jux-track-manager-button {
+    top: -24px;
+}
+
+.jux-txt .jux-track-manager-button {
+    top: 42px;
 }
 
 .react-grid-item .jux-media-item-middle {


### PR DESCRIPTION
This avoids a UI issue where it's not visible if there's a text track
below it.