### PR TITLE
Swap out the LTI user identifier field

### DIFF
--- a/lti_auth/lti.py
+++ b/lti_auth/lti.py
@@ -29,8 +29,8 @@ class LTI(object):
              self.lti_params['user_id'])
 
     def user_identifier(self):
-        if 'lis_person_sourcedid' in self.lti_params:
-            return self.lti_params['lis_person_sourcedid']
+        if 'custom_canvas_user_login_id' in self.lti_params:
+            return self.lti_params['custom_canvas_user_login_id']
 
     def user_email(self):
         """

--- a/lti_auth/tests/test_auth.py
+++ b/lti_auth/tests/test_auth.py
@@ -45,7 +45,7 @@ class LTIBackendTest(TestCase):
     def test_find_or_create_user2(self):
         # via lms username
         username = 'uni123'
-        self.lti.lti_params['lis_person_sourcedid'] = username
+        self.lti.lti_params['custom_canvas_user_login_id'] = username
         user = UserFactory(username=username)
         self.assertEquals(self.backend.find_or_create_user(self.lti), user)
 


### PR DESCRIPTION
Use `custom_canvas_user_login_id` to find the user's UNI. TC and CU both use
this field.