### PR TITLE
CollectionWidget: default owner to "Me"

### DIFF
--- a/media/js/app/assetmgr/collectionwidget.js
+++ b/media/js/app/assetmgr/collectionwidget.js
@@ -23,7 +23,8 @@ var CollectionWidget = function() {
     this.loading = false;
     this.template = 'collectionwidget';
     this.limits = {offset: 0, limit: 20};
-    this.currentRecords = {'space_owner': MediaThread.currentOwner};
+    this.currentRecords =
+        {'space_owner': {'username': MediaThread.current_username}};
 
     this.$modal = jQuery('#collection-modal');
     this.$el = this.$modal.find('.collection-view');


### PR DESCRIPTION
The "All Class Members" filter could be a cause for confusion. Defaulting owner
to the request.user like the composition project workspace.