### PR TITLE
Enable sequence composition for all users

### DIFF
--- a/media/templates/homepage.mustache
+++ b/media/templates/homepage.mustache
@@ -77,13 +77,10 @@
             </form>
         {{/is_faculty}}
 
-        {{! TODO: remove is_superuser check when feature is ready }}
-        {{#is_superuser}}
         <form action="/project/create/" method="post" class="create-form">
         <input type="hidden" name="project_type" value="sequence"/>
         <input type="submit" value="Create Sequence" />
         </form>
-        {{/is_superuser}}
     </div>
 </div>
 


### PR DESCRIPTION
Note: sequence compositions don't have any requirements in order to be
save, so a user can publish an empty sequence to the world.

When viewing a public sequence composition that doesn't have a spine
video, the "Add a primary video" box appears, and the viewer can pick
the spine video! Honestly, I think this is a fine easter egg, because
no one is going to publish an empty sequence, share it with someone and
really need them to see an empty box.