### PR TITLE
Django 1.9.13

### DIFF
--- a/mediathread/assetmgr/models.py
+++ b/mediathread/assetmgr/models.py
@@ -47,7 +47,7 @@ class AssetManager(models.Manager):
 
     def migrate(self, assets, course, user, faculty, object_map,
                 include_tags, include_notes):
-        note_model = models.get_model('djangosherd', 'sherdnote')
+        from mediathread.djangosherd.models import SherdNote
         for old_asset in assets:
             if old_asset.id not in object_map['assets']:
                 new_asset = Asset.objects.migrate_one(old_asset,
@@ -56,7 +56,7 @@ class AssetManager(models.Manager):
 
                 object_map['assets'][old_asset.id] = new_asset
 
-                notes = note_model.objects.get_related_notes(
+                notes = SherdNote.objects.get_related_notes(
                     [old_asset], None, faculty, True)
 
                 # remove all extraneous global annotations
@@ -64,7 +64,7 @@ class AssetManager(models.Manager):
 
                 for old_note in notes:
                     if (old_note.id not in object_map['notes']):
-                        new_note = note_model.objects.migrate_one(
+                        new_note = SherdNote.objects.migrate_one(
                             old_note, new_asset, user,
                             include_tags, include_notes)
                         object_map['notes'][old_note.id] = new_note
@@ -239,9 +239,9 @@ class Asset(models.Model):
         return tags
 
     def global_annotation(self, user, auto_create=True):
-        note_model = models.get_model('djangosherd', 'sherdnote')
-        return note_model.objects.global_annotation(self, user,
-                                                    auto_create=auto_create)[0]
+        from mediathread.djangosherd.models import SherdNote
+        return SherdNote.objects.global_annotation(self, user,
+                                                   auto_create=auto_create)[0]
 
     def media_type(self):
         label = 'video'
@@ -261,8 +261,8 @@ class Asset(models.Model):
         is tagging the asset .. though it'd be nicer to return
         whether this function actually did anything.
         """
-        note_model = models.get_model('djangosherd', 'sherdnote')
-        bucket, created = note_model.objects.global_annotation(self, user)
+        from mediathread.djangosherd.models import SherdNote
+        bucket, created = SherdNote.objects.global_annotation(self, user)
         bucket.add_tag(tag)
         bucket.save()
         return created

--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -245,7 +245,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         response = self.client.get('/asset/most_recent/', {}, follow=True)
         self.assertEquals(response.status_code, 200)
 
-        url = 'http://testserver/asset/%s/' % asset1.id
+        url = '/asset/%s/' % asset1.id
         self.assertEquals(response.redirect_chain, [(url, 302)])
 
     def test_asset_delete(self):
@@ -459,7 +459,7 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
             asset = Asset.objects.get(title="Test Video")
             self.assertRedirects(
                 response,
-                "http://testserver/accounts/login/?next=/asset/%s/" % asset.id,
+                "/accounts/login/?next=/asset/%s/" % asset.id,
                 status_code=302,
                 target_status_code=200)
             self.assertEquals(asset.author.username, self.student_one.username)

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -156,7 +156,7 @@ class AssetCreateView(View):
         returns a dict of sources represented in GET/POST args
         '''
         sources = {}
-        args = request.REQUEST
+        args = request.POST if request.method == 'POST' else request.GET
         for key, val in args.items():
             if cls.good_asset_arg(key) and val != '' and len(val) < 4096:
                 source = Source(label=key, url=val)
@@ -190,9 +190,9 @@ class AssetCreateView(View):
 
     def parse_user(self, request):
         user = request.user
-        if ((user.is_staff or CourseAccess.allowed(request)) and
-                'as' in request.REQUEST):
-            as_user = request.REQUEST['as']
+        args = request.POST if request.method == 'POST' else request.GET
+        if ((user.is_staff or CourseAccess.allowed(request)) and 'as' in args):
+            as_user = args['as']
             user = get_object_or_404(User, username=as_user)
 
         return user

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
-from django.db import models
 from django.http import HttpResponse, HttpResponseForbidden, \
     HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -244,9 +243,9 @@ def threaded_comment_citations(all_comments, viewer):
     citation references to sherdnotes
     """
     citations = []
-    the_model = models.get_model('djangosherd', 'SherdNote')
+    from mediathread.djangosherd.models import SherdNote
     for obj in all_comments:
-        refs = the_model.objects.references_in_string(obj.comment, viewer)
+        refs = SherdNote.objects.references_in_string(obj.comment, viewer)
         citations.extend(refs)
     return citations
 

--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -272,7 +272,7 @@ class DashboardSettingsForm(forms.ModelForm):
 
         cleaned_data = super(DashboardSettingsForm, self).clean()
         title = cleaned_data.get('title')
-        if title.strip() == '':
+        if title is None or title.strip() == '':
             self.add_error('title', 'Title can\'t be blank.')
 
         return cleaned_data

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
 import reversion
+from reversion.models import Version
 from threadedcomments.models import ThreadedComment
 
 from mediathread.assetmgr.models import Asset
@@ -638,14 +639,14 @@ class Project(models.Model):
 
     def latest_version(self):
         try:
-            version = reversion.get_for_object(self).get_unique().next()
+            version = Version.objects.get_for_object(self).get_unique().next()
             return version.revision_id
         except StopIteration:
             return None
 
     def versions(self):
         # all previous versions, latest versions first, duplicates removed
-        return reversion.get_for_object(self).get_unique()
+        return Version.objects.get_for_object(self).get_unique()
 
 
 reversion.register(Project)

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
 import reversion
+from reversion.models import Version
 
 from mediathread.factories import MediathreadTestMixin, UserFactory, \
     AssetFactory, SherdNoteFactory, ProjectFactory, AssignmentItemFactory, \
@@ -121,7 +122,8 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(response.status_code, 405)
 
     def test_project_save_valid(self):
-        versions = reversion.get_for_object(self.project_private).get_unique()
+        versions = Version.objects.get_for_object(
+            self.project_private).get_unique()
         self.assertEquals(sum(1 for v in versions), 1)
 
         self.assertTrue(self.client.login(username=self.student_one.username,
@@ -150,7 +152,8 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertIn(self.student_one, project.participants.all())
         self.assertIn(self.student_two, project.participants.all())
 
-        versions = reversion.get_for_object(self.project_private).get_unique()
+        versions = Version.objects.get_for_object(
+            self.project_private).get_unique()
         self.assertEquals(sum(1 for v in versions), 2)
 
     def test_project_save_swap_authors(self):
@@ -212,12 +215,12 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         response = self.client.post('/project/create/', data, follow=True)
         self.assertEquals(response.status_code, 200)
         self.assertTrue(response.redirect_chain[0][0].startswith(
-            'http://testserver/project/view/'))
+            '/project/view/'))
 
         project = Project.objects.get(course=self.sample_course,
                                       title='Untitled')
 
-        versions = reversion.get_for_object(project).get_unique()
+        versions = Version.objects.get_for_object(project).get_unique()
         self.assertEquals(sum(1 for v in versions), 1)
         self.assertIsNone(project.date_submitted)
         self.assertIn(self.student_one, project.participants.all())
@@ -235,7 +238,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
 
         project = Project.objects.get(title='Student Essay')
 
-        versions = reversion.get_for_object(project).get_unique()
+        versions = Version.objects.get_for_object(project).get_unique()
         self.assertEquals(sum(1 for v in versions), 2)
         self.assertIsNotNone(project.date_submitted)
 
@@ -395,7 +398,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         response = self.client.post(url, data, follow=True)
         self.assertEquals(response.status_code, 200)
         self.assertTrue(response.redirect_chain[0][0].startswith(
-            'http://testserver/project/view/'))
+            '/project/view/'))
 
         assignment_response = Project.objects.get(id=assignment_response.id)
         self.assertFalse(assignment_response.is_submitted())

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -237,7 +237,7 @@ def project_revisions(request, project_id):
     data = {'revisions': []}
     fmt = "%m/%d/%y %I:%M %p"
     for v in project.versions():
-        author = User.objects.get(id=v.field_dict['author'])
+        author = User.objects.get(id=v.field_dict['author_id'])
         data['revisions'].append({
             'version_number': v.revision_id,
             'versioned_id': v.object_id,

--- a/mediathread/taxonomy/urls.py
+++ b/mediathread/taxonomy/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
         taxonomy_workspace,
         name='taxonomy-workspace'),
 
-    url(r'^/(?P<vocabulary_id>\d+)/$',
+    url(r'^(?P<vocabulary_id>\d+)/$',
         taxonomy_workspace,
         name='taxonomy-workspace-view')
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.8.18
+Django==1.9.13
 psycopg2==2.7.1
 #for MySQL: MySQL-python==1.2.5
 statsd==3.2.1
@@ -51,7 +51,7 @@ rjsmin==1.0.12
 
 djangowind==1.0.0
 django-tagging==0.4.5
-django-reversion==1.9.3
+django-reversion==2.0.8
 djangohelpers==0.18.2
 django-contrib-comments==1.8.0
 django-threadedcomments==1.1

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -2,7 +2,7 @@ import importlib
 
 from django.conf import settings
 from django.contrib.auth.models import User, Group
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core import urlresolvers
 from django.db import models
@@ -66,8 +66,8 @@ class Collaboration(models.Model):
     object_pk = models.CharField(_('object ID'), max_length=255,
                                  null=True, blank=True)
 
-    content_object = generic.GenericForeignKey(ct_field="content_type",
-                                               fk_field="object_pk")
+    content_object = GenericForeignKey(ct_field="content_type",
+                                       fk_field="object_pk")
 
     policy_record = models.ForeignKey(CollaborationPolicyRecord,
                                       null=True, default=None, blank=True)

--- a/terrain.py
+++ b/terrain.py
@@ -19,9 +19,6 @@ from selenium.webdriver.support.expected_conditions import (
     visibility_of, presence_of_element_located)
 from selenium.webdriver.support.ui import WebDriverWait
 
-from mediathread.assetmgr.models import Asset
-from mediathread.factories import MediathreadTestMixin
-from mediathread.projects.models import Project
 import selenium.webdriver.support.ui as ui
 
 
@@ -46,6 +43,7 @@ def reset_database(variables):
     world.browser.get(django.django_url("/test/clear/"))
 
     # add the sample course and some user data by default
+    from mediathread.factories import MediathreadTestMixin
     world.mixin = MediathreadTestMixin()
     world.mixin.setup_sample_course()
 
@@ -737,6 +735,7 @@ def i_write_some_text_for_the_panel(step, panel):
 
 @step(u'the composition "([^"]*)" has text')
 def the_composition_title_has_text(step, title):
+    from mediathread.projects.models import Project
     project = Project.objects.get(title=title)
 
     if len(project.body) < 1:
@@ -1076,6 +1075,7 @@ def get_column(title):
 
 @step(u'When I view the "([^"]*)" asset')
 def when_i_view_the_title_asset(step, title):
+    from mediathread.assetmgr.models import Asset
     item = Asset.objects.filter(title=title).first()
     url = reverse('asset-view', kwargs={'asset_id': item.id})
     world.browser.get(django.django_url(url))


### PR DESCRIPTION
* replace get_model references with inline imports
* replace reversion.get_for_object method with Version.object.get_for_object
* tests - 'testserver' is no longer prefixed in the redirect_chain
* replace request.REQUEST with inline search of GET and POST