### PR TITLE
Public to world tweaks

### DIFF
--- a/media/js/app/assetmgr/collectionwidget.js
+++ b/media/js/app/assetmgr/collectionwidget.js
@@ -744,7 +744,7 @@ CollectionWidget.prototype.signalInsert = function(assetId, annotationId) {
 };
 
 jQuery(document).ready(function() {
-    if (typeof djangosherd !== 'undefined') {
+    if (typeof djangosherd !== 'undefined' && MediaThread.current_user) {
         MediaThread.collection = new CollectionWidget();
     }
 });

--- a/mediathread/projects/apiviews.py
+++ b/mediathread/projects/apiviews.py
@@ -1,12 +1,13 @@
 from django.shortcuts import get_object_or_404
-from rest_framework import viewsets, permissions
+from rest_framework import permissions, mixins
 from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
 from mediathread.projects.models import ProjectSequenceAsset, Project
 from mediathread.projects.serializers import ProjectSequenceAssetSerializer
 
 
-class ProjectSequenceAssetViewSet(viewsets.ReadOnlyModelViewSet):
+class ProjectSequenceAssetViewSet(mixins.ListModelMixin, GenericViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = ProjectSequenceAsset.objects.all()
     serializer_class = ProjectSequenceAssetSerializer
@@ -27,8 +28,10 @@ class ProjectSequenceAssetViewSet(viewsets.ReadOnlyModelViewSet):
         project_id = request.query_params.get('project', None)
         if project_id is not None:
             queryset = self.filter_by_project(request.user, project_id)
-        else:
+        elif request.user.is_authenticated():
             queryset = self.filter_by_user(request.user)
+        else:
+            queryset = ProjectSequenceAsset.objects.none()
 
         serializer = ProjectSequenceAssetSerializer(queryset, many=True)
         return Response(serializer.data)

--- a/mediathread/projects/apiviews.py
+++ b/mediathread/projects/apiviews.py
@@ -7,7 +7,7 @@ from mediathread.projects.serializers import ProjectSequenceAssetSerializer
 
 
 class ProjectSequenceAssetViewSet(viewsets.ReadOnlyModelViewSet):
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = ProjectSequenceAsset.objects.all()
     serializer_class = ProjectSequenceAssetSerializer
 

--- a/mediathread/projects/tests/test_apiviews.py
+++ b/mediathread/projects/tests/test_apiviews.py
@@ -38,14 +38,6 @@ class ProjectSequenceAssetViewSetTest(LoggedInTestMixin, APITestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(len(r.data), 1)
 
-    def test_retrieve(self):
-        psa = ProjectSequenceAssetFactory()
-        r = self.client.get(
-            reverse('projectsequenceasset-detail', args=(psa.pk,)))
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(len(r.data), 3)
-        self.assertEqual(r.data['project'], psa.project.pk)
-
 
 class ProjectSequenceAssetViewSetUnAuthedTest(APITestCase):
     def test_list(self):

--- a/mediathread/projects/tests/test_apiviews.py
+++ b/mediathread/projects/tests/test_apiviews.py
@@ -53,4 +53,5 @@ class ProjectSequenceAssetViewSetUnAuthedTest(APITestCase):
         ProjectSequenceAssetFactory()
 
         r = self.client.get(reverse('projectsequenceasset-list'))
-        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(r.data), 0)

--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -237,14 +237,14 @@
                 {% if course %}
                     this.current_course = {{ course.pk }};
                 {% endif %}
-                {% if the_response %}
-                    this.current_project = {{the_response.pk }};
-                {% endif %}
                 this.flags = [
                     {% flag "collection-widget" %}
                         'collection-widget'
                     {% endflag %}
                 ];
+            {% endif %}
+            {% if the_response %}
+                this.current_project = {{the_response.pk }};
             {% endif %}
         })();
     </script>


### PR DESCRIPTION
* ProjectSequenceAsset - change permission to isAuthenticatedOrReadOnly, as the "list" method effectively acts as the authorization layer, remove the "detail" method to prevent direct requests.
* base.html - make sure the_response is available even when there is no user
*  CollectionWidget - don't instantiate when the user is anonymous