### PR TITLE
Discussion: work around HTML5 validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: jenkins
 include *.mk
 
 harvest1: $(PY_SENTINAL)
-	$(MANAGE) harvest --settings=$(APP).settings_test --failfast -v 3 -a mediathread.main,mediathread.assetmgr,mediathread.taxonomy
+	$(MANAGE) harvest --settings=$(APP).settings_test --failfast -v 3 -a mediathread.main,mediathread.assetmgr,mediathread.taxonomy,mediathread.discussions
 
 harvest2: $(PY_SENTINAL)
 	$(MANAGE) harvest --settings=$(APP).settings_test --failfast -v 3 -a mediathread.projects

--- a/media/templates/discussion.mustache
+++ b/media/templates/discussion.mustache
@@ -65,7 +65,7 @@
                                         {{/close}}
                                 {{/context.discussion.thread}}
                             {{/context.discussion.thread.length}}
-                            <form style="display: none" method="POST" action="/comments/post/" class="threaded_comments_form" data-maxlength="{{context.discussion.max_length}}">
+                            <form novalidate style="display: none" method="POST" action="/comments/post/" class="threaded_comments_form" data-maxlength="{{context.discussion.max_length}}">
                                 <h3 style="display: none">Respond</h3>
                                 <input type="hidden" id="comment-edit-id" name="edit-id" />
                                 <script type="text/javascript" src="{{#staticUrl}}{{/staticUrl}}js/app/tinymce_init.js"></script>

--- a/mediathread/discussions/features/discussions.feature
+++ b/mediathread/discussions/features/discussions.feature
@@ -1,0 +1,24 @@
+Feature: Discussion View
+
+    Scenario: discussion.feature 1. Create a discussion
+        Using selenium
+        Given I am instructor_one in Sample Course
+
+        There is a Create button
+        When I click the Create button
+
+        When I click the Create Discussion button
+        Then I am at the Discussion page
+
+        When I click the Save Comment button
+
+        Then there is a Respond button
+        And there is an Edit button
+
+        When I click the "Sample Course" link
+        Given the home workspace is loaded
+        There is a "Discussion Title" link
+        When I click the "Discussion Title" link
+        Then I am at the Discussion page
+
+        Finished using Selenium

--- a/mediathread/main/features/instructor.feature
+++ b/mediathread/main/features/instructor.feature
@@ -46,25 +46,7 @@ Feature: Instructor Dashboard
 
         Finished using Selenium
 
-    Scenario: instructor_dashboard.feature 3. Test Create Discussion
-        Using selenium
-        Given there is a sample response
-        Given I am instructor_one in Sample Course
-
-        There is a Create button
-        When I click the Create button
-
-        When I click the Create Discussion button
-        Then I am at the Discussion page
-        When I click the "Sample Course" link
-        Given the home workspace is loaded
-        There is a "Discussion Title" link
-        When I click the "Discussion Title" link
-        Then I am at the Discussion page
-
-        Finished using Selenium
-
-    Scenario: instructor_dashboard.feature 4. Test Create Composition
+    Scenario: instructor_dashboard.feature 3. Test Create Composition
         Using selenium
         Given there is a sample response
         Given I am instructor_one in Sample Course
@@ -88,7 +70,7 @@ Feature: Instructor Dashboard
 
         Finished using Selenium
 
-    Scenario: instructor_dashboard.feature 5. Test Assignment Responses
+    Scenario: instructor_dashboard.feature 4. Test Assignment Responses
         Using selenium
         Given there is a sample response
         Given I am instructor_one in Sample Course
@@ -110,7 +92,7 @@ Feature: Instructor Dashboard
 
         Finished using Selenium
 
-    Scenario: instructor_dashboard.feature 6. Student Contributions
+    Scenario: instructor_dashboard.feature 5. Student Contributions
         Using selenium
         Given there is a sample response
         Given I am instructor_one in Sample Course

--- a/mediathread/settings_test.py
+++ b/mediathread/settings_test.py
@@ -22,9 +22,10 @@ BROWSER = 'Headless'
 LETTUCE_SERVER_PORT = 8002
 
 LETTUCE_APPS = (
+    'mediathread.assetmgr',
+    'mediathread.discussions',
     'mediathread.main',
     'mediathread.projects',
-    'mediathread.assetmgr',
     'mediathread.taxonomy'
 )
 


### PR DESCRIPTION
Google Chrome prevents discussion form submission due to a hidden required field. The error looks like so:

```An invalid form control with name='name' is not focusable.```

As the form doesn't rely on validation and changing the behavior would require a dive into the django_comments library, I'm simply adding "novalidate" to the form. This resolve the error.

Selenium tests unfortunately didn't catch this one as the behavior appears to be Google Chrome specific. But, I've done a little work to expand on the discussion tests.