### PR TITLE
LTI: style the embed view for images and video

### DIFF
--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4734,12 +4734,17 @@ ul.section-tabs>li>a.active {
     text-align: left;
 }
 
+.lti-asset-view .videoclipbox {
+    background-color: #f8f8f8;
+    border: 1px solid #e7e7e7;
+    border-radius: 4px;
+}
+
 .lti-asset-view .videoclipbox-metadata {
-    background-color: black;
-    color: white;
-    height: 35px;
+    color: #777; 
+    height: 55px;
     padding: 8px;
-    font-size: 16px;
+    font-size: 18px;
 }
 
 .lti-asset-view .videoclipbox-metadata .title {
@@ -4748,15 +4753,11 @@ ul.section-tabs>li>a.active {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 300px;
-    height: 27px;
+    height: 37px;
+    font-weight: bold;
 }
 
-.lti-asset-view .clipplay-container {
-    cursor: pointer;
-    padding: 4px 6px;
-    margin: -5px 0 0 5px;
-}
-
-.lti-asset-view .glyphicon-play {
-    margin: -2px 0 0 4px;
+.lti-asset-view .videoclipbox-metadata .timecode {
+    font-weight: normal;
+    margin-top: 8px;
 }

--- a/media/css/mediathread.css
+++ b/media/css/mediathread.css
@@ -4724,3 +4724,39 @@ ul.section-tabs>li>a.active {
 #sequence.submitted .jux-playhead-line {
     height: 10px;
 }
+
+/* LTI Asset View */
+.lti-asset-view .flowplayer-timedisplay {
+    display: none;
+}
+
+.lti-asset-view .asset-display {
+    text-align: left;
+}
+
+.lti-asset-view .videoclipbox-metadata {
+    background-color: black;
+    color: white;
+    height: 35px;
+    padding: 8px;
+    font-size: 16px;
+}
+
+.lti-asset-view .videoclipbox-metadata .title {
+    margin: 0 6px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 300px;
+    height: 27px;
+}
+
+.lti-asset-view .clipplay-container {
+    cursor: pointer;
+    padding: 4px 6px;
+    margin: -5px 0 0 5px;
+}
+
+.lti-asset-view .glyphicon-play {
+    margin: -2px 0 0 4px;
+}

--- a/media/js/lib/sherdjs/src/video/annotators/clipplay.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipplay.js
@@ -50,11 +50,8 @@ if (!Sherd.Video.Annotators.ClipPlay) {
         this.microformat.create = function (obj) {
             return {
                 htmlID: 'play-selection',
-                text: '<button class="btn btn-sm btn-default"' +
-                    'id="play-selection">' +
-                    'Play Selection ' +
-                    '<span class="glyphicon glyphicon-play" ' +
-                    'aria-hidden="true"></span></button>'
+                text: '<span id="play-selection" class="glyphicon glyphicon-play" ' +
+                    'aria-hidden="true"></span>'
             };
         };
 

--- a/media/js/lib/sherdjs/src/video/annotators/clipplay.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipplay.js
@@ -50,8 +50,11 @@ if (!Sherd.Video.Annotators.ClipPlay) {
         this.microformat.create = function (obj) {
             return {
                 htmlID: 'play-selection',
-                text: '<span id="play-selection" class="glyphicon glyphicon-play" ' +
-                    'aria-hidden="true"></span>'
+                text: '<button class="btn btn-sm btn-default"' +
+                    'id="play-selection">' +
+                    'Play Selection ' +
+                    '<span class="glyphicon glyphicon-play" ' +
+                    'aria-hidden="true"></span></button>'
             };
         };
 

--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -13,6 +13,7 @@ from django.test.client import RequestFactory
 
 from mediathread.assetmgr.models import Asset, ExternalCollection
 from mediathread.assetmgr.views import (
+    EMBED_WIDTH, EMBED_HEIGHT,
     asset_workspace_courselookup,
     RedirectToExternalCollectionView,
     RedirectToUploaderView, AssetCreateView, AssetEmbedListView,
@@ -717,8 +718,8 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
 
         view = AssetEmbedListView()
         dims = view.get_dimensions(primary)
-        self.assertEquals(dims['width'], view.EMBED_IMAGE_WIDTH)
-        self.assertEquals(dims['height'], view.EMBED_IMAGE_WIDTH)
+        self.assertEquals(dims['width'], EMBED_WIDTH)
+        self.assertEquals(dims['height'], EMBED_HEIGHT)
 
         # set a width/height
         primary.width = 400
@@ -726,8 +727,8 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
         primary.save()
 
         dims = view.get_dimensions(primary)
-        self.assertEquals(dims['width'], view.EMBED_IMAGE_WIDTH)
-        self.assertEquals(dims['height'], 400)
+        self.assertEquals(dims['width'], EMBED_WIDTH)
+        self.assertEquals(dims['height'], 425)
 
     def test_get_dimensions_video(self):
         asset = AssetFactory.create(
@@ -737,8 +738,8 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
 
         view = AssetEmbedListView()
         dims = view.get_dimensions(asset.primary)
-        self.assertEquals(dims['width'], view.EMBED_VIDEO_WIDTH)
-        self.assertEquals(dims['height'], view.EMBED_VIDEO_HEIGHT)
+        self.assertEquals(dims['width'], EMBED_WIDTH)
+        self.assertEquals(dims['height'], EMBED_HEIGHT)
 
     def test_get_secret(self):
         secrets = {'http://testserver/': 'testing'}
@@ -800,7 +801,7 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
             self.assertTrue('item' in ctx)
             self.assertEquals(ctx['item_id'], asset.id)
             self.assertEquals(ctx['selection_id'], note.id)
-            self.assertEquals(ctx['presentation'], 'gallery')
+            self.assertEquals(ctx['presentation'], 'medium')
             self.assertEquals(ctx['title'], 'Selection')
 
 

--- a/mediathread/templates/assetmgr/asset_embed_view.html
+++ b/mediathread/templates/assetmgr/asset_embed_view.html
@@ -16,13 +16,18 @@
     {% endcompress %}
 </head>
 
-<body>
-    <h3>{{title}}</h3>
-    {% if timecode %}
-        <p>{{timecode}}</p>
-    {% endif %}
+<body class="lti-asset-view">
     <div id="videoclipbox" class="videoclipbox" style="display: none;">
-        <div class="clipplay"></div><br />
+        <div class="videoclipbox-metadata">
+            <img class="pull-left" src='{% static "img/icons/icon-16.png" %}' alt_text="mediathread icon" />
+            <div class="title pull-left">{{title}}</div>
+            {% if timecode %}
+            <div class="clipplay-container pull-right">
+                {{timecode}} <div class="clipplay pull-right"></div>
+            </div>
+            {% endif %}
+        </div>
+
         <div class="asset-object" style="border: none; background-color: #ededed;"></div>
         <div class="asset-display"></div>
         <div class="clipstrip-display"></div>
@@ -52,7 +57,7 @@
                 {% endif %}
                 'autoplay': false,
                 'winHeight': function() {
-                    return 200;
+                    return {{defaultHeight}} - 50
                 }
             });
 

--- a/mediathread/templates/assetmgr/asset_embed_view.html
+++ b/mediathread/templates/assetmgr/asset_embed_view.html
@@ -16,16 +16,24 @@
     {% endcompress %}
 </head>
 
-<body class="lti-asset-view">
+<body class="lti-asset-view" style="width: 480px; height: 425px;">
     <div id="videoclipbox" class="videoclipbox" style="display: none;">
         <div class="videoclipbox-metadata">
-            <img class="pull-left" src='{% static "img/icons/icon-16.png" %}' alt_text="mediathread icon" />
-            <div class="title pull-left">{{title}}</div>
-            {% if timecode %}
-            <div class="clipplay-container pull-right">
-                {{timecode}} <div class="clipplay pull-right"></div>
+            <div>
+                <img class="pull-left" src='{% static "img/icons/icon-16.png" %}' alt_text="mediathread icon" />
+                <div class="title pull-left" title="{{title}}">
+                    {{title}}
+                    {% if timecode %}
+                        <br />
+                        <div class="timecode small">
+                            {{timecode}}
+                        </div>
+                    {% endif %}
+                 </div>
+                {% if timecode %}
+                     <div class="clipplay pull-right"></div>
+                {% endif %}
             </div>
-            {% endif %}
         </div>
 
         <div class="asset-object" style="border: none; background-color: #ededed;"></div>

--- a/mediathread/templates/lti_auth/landing_page.html
+++ b/mediathread/templates/lti_auth/landing_page.html
@@ -3,6 +3,7 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="screen" />
     </head>
     <body>
+        <div class="container-fluid">
         <div class="row">
             <div class="col-md-12">
                 <div class="container">
@@ -15,6 +16,7 @@
                     </div>
                 </div>
             </div>
+        </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
* Add Mediathread icon, title & clip time at the top of a gray nav bar
* Move the "Play Selection" button up to the top nav.
* Fiddle with dimensions to ensure no scrollbars pop up.

<img width="492" alt="screen shot 2017-06-03 at 11 28 14 am" src="https://cloud.githubusercontent.com/assets/141369/26754829/f2c9d664-484f-11e7-9f9e-3114d55699a2.png">



