### PR TITLE
django-contrib-comments 1.8.0 upgrade

### DIFF
--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -16,7 +16,7 @@ from django.views.generic.base import View
 import django_comments
 from django_comments.models import COMMENT_MAX_LENGTH
 from djangohelpers.lib import rendered_with, allow_http
-from threadedcomments import ThreadedComment
+from threadedcomments.models import ThreadedComment
 from threadedcomments.util import annotate_tree_properties, fill_tree
 
 from mediathread.api import UserResource

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,8 +48,8 @@ djangowind==0.16.1
 django-tagging==0.4.5
 django-reversion==1.9.3
 djangohelpers==0.18.2
-django-contrib-comments==1.7.3
-django-threadedcomments==1.0b1
+django-contrib-comments==1.8.0
+django-threadedcomments==1.1
 django-courseaffils==2.1.12
 django-statsd-mozilla==0.3.16
 raven==6.0.0


### PR DESCRIPTION
Required an upgrade to django-threadedcomments 1.1, and a small code change.