### PR TITLE
restore django-contrib-comments 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ djangowind==0.16.1
 django-tagging==0.4.5
 django-reversion==1.9.3
 djangohelpers==0.18.2
-django-contrib-comments==1.8.0
+django-contrib-comments==1.7.3
 django-threadedcomments==1.0b1
 django-courseaffils==2.1.12
 django-statsd-mozilla==0.3.16


### PR DESCRIPTION
Discussion boards are broken in production. Restoring the version used prior to 1.8.0 (https://github.com/ccnmtl/mediathread/pull/1220) while I investigate.