### PR TITLE
LTI Course Create

### DIFF
--- a/lti_auth/lti.py
+++ b/lti_auth/lti.py
@@ -69,6 +69,14 @@ class LTI(object):
         if 'context_id' in self.lti_params:
             return self.lti_params.get('context_id')
 
+    def course_title(self):
+        if 'context_title' in self.lti_params:
+            return self.lti_params.get('context_title')
+
+    def canvas_domain(self):
+        if 'custom_canvas_api_domain' in self.lti_params:
+            return self.lti_params.get('custom_canvas_api_domain')
+
     def custom_course_context(self):
         """
         Returns the custom LTICourseContext id as provided by LTI

--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -44,13 +44,19 @@ class LTIAuthMixin(object):
             ctx = LTICourseContext.objects.get(
                 lms_course_context=lti.course_context())
         except (KeyError, ValueError, LTICourseContext.DoesNotExist):
+            autocreate_course = (
+                lti.canvas_domain() in
+                settings.LTI_TOOL_CONFIGURATION['autocreate_course'])
+
             return render(
                 request,
                 'lti_auth/fail_course_configuration.html',
                 {
                     'roles': lti.user_roles(),
                     'user': user,
-                    'lms_course': lti.course_context()
+                    'lms_course': lti.course_context(),
+                    'lms_course_title': lti.course_title(),
+                    'autocreate_course': autocreate_course
                 })
 
         # add user to the course

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -193,7 +193,8 @@ LTI_TOOL_CONFIGURATION = {
     'embed_url': 'asset/embed/',
     'embed_icon_url': 'img/icons/icon-16.png',
     'embed_tool_id': 'mediathread',
-    'landing_url': '{}://{}/course/lti/{}/'
+    'landing_url': '{}://{}/course/lti/{}/',
+    'autocreate_course': []
 }
 
 LTI_EXTRA_PARAMETERS = ['custom_course_context']

--- a/mediathread/templates/lti_auth/fail_course_configuration.html
+++ b/mediathread/templates/lti_auth/fail_course_configuration.html
@@ -11,19 +11,35 @@
             <div class="container">
                 <div class="well">
                     <h2>Course Configuration</h2>
-                    {% if courses|length < 1 %}
-                        {% if 'Administrator' in roles or 'Instructor' in roles or 'Staff' in roles %}
-                            <p class="lead"><a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course</p>
-                        {% else %}
-                            <p class="lead">
-                                Your {{title}} course has not been configured to use this component.<br />
-                                Contact your instructor for more information.</p>
-                            <p>
-                        {% endif %}
+
+                    {% if autocreate_course %}
+                         {% if 'Administrator' in roles or 'Instructor' in roles or 'Staff' in roles %}
+                            <form action="{% url 'lti-course-create' %}" method='POST'>
+                                <input type="hidden" name="lms_course" value="{{lms_course}}">
+                                <input type="hidden" name="lms_course_title" value="{{lms_course_title}}">
+                                <button type="submit" class="btn btn-primary">Connect New Course</button>
+                            </form>
+                         {% endif %}
                     {% else %}
+                        {% if courses|length < 1 %}
+                            {% if 'Administrator' in roles or 'Instructor' in roles or 'Staff' in roles %}
+                                <p class="lead"><a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course</p>
+                            {% else %}
+                                <p class="lead">
+                                    Your {{title}} course has not been configured to use this component.<br />
+                                    Contact your instructor for more information.</p>
+                                <p>
+                            {% endif %}
+                        {% endif %}
+                    {% endif %}
+
+                    {% if courses|length > 0 %} 
                         <p class="lead">
-                        Connect a Mediathread course to your Canvas course.<br />
-                        Don't see your course? <a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course first.</p>
+                        Connect an existing Mediathread course to your Canvas course.<br />
+
+                        {% if not autocreate_course %}
+                            Don't see your course? <a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course first.</p>
+                        {% endif %}
 
                         <table class="table course-choices tablesorter">
                             <thead>

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -32,7 +32,8 @@ from mediathread.main.views import (
     CourseRosterView, CoursePromoteUserView, CourseDemoteUserView,
     CourseRemoveUserView, CourseAddUserByUNIView,
     CourseInviteUserByEmailView, CourseAcceptInvitationView, ClearTestCache,
-    CourseResendInviteView, set_user_setting, LTICourseSelector)
+    CourseResendInviteView, set_user_setting,
+    LTICourseSelector, LTICourseCreate)
 from mediathread.projects.views import (
     ProjectCollectionView, ProjectDetailView, ProjectItemView,
     ProjectPublicView)
@@ -158,6 +159,8 @@ urlpatterns = [
     url(r'^course/list/$',
         MethCourseListView.as_view(),
         name='course_list'),
+    url(r'^course/lti/create/$',
+        LTICourseCreate.as_view(), name='lti-course-create'),
     url(r'^course/lti/(?P<context>\w[^/]*)/$',
         LTICourseSelector.as_view(), name='lti-course-select'),
 


### PR DESCRIPTION
Allow administrators, instructors and staff to autocreate their course in
specific cases. Settings control which domain can autocreate.