### PR TITLE
Easier LTI Course Configuration

### DIFF
--- a/lti_auth/admin.py
+++ b/lti_auth/admin.py
@@ -1,4 +1,10 @@
 from django.contrib import admin
 from lti_auth.models import LTICourseContext
 
-admin.site.register(LTICourseContext)
+
+@admin.register(LTICourseContext)
+class AssetAdmin(admin.ModelAdmin):
+    class Meta:
+        model = LTICourseContext
+
+    list_display = ('group', 'faculty_group')

--- a/lti_auth/lti.py
+++ b/lti_auth/lti.py
@@ -65,6 +65,10 @@ class LTI(object):
 
         return []
 
+    def course_context(self):
+        if 'context_id' in self.lti_params:
+            return self.lti_params.get('context_id')
+
     def custom_course_context(self):
         """
         Returns the custom LTICourseContext id as provided by LTI

--- a/lti_auth/migrations/0005_auto_20170311_0832.py
+++ b/lti_auth/migrations/0005_auto_20170311_0832.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lti_auth', '0004_lticoursecontext_enable'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='lticoursecontext',
+            name='enable',
+        ),
+        migrations.RemoveField(
+            model_name='lticoursecontext',
+            name='uuid',
+        ),
+        migrations.AddField(
+            model_name='lticoursecontext',
+            name='lms_course_context',
+            field=models.TextField(unique=True, null=True),
+        ),
+    ]

--- a/lti_auth/models.py
+++ b/lti_auth/models.py
@@ -1,16 +1,12 @@
-import uuid
-
 from django.contrib.auth.models import Group
 from django.db import models
-from django.db.models.fields import UUIDField
 
 
 class LTICourseContext(models.Model):
     group = models.ForeignKey(Group, related_name='course_group')
     faculty_group = models.ForeignKey(Group,
                                       related_name='course_faculty_group')
-    uuid = UUIDField(default=uuid.uuid4, editable=False)
-    enable = models.BooleanField(default=False)
+    lms_course_context = models.TextField(null=True, unique=True)
 
     class Meta:
         unique_together = (('group', 'faculty_group'),)

--- a/lti_auth/tests/factories.py
+++ b/lti_auth/tests/factories.py
@@ -42,7 +42,7 @@ def generate_lti_request(course_context=None, provider=None, use=None):
 
     params = BASE_LTI_PARAMS.copy()
     if course_context:
-        params.update({'custom_course_context': course_context.uuid})
+        params.update({'context_id': course_context.lms_course_context})
     if provider:
         params.update({'tool_consumer_info_product_family_code': provider})
     if use:
@@ -90,3 +90,4 @@ class LTICourseContextFactory(factory.DjangoModelFactory):
 
     group = factory.SubFactory(GroupFactory)
     faculty_group = factory.SubFactory(GroupFactory)
+    lms_course_context = factory.Sequence(lambda n: 'lti%d' % n)

--- a/lti_auth/tests/test_lti.py
+++ b/lti_auth/tests/test_lti.py
@@ -3,9 +3,8 @@ from django.test.testcases import TestCase
 from pylti.common import LTI_SESSION_KEY, LTINotInSessionException
 
 from lti_auth.lti import LTI
-from lti_auth.models import LTICourseContext
 from lti_auth.tests.factories import BASE_LTI_PARAMS, CONSUMERS, \
-    generate_lti_request, LTICourseContextFactory
+    generate_lti_request
 
 
 class LTITest(TestCase):
@@ -45,30 +44,6 @@ class LTITest(TestCase):
 
         lti.lti_params = BASE_LTI_PARAMS
         self.assertEquals(lti.user_roles(), ['Instructor', 'Staff'])
-
-    def test_custom_course_context(self):
-        lti = LTI('initial', 'any')
-
-        with self.assertRaises(KeyError):
-            lti.custom_course_context()
-
-        lti.lti_params = BASE_LTI_PARAMS
-        lti.lti_params['custom_course_context'] = 434
-        with self.assertRaises(LTICourseContext.DoesNotExist):
-            lti.custom_course_context()
-
-        ctx = LTICourseContextFactory()
-        lti.lti_params['custom_course_context'] = 'abc'
-        with self.assertRaises(ValueError):
-            lti.custom_course_context()
-
-        lti.lti_params['custom_course_context'] = ctx.uuid
-        with self.assertRaises(LTICourseContext.DoesNotExist):
-            lti.custom_course_context()
-
-        ctx.enable = True
-        ctx.save()
-        self.assertEquals(lti.custom_course_context(), ctx)
 
     def test_consumers(self):
         lti = LTI('any', 'any')

--- a/lti_auth/urls.py
+++ b/lti_auth/urls.py
@@ -6,7 +6,8 @@ from lti_auth.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
 
 urlpatterns = [
     url(r'^config.xml$', LTIConfigView.as_view(), {}, 'lti-config'),
-    url(r'^landing/$', LTILandingPage.as_view(), {}, 'lti-landing-page'),
     url(r'^enable/$', LTICourseEnableView.as_view(), {}, 'lti-enable-course'),
+    url(r'^landing/(?P<context>\w[^/]*)/$',
+        LTILandingPage.as_view(), {}, 'lti-landing-page'),
     url(r'^$', LTIRoutingView.as_view(), {}, 'lti-login'),
 ]

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -190,8 +190,10 @@ LTI_TOOL_CONFIGURATION = {
     'launch_url': 'lti/',
     'embed_url': 'asset/embed/',
     'embed_icon_url': 'media/img/icons/icon-16.png',
-    'embed_tool_id': 'mediathread'
+    'embed_tool_id': 'mediathread',
+    'landing_url': '{}://{}/course/lti/{}/'
 }
+
 LTI_EXTRA_PARAMETERS = ['custom_course_context']
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')

--- a/mediathread/templates/courseaffils/course_update_form.html
+++ b/mediathread/templates/courseaffils/course_update_form.html
@@ -41,17 +41,6 @@
                 {% bootstrap_field form.allow_roster_changes %}
             </div>
         {% endif %}
-        <div class="well">
-            <h3>LTI</h3>
-            {% bootstrap_field form.lti_integration %}
-            {% if lti_context and lti_context.enable %}
-                <h5>Unique Course Identifier</h5>
-                <ol>
-                    <li>custom_course_context={{lti_context.uuid}}</li>
-                    <li><a href="https://github.com/ccnmtl/mediathread/wiki/LTI-Integration">Read full configuration instructions</a></li>
-                </ol>
-            {% endif %}
-        </div>
         <div class="form-group">
             <button class="btn btn-primary" type="submit">Save</button>
             <a href="." class="btn btn-default" role="button">Cancel</a>

--- a/mediathread/templates/lti_auth/fail_course_configuration.html
+++ b/mediathread/templates/lti_auth/fail_course_configuration.html
@@ -1,0 +1,67 @@
+{% load coursetags %}
+{% load methtags %}
+{% get_courses for user as courses %}
+<html>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="screen" />
+</head>
+<body>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="container">
+                <div class="well">
+                    <h2>Course Configuration</h2>
+                    {% if 'Administrator' in roles or 'Instructor' in roles or 'Staff' in roles %}
+                        {% if courses|length < 1 %}
+                            <p class="lead"><a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course</p>
+                        {% else %}
+                            <p class="lead">
+                            Connect a Mediathread course to your Canvas course.<br />
+                            Don't see your course? <a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course first.</p>
+
+                            <table class="table course-choices tablesorter">
+                                <thead>
+                                    <tr>
+                                        <th>Course Title</th>
+                                        <th>Term</th>
+                                        <th class="nosort">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for course in courses %}
+                                        {% if course.group.course_group.count < 1 %}
+                                            <tr>
+                                                <td>{{course.title}}</td>
+                                                <td>
+                                                    {% if course.info.termyear %}
+                                                        {{course.info.termyear}}
+                                                    {% elif course.to_dict %}
+                                                        {{course.to_dict.term|int_to_term}} {{course.to_dict.year}}
+                                                    {% endif %}
+                                                </td>
+                                                <td>
+                                                    <form action="{% url 'lti-enable-course' %}" method="post">
+                                                        <input type="hidden" name="group" value="{{course.group.id}}">
+                                                        <input type="hidden" name="faculty_group" value="{{course.faculty_group.id}}">
+                                                        <input type="hidden" name="lms_course" value="{{lms_course}}">
+                                                        <button type="submit">Connect</button>
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                         {% endif %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        {% endif %}
+                    {% else %}
+                        <p class="lead">
+                            Your {{title}} course has not been configured to use this component.<br />
+                            Contact your instructor for more information.</p>
+                        <p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div> 
+</body>
+</html>

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -31,7 +31,7 @@ from mediathread.main.views import (
     CourseRosterView, CoursePromoteUserView, CourseDemoteUserView,
     CourseRemoveUserView, CourseAddUserByUNIView,
     CourseInviteUserByEmailView, CourseAcceptInvitationView, ClearTestCache,
-    CourseResendInviteView, set_user_setting)
+    CourseResendInviteView, set_user_setting, LTICourseSelector)
 from mediathread.projects.views import (
     ProjectCollectionView, ProjectDetailView, ProjectItemView,
     ProjectPublicView)
@@ -153,9 +153,12 @@ urlpatterns = [
     url(r'^affil/(?P<pk>\d+)/activate/$',
         AffilActivateView.as_view(),
         name='affil_activate'),
+
     url(r'^course/list/$',
         MethCourseListView.as_view(),
         name='course_list'),
+    url(r'^course/lti/(?P<context>\w[^/]*)/$',
+        LTICourseSelector.as_view(), name='lti-course-select'),
 
     # Bookmarklet
     url(r'^accounts/logged_in.js$', IsLoggedInView.as_view(), {},


### PR DESCRIPTION
This pull request attempts to ease the path for Mediathread / LTI configuration by creating a connect course step from the LMS side to Mediathread. As an instructor, the steps will be:

1. Create a Mediathread course.
2. Add or Enable Mediathread in the LMS
3. Clicking on the Mediathread link the first time will show a Connect list. When Connect is clicked, the association between the LMS and Mediathread is created via the LTI context id.

Underneath the covers, this is accomplished by removing the LTI configuration step on the Mediathread side and creating a redirect view that sets the user's Mediathread course based on the LTI context id.