### PR TITLE
Fix sequence composition display bug

### DIFF
--- a/media/juxtapose/css/juxtapose.css
+++ b/media/juxtapose/css/juxtapose.css
@@ -1,7 +1,6 @@
 button.jux-rewind,
 button.jux-play {
     background-color: #bbb;
-    float: left;
     border: 0;
     height: 30px;
     width: 35px;

--- a/mediathread/templates/projects/sequence.html
+++ b/mediathread/templates/projects/sequence.html
@@ -131,7 +131,7 @@
         <!-- Tab panes -->
         <div class="tab-content">
             <div role="tabpanel"
-                 class="tab-pane fade in active {% if project.is_submitted %}submitted{% endif %}"
+                 class="tab-pane fade in active"
                  id="sequence">
                 <div class="loader">
                     <div class="ball-pulse">


### PR DESCRIPTION
The main thing here is that the playhead was picking up the 'submitted'
sequence's style for the playhead, making it look strange:

![2017-03-01-105649_482x245_scrot](https://cloud.githubusercontent.com/assets/59292/23469080/a6d5fcca-fe70-11e6-8856-b22f15c4e34b.png)


I've also removed a `float: left;` on the buttons since it's
unnecessary.

requires: https://github.com/ccnmtl/juxtapose/pull/287