### PR TITLE
Pass in loadTemplate() instead of loadTemplates() to jQuery.when - PMT #109383

### DIFF
--- a/media/js/app/assetmgr/collectionwidget.js
+++ b/media/js/app/assetmgr/collectionwidget.js
@@ -36,14 +36,14 @@ var CollectionWidget = function() {
     jQuery.when(
         self.getCourse(),
         self.getVocabulary(),
-        MediaThread.loadTemplates(
-            [self.template, self.template + '_quickedit'])
+        MediaThread.loadTemplate([self.template]),
+        MediaThread.loadTemplate([self.template + '_quickedit'])
     ).done(function(courseReq, vocabularyReq) {
         self.owners = courseReq[0].objects[0].group.user_set;
         self.vocabulary = vocabularyReq[0].objects;
         self.postInitialize();
     }).fail(function() {
-        // handle errors
+        console.error('Loading error in CollectionWidget constructor');
     });
 };
 


### PR DESCRIPTION
The loadTemplates() function returns an array of promises, and it's unclear
if this is supported by jQuery.when according to the documentation. I'm
working under the assumption that the referenced bug is a race
condition, and changing this to give jQuery.when input that we know is
supported.