### PR TITLE
update MAX_TAG_LENGTH to 255

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -202,3 +202,6 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
     )
 
 BLOCKED_EMAIL_DOMAINS = []
+
+# django-tagging
+MAX_TAG_LENGTH = 255


### PR DESCRIPTION
This won't have any real effect until we run this migration in
django-tagging:

https://github.com/Fantomas42/django-tagging/pull/16