### PR TITLE
Project.responses - add check for undefined content_object

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -364,7 +364,8 @@ class Project(models.Model):
 
         for child in children:
             response = child.content_object
-            if response.can_read(course, viewer, child, viewer_response):
+            if (response and
+                    response.can_read(course, viewer, child, viewer_response)):
                 visible.append(response)
         return visible
 


### PR DESCRIPTION
Sentry #201100291 shows that in certain cases, the collaboration content_object can be None. I was unable to reproduce this state with a unit test, so am simply adding an additional check.