### PR TITLE
Only allow sequence submission when valid - PMT #109151

### DIFF
--- a/media/js/app/projects/sequenceAssignmentView.js
+++ b/media/js/app/projects/sequenceAssignmentView.js
@@ -78,11 +78,18 @@
                     self.setDirty(data.dirty);
                 });
 
+            jQuery(window).on(
+                'sequenceassignment.set_submittable',
+                function(e, data) {
+                    self.setSubmittable(data.submittable);
+                });
+
             var $saveButton = this.$el.find('.btn-save');
             jQuery(window).on(
                 'sequenceassignment.on_save_success',
                 function(e, data) {
                     self.setDirty(false);
+                    self.setSubmittable(data.submittable);
                     $saveButton.removeAttr('disabled')
                         .removeClass('saving', 1200, function() {
                             jQuery(self).text('Saved');
@@ -131,10 +138,18 @@
                 $elt.removeClass('disabled');
                 jQuery('.btn-show-submit').addClass('disabled');
             } else {
-                tinymce.activeEditor.isNotDirty = true;
+                if (tinymce && tinymce.activeEditor) {
+                    tinymce.activeEditor.isNotDirty = true;
+                }
                 $elt.text('Saved');
                 $elt.addClass('disabled');
+            }
+        },
+        setSubmittable: function(isSubmittable) {
+            if (isSubmittable) {
                 jQuery('.btn-show-submit').removeClass('disabled');
+            } else {
+                jQuery('.btn-show-submit').addClass('disabled');
             }
         },
         validTitle: function() {

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -232,7 +232,7 @@
                             <a href="#" class="btn btn-primary btn-tab btn-save disabled">Saved</a>
                         </li>
                         <li role="presentation">
-                            <a href="#" class="btn btn-primary btn-tab btn-show-submit">Submit</a>
+                            <a href="#" class="btn btn-primary btn-tab btn-show-submit disabled">Submit</a>
                         </li>
                     {% endif %}
                     {% if is_faculty %}


### PR DESCRIPTION
This prevents the Submit button from being active when the sequence is
in a non-submittable state.

We'll also be setting the submittable state from React as the project
loads, during initialization. This is for the case where the response
is in a submittable state, but the user has just navigated to it without
doing any editing or saving.