### PR TITLE
Resolve AttributeError: 'Version' object has no attribute 'object_ver…

### DIFF
--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -477,8 +477,13 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
 
         # ajax
         response = self.client.get(url, {},
-                                   HTTP_X_REQUESTED_WITH='XmlHttpRequest')
+                                   HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
+
+        the_json = json.loads(response.content)
+        self.assertTrue('panels' in the_json)
+        self.assertEquals(the_json['panels'][0]['panel_state_label'],
+                          'Version View')
 
     def test_project_public_view(self):
         url = self.project_private.get_collaboration().get_absolute_url()

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -371,7 +371,7 @@ class ProjectReadOnlyView(ProjectReadableMixin, JSONResponseMixin,
                 version = get_object_or_404(Version,
                                             object_id=str(project.id),
                                             revision_id=version_number)
-                project = version.object_version.object
+                project = version._object_version.object
 
             panels = []
 


### PR DESCRIPTION
…sion'

A reversion upgrade introduced a breaking change.