### PR TITLE
Sequence assignment: add assignment summary option for public display

### DIFF
--- a/media/js/app/projects/assignment_edit.js
+++ b/media/js/app/projects/assignment_edit.js
@@ -59,6 +59,7 @@
                     tinymce.settings = this.tinymceSettings;
                     tinymce.execCommand('mceAddEditor', true,
                                         'assignment-instructions');
+                    tinymce.execCommand('mceAddEditor', true, 'summary');
                 }
             } else if (pageContent === 'due-date') {
                 // if there is only one radio button, select it

--- a/mediathread/projects/forms.py
+++ b/mediathread/projects/forms.py
@@ -30,7 +30,7 @@ class ProjectForm(forms.ModelForm):
         model = Project
         fields = ('title', 'body', 'participants',
                   'submit', 'publish', 'due_date',
-                  'response_view_policy',
+                  'response_view_policy', 'summary',
                   'custom_instructions_1', 'custom_instructions_2')
 
     def __init__(self, request, *args, **kwargs):

--- a/mediathread/projects/migrations/0020_project_summary.py
+++ b/mediathread/projects/migrations/0020_project_summary.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0019_auto_20161122_1557'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='summary',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -290,6 +290,7 @@ class Project(models.Model):
     objects = ProjectManager()  # custom manager
 
     title = models.CharField(max_length=1024)
+    summary = models.TextField(null=True, blank=True)
 
     course = models.ForeignKey(Course, related_name='project_set')
 

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -71,11 +71,12 @@ class ProjectCreateView(LoggedInCourseMixin, JSONResponseMixin,
         due_date = self.format_date(self.request.POST.get('due_date', None))
         instructions1 = self.request.POST.get('custom_instructions_1', None)
         instructions2 = self.request.POST.get('custom_instructions_2', None)
+        summary = self.request.POST.get('summary', None)
         project = Project.objects.create(
             author=request.user, course=request.course, title=self.get_title(),
             project_type=project_type, response_view_policy=response_policy,
             body=body, due_date=due_date, custom_instructions_1=instructions1,
-            custom_instructions_2=instructions2)
+            custom_instructions_2=instructions2, summary=summary)
 
         project.participants.add(request.user)
 

--- a/mediathread/templates/projects/sequence_assignment_edit.html
+++ b/mediathread/templates/projects/sequence_assignment_edit.html
@@ -72,15 +72,15 @@
                         "secondary" selections and/or annotations. The 
                         secondary selections will appear at designated points 
                         when the primary selection plays.</p>
-                        
+
                         <p>This type of assignment is good for assessing how 
                         students juxtapose a primary media object against other 
                         media selections (ie, visual annotations) or a series 
                         of thoughts (ie, textual annotations).</p>
-                        
+
                         <p>The assignment has two workspaces as described 
                         below.</p>
-                        
+
                         <h4>Sequence workspace:</h4>
 
                         <p><img src="{{STATIC_URL}}img/screenshot-sequence.jpg" style="width:500px; border: 1px solid #ccc;" /></p>
@@ -118,16 +118,16 @@
                             which will appear as the primary media object 
                             plays.
                             </p>
-                            
+
                             <p>Instructions may include:</p>
-                            
-                           <span><b>Sequence workspace:</b></span>
+
+                           <span>Sequence workspace:</span>
                            <ul>
                             <li>Criteria for selecting the primary media object</li>
                             <li>Criteria for type, timing, or amount of secondary media selections, aka visual annotations</li>
                             <li>Criteria for type, timing, or amount of student-authored notes, aka textual annotations</li>
                             </ul>
-                           <span><b>Reflection workspace (optional):</b></span>
+                           <span>Reflection workspace (optional):</span>
                            <ul>
                             <li>Criteria for overall characterization or justification of sequence</li>
                             </ul>
@@ -144,7 +144,7 @@
                         </nav>
                     </div>
                     <div data-page="3" data-page-content="custom-instructions" class="hidden page">
-                        <h3>Step 3. Write custom instructions</h3><br />
+                        <h3>Step 3. Write custom instructions &amp; assignment summary</h3><br />
                         <div class="form-group">
                             <label>Additional criteria for selecting primary media object</label>
                             <p>Add brief, targeted instructions to provide guidance on how to choose a primary video or audio. (140 character limit)</p>
@@ -153,7 +153,7 @@
                                 <img src="{{STATIC_URL}}img/screenshot-custom1.jpg" style="width:300px; border: 1px solid #ccc;" />
                                 </div>
                                 <div class="col-xs-6">
-                                <textarea name="custom_instructions_1" class="form-control mceEditor" maxlength="140" placeholder="Custom instructions (optional)..." style="height: 100px; margin-top: 20px;">{{form.instance.custom_instructions_2}}</textarea>
+                                <textarea name="custom_instructions_1" class="form-control" maxlength="140" placeholder="Custom instructions (optional)..." style="height: 100px; margin-top: 20px;">{{form.instance.custom_instructions_2}}</textarea>
                                 </div>
                             </div>
                         </div>
@@ -168,10 +168,27 @@
                                 <img src="{{STATIC_URL}}img/screenshot-custom2.jpg" style="width:300px; border: 1px solid #ccc;" />
                                 </div>
                                 <div class="col-xs-6">
-                                <textarea name="custom_instructions_2" class="form-control mceEditor" maxlength="140" placeholder="Custom instructions (optional)..." style="height: 100px; margin-top: 20px;">{{form.instance.custom_instructions_2}}</textarea>
+                                <textarea name="custom_instructions_2" class="form-control" maxlength="140" placeholder="Custom instructions (optional)..." style="height: 100px; margin-top: 20px;">{{form.instance.custom_instructions_2}}</textarea>
                                 </div>
                             </div>
-                            
+                        </div>
+
+                        <p>&nbsp;</p>
+
+                        <div class="form-group">
+                            <label>Submitted assignment summary</label>
+                            <p>
+                                Summarize the assignment's learning goals and expected outcome.
+                                This summary will replace instructions if a
+                                submitted response can be displayed publicly.
+                            </p>
+                            <div class="row">
+                                <div class="col-xs-12">
+                                    <textarea id="summary" name="summary" class="form-control mceEditor" placeholder="Assignment summary (optional)..." style="height: 100px; margin-top: 20px;">
+                                        {{form.instance.summary}}
+                                    </textarea>
+                                </div>
+                            </div>
                         </div>
                         <nav>
                             <ul class="pager">

--- a/mediathread/templates/projects/sequence_assignment_view.html
+++ b/mediathread/templates/projects/sequence_assignment_view.html
@@ -113,7 +113,28 @@
     <div class="clearfix"></div>
     <div class="spacer"></div>
 
-    {% if not read_only_view %}
+    {% if read_only_view %}
+        {% if assignment.summary|length > 0 %}
+            <div id="accordion" class="panel-group" role="tablist" aria-multiselectable="true">
+                <div class="panel panel-default">
+                    <div class="panel-heading" role="tab" id="headingOne">
+                        <h4 class="panel-title">
+                            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                                <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> Background
+                            </a>
+                        </h4>
+                    </div>
+                    <div id="collapseOne" class="panel-collapse collapse {% if show_instructions %}in{% endif %}" role="tabpanel" aria-labelledby="headingOne">
+                        <div class="panel-body">
+                            <p>
+                                {{assignment.summary|safe}}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    {% else %}
     <div id="accordion" class="panel-group" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">
             <div class="panel-heading" role="tab" id="headingOne">


### PR DESCRIPTION
For the sequence assignment project type, a new project `summary` field can be populated with general background information. The project summary replaces instructions for a response's public to world view.

<img width="1062" alt="screen shot 2017-03-03 at 11 19 08 am" src="https://cloud.githubusercontent.com/assets/141369/23558899/4e37d2ca-0003-11e7-80f4-9770207b6d35.png">

