### PR TITLE
Increase allowed tag length to maximum allowed by back-end - PMT #109846

### DIFF
--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -1109,7 +1109,7 @@
                     self.$parent.find(selector).select2({
                         tags: tags,
                         tokenSeparators: [','],
-                        maximumInputLength: 20,
+                        maximumInputLength: 50,
                         width: '70%'
                     });
                 }


### PR DESCRIPTION
So, I would like to increase this to 255 instead of 50, but doing
that requires adding a migration to django-tagging, which isn't
straightforward since this is a third-party package.