### PR TITLE
Highlight timeline input on hover - PMT #110066

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -383,7 +383,7 @@ button.jux-play span.glyphicon {
 }
 
 .jux-timeline-ruler {
-    height: 10px;
+    height: 8px;
     position: relative;
     margin-left: 55px;
     z-index: 0;

--- a/media/juxtapose/css/playhead.css
+++ b/media/juxtapose/css/playhead.css
@@ -3,12 +3,16 @@
     position: relative; /* needed for zindex */
 }
 .jux-playhead-container input[type=range] {
-    cursor: col-resize;
+    cursor: pointer;
     width: 930px;
     /* Hide range slider in webkit */
     -webkit-appearance: none;
     background: transparent;
     outline: none;
+}
+
+.jux-playhead-container input[type=range]:hover {
+    background-color: rgba(200, 200, 200, 0.25);
 }
 
 .jux-playhead-container input[type=range]::-moz-range-track {


### PR DESCRIPTION
The input is now highlighted on hover and has `cursor: pointer;`,
to make it more obvious that it can be clicked on.