### PR TITLE
SherdNote:tags - widen the field to 1024

### DIFF
--- a/mediathread/djangosherd/migrations/0004_auto_20170508_1434.py
+++ b/mediathread/djangosherd/migrations/0004_auto_20170508_1434.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import tagging.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangosherd', '0003_auto_20150721_1435'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sherdnote',
+            name='tags',
+            field=tagging.fields.TagField(max_length=1024, blank=True),
+        ),
+    ]

--- a/mediathread/djangosherd/models.py
+++ b/mediathread/djangosherd/models.py
@@ -322,7 +322,7 @@ class SherdNote(Annotation):
     title = models.CharField(blank=True, max_length=1024, null=True)
     asset = models.ForeignKey(Asset, related_name="sherdnote_set")
     author = models.ForeignKey(User, null=True, blank=True)
-    tags = TagField()
+    tags = TagField(max_length=1024)
     body = models.TextField(blank=True, null=True)
     added = models.DateTimeField('date created', editable=False,
                                  auto_now_add=True)


### PR DESCRIPTION
The base tagging library requires this to be a CharField. Widening the length so that an overflow is less likely.