### PR TITLE
Switch from course_exists to Affil.get_course

### DIFF
--- a/mediathread/main/tests/test_util.py
+++ b/mediathread/main/tests/test_util.py
@@ -1,11 +1,8 @@
 from django.core import mail
 from django.test.testcases import TestCase
-from courseaffils.tests.factories import AffilFactory
 
 from mediathread.factories import UserFactory
-from mediathread.main.util import (
-    send_template_email, user_display_name, course_exists
-)
+from mediathread.main.util import send_template_email, user_display_name
 
 
 class UtilTest(TestCase):
@@ -26,7 +23,3 @@ class UtilTest(TestCase):
 
         user = UserFactory(first_name='John', last_name='Smith')
         self.assertEquals(user_display_name(user), 'John Smith')
-
-    def test_course_exists(self):
-        a = AffilFactory()
-        self.assertIsNone(course_exists(a))

--- a/mediathread/main/util.py
+++ b/mediathread/main/util.py
@@ -1,6 +1,4 @@
-import re
 from django.conf import settings
-from django.contrib.auth.models import Group
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.exceptions import ImproperlyConfigured
@@ -9,7 +7,6 @@ from django.template.context import Context
 import requests
 from requests.exceptions import SSLError
 from raven import Client
-from courseaffils.models import Course
 
 
 def send_template_email(subject, template_name, params, recipient):
@@ -62,20 +59,3 @@ def log_sentry_error(msg):
         return
 
     return client.captureMessage(msg)
-
-
-def course_exists(affil):
-    """Returns an associated course for the affil, if it exists.
-
-    TODO: move this to courseaffils.
-    """
-    fgroup = Group.objects.filter(name=affil.name).first()
-    if Course.objects.filter(faculty_group=fgroup).exists():
-        return Course.objects.filter(faculty_group=fgroup).first()
-
-    studentaffil = re.sub(r'\.fc\.', '.st.', affil.name)
-    sgroup = Group.objects.filter(name=studentaffil).first()
-    if Course.objects.filter(group=sgroup).exists():
-        return Course.objects.filter(group=sgroup).first()
-
-    return None

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -50,7 +50,7 @@ from mediathread.main.forms import (
 from mediathread.main.models import UserSetting, CourseInvitation
 from mediathread.main.util import (
     send_template_email, user_display_name, send_course_invitation_email,
-    make_pmt_item, log_sentry_error, course_exists
+    make_pmt_item, log_sentry_error
 )
 from mediathread.mixins import (
     ajax_required,
@@ -768,7 +768,7 @@ class MethCourseListView(LoggedInMixin, CourseListView):
         # them, but for whatever reason have "activated" set to False.
         filtered_affils = []
         for affil in affils:
-            if not course_exists(affil):
+            if not affil.get_course():
                 filtered_affils.append(affil)
 
         for affil in filtered_affils:
@@ -914,7 +914,7 @@ Faculty: {} <{}>
         self.affil = Affil.objects.get(pk=pk)
         affil_dict = self.affil.to_dict()
 
-        c = course_exists(self.affil)
+        c = self.affil.get_course()
         if c:
             # If a Course already exists for this affil, show an error.
             msg = ('The {} affil is already connected to the course:'


### PR DESCRIPTION
This method was moved from Mediathread to courseaffils in October.
See:
https://github.com/ccnmtl/django_courseaffils/blob/master/courseaffils/models.py#L323