### PR TITLE
playhead: minor style tweaks

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -20,6 +20,8 @@ button.jux-play span.glyphicon {
     min-height: 600px;
     margin: 0 auto;
     opacity: 0;
+    border-collapse: collapse;
+    border-right-width: 0;
 }
 
 .react-grid-item {
@@ -82,6 +84,8 @@ button.jux-play span.glyphicon {
     background-color: #ddd;
     float: left;
     border: 1px solid #ccc;
+    border-left-width: 0;
+    border-bottom-width: 0;
 }
 
 .jux-media-display .text-track-icon:before,
@@ -137,6 +141,7 @@ button.jux-play span.glyphicon {
     margin-left: 55px;
     background-color: #f5f5f5;
     position: relative;
+    border-bottom-width: 0;
 }
 
 .jux-track-instructions {
@@ -312,6 +317,11 @@ button.jux-play span.glyphicon {
 }
 
 /* TimelineRuler */
+
+.jux-timeline {
+    border: 1px solid #ccc;
+    border-right-width: 0;
+}
 
 .jux-timeline-ruler {
     height: 21px;

--- a/media/juxtapose/css/playhead.css
+++ b/media/juxtapose/css/playhead.css
@@ -4,6 +4,9 @@
 .jux-playhead-container input[type=range] {
     cursor: col-resize;
     width: 930px;
+    -webkit-appearance: none;
+    background: transparent;
+    outline: none;
 }
 
 .jux-playhead-line {


### PR DESCRIPTION
<img width="1009" alt="screen shot 2017-01-04 at 10 16 07 am" src="https://cloud.githubusercontent.com/assets/141369/21647068/d5a09f14-d266-11e6-8bd1-f75843edfe14.png">

* hide the range. the track can still be clicked to jump to a particular point.
* add some borders