### PR TITLE
Use normal range input for playhead - PMT #109411

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -2948,10 +2948,6 @@ textarea {
     border: 1px solid #ccc;
 }
 
-input {
-    border: 1px solid #333333;
-}
-
 input[type="checkbox"] {
     border: none; /* IE 8,9 look very very odd with a border */
 }

--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -2,7 +2,7 @@ button.jux-play {
     background-color: #bbb;
     float: left;
     border: 0;
-    height: 50px;
+    height: 30px;
     width: 35px;
     outline: none;
 }
@@ -95,7 +95,7 @@ button.jux-play span.glyphicon {
 }
 
 .jux-track-container.jux-media {
-    margin-top: 0;
+    margin-top: -106px;
 }
 
 .jux-media-display .media-track-icon:before,

--- a/media/juxtapose/css/playhead.css
+++ b/media/juxtapose/css/playhead.css
@@ -1,109 +1,16 @@
 .jux-playhead-container {
-    height: 0;
-    margin-left: 55px;
+    margin-left: 48px;
+}
+.jux-playhead-container input[type=range] {
+    cursor: col-resize;
+    width: 930px;
 }
 
 .jux-playhead-line {
-    height: 100px;
+    height: 104px;
     width: 2px;
     background-color: #000;
     position: relative;
-    z-index: 50;
-    margin-top: -1px;
-}
-
-.jux-playhead-line .jux-playhead-top-cutpoint,
-.jux-playhead-line .jux-playhead-bottom-cutpoint {
-    position: relative;
-    width: 1px;
-    margin-left: -7px;
-}
-
-.jux-playhead-line .jux-playhead-top-cutpoint {
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-top: 8px solid black;
-}
-
-.jux-playhead-line .jux-playhead-bottom-cutpoint {
-    top: 86px;
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-bottom: 8px solid black;
-}
-
-.jux-playhead-container input[type=range] {
-    z-index: 50;
-    -webkit-appearance: none;
-    width: 100%;
-    cursor: col-resize;
-    position: relative;
-    margin: 0;
-    border: 0;
-}
-
-.jux-playhead-container input[type=range]::-webkit-slider-runnable-track {
-    width: 100%;
-    height: 0;
-    cursor: col-resize;
-    box-shadow: 1.1px 1.1px 1px rgba(0, 0, 0, 0), 0px 0px 1.1px rgba(13, 13, 13, 0);
-    background-color: #000;
-    border-radius: 0px;
-    border: 0px solid rgba(255, 255, 37, 0);
-}
-.jux-playhead-container input[type=range]::-webkit-slider-thumb {
-    height: 100px;
-    width: 20px;
-    cursor: col-resize;
-    -webkit-appearance: none;
-    margin-top: -100px;
-}
-.jux-playhead-container input[type=range]:focus::-webkit-slider-runnable-track {
-    background: #000000;
-}
-.jux-playhead-container input[type=range]::-moz-range-track {
-    width: 100%;
-    height: 0;
-    cursor: col-resize;
-    box-shadow: 1.1px 1.1px 1px rgba(0, 0, 0, 0), 0px 0px 1.1px rgba(13, 13, 13, 0);
-    background: #000000;
-    border-radius: 0px;
-    border: 0px solid rgba(255, 255, 37, 0);
-}
-.jux-playhead-container input[type=range]::-moz-range-thumb {
-    background-color: rgba(255, 255, 255, 0);
-    height: 100px;
-    border: 0;
-}
-.jux-playhead-container input[type=range]::-ms-track {
-    width: 100%;
-    height: 0;
-    cursor: col-resize;
-    background: transparent;
-    border-color: transparent;
-    color: transparent;
-}
-.jux-playhead-container input[type=range]::-ms-fill-lower {
-    background: #000000;
-    border: 0px solid rgba(255, 255, 37, 0);
-    border-radius: 0px;
-    box-shadow: 1.1px 1.1px 1px rgba(0, 0, 0, 0), 0px 0px 1.1px rgba(13, 13, 13, 0);
-}
-.jux-playhead-container input[type=range]::-ms-fill-upper {
-    background: #000000;
-    border: 0px solid rgba(255, 255, 37, 0);
-    border-radius: 0px;
-    box-shadow: 1.1px 1.1px 1px rgba(0, 0, 0, 0), 0px 0px 1.1px rgba(13, 13, 13, 0);
-}
-.jux-playhead-container input[type=range]::-ms-thumb {
-    height: 100px;
-    width: 20px;
-    cursor: col-resize;
-    margin-top: -100px;
-}
-.jux-playhead-container input[type=range]:focus::-ms-fill-lower {
-    background: #000000;
-}
-.jux-playhead-container input[type=range]:focus::-ms-fill-upper {
-    background: #000000;
+    display: inline-block;
+    z-index: 5;
 }


### PR DESCRIPTION
This resolves the issue in the referenced PMT, and makes the playhead easier to use. I made the play button not extend all the way down to the tracks, which I admit looks a little odd, but the reason is that different browsers will have slightly different heights for their range inputs, so we can't use an absolute value for the play button height if it needs to extend to the tracks. 

Mac / Chrome
![screen shot 2017-01-03 at 14 49 08](https://cloud.githubusercontent.com/assets/59292/21620829/31f0cbde-d1c4-11e6-9420-0e18f4e8b4e3.png)

Mac / Firefox:
![screen shot 2017-01-03 at 14 49 20](https://cloud.githubusercontent.com/assets/59292/21620834/35e7348a-d1c4-11e6-9f54-87b65e3eea68.png)

Depends on changes from this juxtapose branch: https://github.com/ccnmtl/juxtapose/pull/214