### PR TITLE
Add margin to text updated notice

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -287,6 +287,7 @@ button.jux-play span.glyphicon {
 
 .jux-updated-text {
     display: none;
+    margin-top: 4px;
 }
 
 .jux-track-element-manager {


### PR DESCRIPTION
I took off the `help-text` class from this text to make it bigger, and now it needs a margin:
https://github.com/ccnmtl/juxtapose/pull/234