### PR TITLE
Firefox: fix vertical track element alignment - PMT #109418

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -169,6 +169,11 @@ button.jux-play span.glyphicon {
     bottom: 51px;
     z-index: 2;
 }
+@-moz-document url-prefix() {
+    .jux-track>.react-grid-layout {
+        bottom: 49px;
+    }
+}
 
 .jux-spine-display {
     background-color: #bbb;


### PR DESCRIPTION
This removes the 2px high space below track elements in firefox.
Unfortunately having to resolve this issue with firefox-specific CSS for
now.