### PR TITLE
Disallow .flv migration to new courses

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -399,6 +399,10 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(response.status_code, 403)
 
     def test_migrate_materials_sample_course(self):
+        flv = AssetFactory.create(course=self.sample_course,
+                                  primary_source='flv_pseudo')
+        SherdNoteFactory(asset=flv, author=self.instructor_one)
+
         self.project1 = ProjectFactory.create(course=self.sample_course,
                                               author=self.instructor_one,
                                               policy='PrivateEditorsAreOwners')

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -274,7 +274,7 @@ class MigrateMaterialsView(LoggedInFacultyMixin, AjaxRequiredMixin,
         assets = Asset.objects.by_course(course)
         assets = assets.filter(sherdnote_set__author__id__in=faculty)
         notes = SherdNote.objects.get_related_notes(
-            assets, None, faculty, True).exclude_primary_type('flv_pseudo')
+            assets, None, faculty, True).exclude_primary_types(['flv_pseudo'])
 
         ares = AssetResource(include_annotations=False)
         asset_ctx = ares.render_list(request, None, None, assets, notes)

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -274,7 +274,7 @@ class MigrateMaterialsView(LoggedInFacultyMixin, AjaxRequiredMixin,
         assets = Asset.objects.by_course(course)
         assets = assets.filter(sherdnote_set__author__id__in=faculty)
         notes = SherdNote.objects.get_related_notes(
-            assets, None, faculty, True)
+            assets, None, faculty, True).exclude_primary_type('flv_pseudo')
 
         ares = AssetResource(include_annotations=False)
         asset_ctx = ares.render_list(request, None, None, assets, notes)


### PR DESCRIPTION
Exclude assets with primary source ```flv_pseudo``` from migration materials.