### PR TITLE
Allow track element to begin immediately at the previous one's end time

### DIFF
--- a/mediathread/sequence/tests/test_apiviews.py
+++ b/mediathread/sequence/tests/test_apiviews.py
@@ -420,6 +420,11 @@ class AssetViewSetTest(LoggedInTestMixin, APITestCase):
                         'text': 'My text',
                         'start_time': 0,
                         'end_time': 10,
+                    },
+                    {
+                        'text': 'My text',
+                        'start_time': 10,
+                        'end_time': 12,
                     }
                 ]
             }, format='json')
@@ -432,7 +437,7 @@ class AssetViewSetTest(LoggedInTestMixin, APITestCase):
         self.assertEqual(sa.spine, note)
 
         self.assertEqual(SequenceMediaElement.objects.count(), 1)
-        self.assertEqual(SequenceTextElement.objects.count(), 1)
+        self.assertEqual(SequenceTextElement.objects.count(), 2)
 
     def test_update_with_overlapping_elements(self):
         sa = SequenceAssetFactory(author=self.u)

--- a/mediathread/sequence/validators.py
+++ b/mediathread/sequence/validators.py
@@ -9,8 +9,8 @@ def prevent_overlap(value):
     for i in range(len(value) - 1):
         a = value[i]
         b = value[i + 1]
-        overlap = a.get('start_time') <= b.get('end_time') and \
-            b.get('start_time') <= a.get('end_time')
+        overlap = a.get('start_time') < b.get('end_time') and \
+            b.get('start_time') < a.get('end_time')
         if overlap:
             raise ValidationError('Elements can\'t overlap.')
 


### PR DESCRIPTION
I ran into a bug where my sequence loaded successfully with a text
element ending at point 117, and the next one starting at exactly the
same point. After altering the media track and attempting to save, the
API didn't validate. We should allow this case where the element begins
immediately where the last one ends.