### PR TITLE
Hide bullets from response view policy list items - PMT #109444

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4270,6 +4270,11 @@ a.btn.btn-default img.left {
     width: 100%;
 }
 
+.selection-assignment #id_response_view_policy li,
+.sequence-assignment #id_response_view_policy li {
+    list-style-type: none;
+}
+
 .sequence-assignment #id_response_view_policy label,
 .sequence-assignment #id_publish label,
 .selection-assignment #id_response_view_policy label,


### PR DESCRIPTION
The applies to both selection and sequence assignment creation. The
problem was more prevalent in firefox than chrome.

Before hiding these bullets:
![2017-01-05-140313_327x347_scrot](https://cloud.githubusercontent.com/assets/59292/21693712/f87a3a88-d34f-11e6-895d-c5853062a4fa.png)
