### PR TITLE
Tighten up timeline ruler display

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -330,7 +330,7 @@ button.jux-play span.glyphicon {
 }
 
 .jux-timeline-ruler {
-    height: 21px;
+    height: 10px;
     position: relative;
     margin-left: 55px;
     z-index: 0;
@@ -338,7 +338,6 @@ button.jux-play span.glyphicon {
 
 .jux-timeline-hline {
     height: 1px;
-    top: 20px;
     position: relative;
     border-bottom: 1px solid #000;
 }
@@ -349,6 +348,7 @@ button.jux-play span.glyphicon {
 }
 
 .jux-timeline-ticklabel {
+    top: 10px;
     display: inline;
     width: 46px;
     text-align: center;
@@ -358,7 +358,6 @@ button.jux-play span.glyphicon {
 
 .jux-timeline-tick {
     display: inline-block;
-    top: 20px;
     width: 2px;
     height: 9px;
     background-color: #000;


### PR DESCRIPTION
This puts the labels below the ruler and saves some vertical space.

Maybe we should hide the `00:00:00` label, since that position is kind
of obvious, and the playhead is covering it in its default state.

![screen shot 2017-01-05 at 10 57 07 am](https://cloud.githubusercontent.com/assets/59292/21687121/0892cefe-d336-11e6-9550-d36f54693c2a.png)
