### PR TITLE
ProjectSequenceAsset: filter by project access

### DIFF
--- a/mediathread/projects/tests/test_apiviews.py
+++ b/mediathread/projects/tests/test_apiviews.py
@@ -1,5 +1,6 @@
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
+
 from mediathread.projects.tests.factories import ProjectSequenceAssetFactory
 from mediathread.sequence.tests.factories import SequenceAssetFactory
 from mediathread.sequence.tests.mixins import LoggedInTestMixin
@@ -18,6 +19,24 @@ class ProjectSequenceAssetViewSetTest(LoggedInTestMixin, APITestCase):
         r = self.client.get(reverse('projectsequenceasset-list'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(len(r.data), 3)
+
+    def test_list_by_project(self):
+        psa = ProjectSequenceAssetFactory()
+
+        url = '{}?project={}'.format(
+            reverse('projectsequenceasset-list'), psa.id)
+
+        # anonymous user
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(r.data), 0)
+
+        # project's author
+        self.client.login(
+            username=psa.project.author.username, password='test')
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(r.data), 1)
 
     def test_retrieve(self):
         psa = ProjectSequenceAssetFactory()


### PR DESCRIPTION
Allow a user to see a ProjectSequenceAsset if the project is visible to the requesting user based on the associated project's visibility.

e.g. a PSA associated with an assignment response that is "private", can only be seen by its author. a PSA associated with an assignment response that is "published to course", can be seen by course members.