### PR TITLE
Filter out Vimeo assets from CollectionWidget - PMT #109584

### DIFF
--- a/media/js/app/assetmgr/collectionwidget.js
+++ b/media/js/app/assetmgr/collectionwidget.js
@@ -489,10 +489,12 @@ CollectionWidget.prototype.updateSwitcher = function() {
             for (var key in self.currentRecords.active_filters) {
                 if (self.currentRecords.active_filters.hasOwnProperty(key) &&
                     self.currentRecords.active_filters[key].length > 0) {
-                    var val = self.currentRecords.active_filters[key]
-                        .split(',');
-                    self.currentRecords.active_filters[key] = val;
-                    values = values.concat(val);
+                    if (self.currentRecords.active_filters[key].split) {
+                        var val = self.currentRecords.active_filters[key]
+                            .split(',');
+                        self.currentRecords.active_filters[key] = val;
+                        values = values.concat(val);
+                    }
                 }
             }
             jQuery(vocabulary).select2('val', values);
@@ -705,7 +707,11 @@ CollectionWidget.prototype.filteredUrl = function() {
             }
         }
     }
-    url += '&primary_type=image_fpxid'; // exclude ARTStor for the moment
+    var filters = jQuery.param({
+        // Excludes artstor and vimeo
+        primary_type: ['image_fpxid', 'vimeo']
+    });
+    url += '&' + filters;
     return url;
 };
 

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -1028,6 +1028,10 @@ class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
             if (key in self.valid_filters or key.startswith('vocabulary-')):
                 ctx['active_filters'][key] = val
 
+        filtered_types = request.GET.getlist('primary_type[]')
+        if filtered_types:
+            ctx['active_filters']['primary_types'] = filtered_types
+
         ctx['editable'] = self.viewing_own_records
         ctx['citable'] = citable
 

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -106,8 +106,14 @@ class RestrictedMaterialsMixin(object):
             self.all_items_are_visible, tag_string, modified, vocabulary)
         visible_notes = visible_notes.filter_by_media_type(
             request.GET.get('media_type'))
-        visible_notes = visible_notes.exclude_primary_type(
-            request.GET.get('primary_type'))
+
+        if request.GET.get('primary_type'):
+            visible_notes = visible_notes.exclude_primary_type(
+                request.GET.get('primary_type'))
+        elif request.GET.getlist('primary_type[]'):
+            filtered_types = request.GET.getlist('primary_type[]')
+            for t in filtered_types:
+                visible_notes = visible_notes.exclude_primary_type(t)
 
         search_text = request.GET.get('search_text', '').strip().lower()
         if len(search_text) > 0:


### PR DESCRIPTION
I made the primary_type filter accept an array as well as a single
value. It looks like we need to filter out 'image_fpxid' (artstor) as well
as the 'vimeo' primary type.

This is my first foray into the asset filtering code and the
RestrictedMaterialsMixin so please review and edit or make suggestions as
needed.