### PR TITLE
Turn off spine iframe pointer-events - PMT #109466

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -187,6 +187,10 @@ button.jux-play span.glyphicon {
     width: 490px;
 }
 
+.jux-spine-display iframe {
+    pointer-events: none;
+}
+
 .jux-spine-display .instructions,
 .jux-media-display .instructions {
     font-size: 1.2em;


### PR DESCRIPTION
The iframe for YouTube / Vimeo was causing the hover state for the
.jux-spine-display div to not get triggered in MS Edge, so the
change/replace buttons were always hidden. HTML5 videos worked fine.

This disables pointer events on the iframe, which we aren't using
anyways, and solves the problem.