### PR TITLE
LTI: automatic course provisioning

### DIFF
--- a/lti_auth/lti.py
+++ b/lti_auth/lti.py
@@ -80,6 +80,10 @@ class LTI(object):
         if 'context_title' in self.lti_params:
             return self.lti_params.get('context_title')
 
+    def sis_course_id(self):
+        if 'lis_course_offering_sourcedid' in self.lti_params:
+            return self.lti_params.get('lis_course_offering_sourcedid')
+
     def canvas_domain(self):
         if 'custom_canvas_api_domain' in self.lti_params:
             return self.lti_params.get('custom_canvas_api_domain')

--- a/lti_auth/templates/lti_auth/fail_course_configuration.html
+++ b/lti_auth/templates/lti_auth/fail_course_configuration.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <title>Course Configuration</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="screen" />
 </head>
 <body>

--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -45,10 +45,6 @@ class LTIAuthMixin(object):
             ctx = LTICourseContext.objects.get(
                 lms_course_context=lti.course_context())
         except (KeyError, ValueError, LTICourseContext.DoesNotExist):
-            autocreate_course = (
-                lti.canvas_domain() in
-                settings.LTI_TOOL_CONFIGURATION['autocreate_course'])
-
             return render(
                 request,
                 'lti_auth/fail_course_configuration.html',
@@ -58,7 +54,7 @@ class LTIAuthMixin(object):
                     'user': user,
                     'lms_course': lti.course_context(),
                     'lms_course_title': lti.course_title(),
-                    'autocreate_course': autocreate_course
+                    'sis_course_id': lti.sis_course_id(),
                 })
 
         # add user to the course

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1586,43 +1586,47 @@ class LTICourseSelectorTest(MediathreadTestMixin, TestCase):
 class LTICourseCreateTest(TestCase):
 
     def test_post_sis_course_id(self):
-        user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        with self.settings(
+                COURSEAFFILS_COURSESTRING_MAPPER=CourseStringMapper):
+            user = UserFactory()
+            self.client.login(username=user.username, password='test')
 
-        data = {
-            'lms_course': '1234',
-            'lms_course_title': 'LTI Course',
-            'sis_course_id': 'SOCWT7113_010_2017_3'
-        }
-        response = self.client.post(reverse('lti-course-create'), data)
-        self.assertEqual(response.status_code, 302)
+            data = {
+                'lms_course': '1234',
+                'lms_course_title': 'LTI Course',
+                'sis_course_id': 'SOCWT7113_010_2017_3'
+            }
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
 
-        c = Course.objects.get(title='LTI Course')
-        self.assertEquals(c.group.name,
-                          't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
-        self.assertEquals(c.faculty_group.name,
-                          't3.y2017.s010.ct7113.socw.fc.course:columbia.edu')
+            c = Course.objects.get(title='LTI Course')
+            self.assertEquals(
+                c.group.name,
+                't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
+            self.assertEquals(
+                c.faculty_group.name,
+                't3.y2017.s010.ct7113.socw.fc.course:columbia.edu')
 
-        self.assertEquals(c.info.term, 3)
-        self.assertEquals(c.info.year, 2017)
+            self.assertEquals(c.info.term, 3)
+            self.assertEquals(c.info.year, 2017)
 
-        self.assertTrue(user in c.group.user_set.all())
-        self.assertTrue(user in c.faculty_group.user_set.all())
+            self.assertTrue(user in c.group.user_set.all())
+            self.assertTrue(user in c.faculty_group.user_set.all())
 
-        LTICourseContext.objects.get(
-            lms_course_context='1234',
-            group=c.group, faculty_group=c.faculty_group)
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
 
-        # try this again and make sure there is no duplication
-        data['lms_course_title'] = 'LTI Course With More Detail'
-        response = self.client.post(reverse('lti-course-create'), data)
-        self.assertEqual(response.status_code, 302)
-        Course.objects.get(title='LTI Course')
-        Group.objects.get(name=c.group.name)
-        Group.objects.get(name=c.faculty_group.name)
-        LTICourseContext.objects.get(
-            lms_course_context='1234',
-            group=c.group, faculty_group=c.faculty_group)
+            # try this again and make sure there is no duplication
+            data['lms_course_title'] = 'LTI Course With More Detail'
+            response = self.client.post(reverse('lti-course-create'), data)
+            self.assertEqual(response.status_code, 302)
+            Course.objects.get(title='LTI Course')
+            Group.objects.get(name=c.group.name)
+            Group.objects.get(name=c.faculty_group.name)
+            LTICourseContext.objects.get(
+                lms_course_context='1234',
+                group=c.group, faculty_group=c.faculty_group)
 
     def test_post_course_context(self):
         user = UserFactory()

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1585,13 +1585,53 @@ class LTICourseSelectorTest(MediathreadTestMixin, TestCase):
 
 class LTICourseCreateTest(TestCase):
 
-    def test_post(self):
+    def test_post_sis_course_id(self):
         user = UserFactory()
         self.client.login(username=user.username, password='test')
 
         data = {
             'lms_course': '1234',
-            'lms_course_title': 'LTI Course'
+            'lms_course_title': 'LTI Course',
+            'sis_course_id': 'SOCWT7113_010_2017_3'
+        }
+        response = self.client.post(reverse('lti-course-create'), data)
+        self.assertEqual(response.status_code, 302)
+
+        c = Course.objects.get(title='LTI Course')
+        self.assertEquals(c.group.name,
+                          't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
+        self.assertEquals(c.faculty_group.name,
+                          't3.y2017.s010.ct7113.socw.fc.course:columbia.edu')
+
+        self.assertEquals(c.info.term, 3)
+        self.assertEquals(c.info.year, 2017)
+
+        self.assertTrue(user in c.group.user_set.all())
+        self.assertTrue(user in c.faculty_group.user_set.all())
+
+        LTICourseContext.objects.get(
+            lms_course_context='1234',
+            group=c.group, faculty_group=c.faculty_group)
+
+        # try this again and make sure there is no duplication
+        data['lms_course_title'] = 'LTI Course With More Detail'
+        response = self.client.post(reverse('lti-course-create'), data)
+        self.assertEqual(response.status_code, 302)
+        Course.objects.get(title='LTI Course')
+        Group.objects.get(name=c.group.name)
+        Group.objects.get(name=c.faculty_group.name)
+        LTICourseContext.objects.get(
+            lms_course_context='1234',
+            group=c.group, faculty_group=c.faculty_group)
+
+    def test_post_course_context(self):
+        user = UserFactory()
+        self.client.login(username=user.username, password='test')
+
+        data = {
+            'lms_course': '1234',
+            'lms_course_title': 'LTI Course',
+            'sis_course_id': 'mediathread'
         }
         response = self.client.post(reverse('lti-course-create'), data)
         self.assertEqual(response.status_code, 302)
@@ -1600,8 +1640,20 @@ class LTICourseCreateTest(TestCase):
         self.assertEquals(c.group.name, '1234')
         self.assertEquals(c.faculty_group.name, '1234_faculty')
 
-        self.assertTrue(c.is_faculty(user))
+        self.assertTrue(user in c.group.user_set.all())
+        self.assertTrue(user in c.faculty_group.user_set.all())
 
+        LTICourseContext.objects.get(
+            lms_course_context='1234',
+            group=c.group, faculty_group=c.faculty_group)
+
+        # try this again and make sure there is no duplication
+        data['lms_course_title'] = 'LTI Course With More Detail'
+        response = self.client.post(reverse('lti-course-create'), data)
+        self.assertEqual(response.status_code, 302)
+        Course.objects.get(title='LTI Course')
+        Group.objects.get(name=c.group.name)
+        Group.objects.get(name=c.faculty_group.name)
         LTICourseContext.objects.get(
             lms_course_context='1234',
             group=c.group, faculty_group=c.faculty_group)

--- a/mediathread/templates/lti_auth/fail_course_configuration.html
+++ b/mediathread/templates/lti_auth/fail_course_configuration.html
@@ -2,6 +2,7 @@
 {% get_instructor_courses user as courses %}
 <html>
 <head>
+    <title>Course Configuration</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="screen" />
 
     <style>
@@ -13,10 +14,17 @@
             padding: 0;
             background-color: #383838;
         }
+        .mediathread-background-logo {
+            background: url(https://ccnmtl-mediathread-static-prod.s3.amazonaws.com/media/img/login_bg.jpg) -250px 35px no-repeat;
+        }
+        p {
+            margin-top: 20px;
+            font-size: medium;
+        }
     </style>
 
 </head>
-<body>
+<body class="mediathread-background-logo">
     <div id="header">
         <div id="standardnav_container">
             <div id="mediathread_logo">
@@ -30,41 +38,37 @@
 
     <div class="container-fluid">
     <div class="row">
-        <div class="col-md-12">
-            <h2>Course Configuration</h2>
+         {% if not is_instructor and not is_administrator %}
+            <div class="col-md-12" style="margin-top: 20px">
+                <p class="lead text-center">
+                    Your {{title}} course has not been configured to use this component.<br />
+                    Contact your instructor for more information.
+                </p>
+            </div>
+         {% else %}
+            <div class="col-sm-6 col-sm-offset-3" style="margin-top: 20px">
+                <p class="lead text-center">
+                    Mediathread is an open-source platform for exploration, analysis, and organization of web-based multimedia content.
+                </p>
+                <p class="lead text-center">
+                    Connect your Canvas course to Mediathread.
+                </p>
 
-            {% if autocreate_course %}
-                 {% if is_instructor or is_administrator %}
-                    <p class="lead">
-                        Create a Mediathread course for this Canvas course.<br />
+                <form class="text-center" action="{% url 'lti-course-create' %}" method='POST'>
+                    <input type="hidden" name="lms_course" value="{{lms_course}}">
+                    <input type="hidden" name="lms_course_title" value="{{lms_course_title}}">
+                    <input type="hidden" name="sis_course_id" value="{{sis_course_id}}">
+                    <p>
+                        <a href="http://mediathread.info" target="about:blank" class="btn btn-default btn-lg" style="margin-right: 5px;">Learn More</a>
+                        <button type="submit" class="btn btn-primary btn-lg">Connect Now</button>
                     </p>
-                    <form action="{% url 'lti-course-create' %}" method='POST'>
-                        <input type="hidden" name="lms_course" value="{{lms_course}}">
-                        <input type="hidden" name="lms_course_title" value="{{lms_course_title}}">
-                        <button type="submit" class="btn btn-primary">Create {{lms_course_title}}</button>
-                    </form>
-                 {% endif %}
-                 <br />
-            {% else %}
-                {% if courses|length < 1 %}
-                    {% if is_instructor or is_administrator %}
-                        <p class="lead"><a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course</p>
-                    {% else %}
-                        <p class="lead">
-                            Your {{title}} course has not been configured to use this component.<br />
-                            Contact your instructor for more information.</p>
-                        <p>
-                    {% endif %}
-                {% endif %}
-            {% endif %}
+                </form>
+            </p>
 
-            {% if courses|length > 0 %} 
-                <p class="lead">
-                Connect a Mediathread course to this Canvas course.<br />
-
-                {% if not autocreate_course %}
-                    Don't see your course? <a href='/' target="about:blank">Navigate to Mediathread</a> to activate or create the course first.</p>
-                {% endif %}
+            {% if courses|length > 0 and is_administrator %} 
+                <p class="lead" style="margin-top: 50px">
+                <b>Administrators Only</b><br />
+                Connect a different Mediathread course to this Canvas course.<br />
 
                 <div class="row">
                 <div class="col-md-12">
@@ -105,6 +109,7 @@
                 </div></div>
             {% endif %}
 
+        {% endif %}
         </div>
     </div>
     </div>

--- a/mediathread/templates/lti_auth/landing_page.html
+++ b/mediathread/templates/lti_auth/landing_page.html
@@ -14,11 +14,13 @@
         }
         .mediathread-background-logo {
             background: url(https://ccnmtl-mediathread-static-prod.s3.amazonaws.com/media/img/login_bg.jpg) -250px 35px no-repeat;
-            min-height: 700px;
         }
         p {
             margin-top: 20px;
             font-size: medium;
+        }
+        .alert-info button.close {
+            display: none;
         }
     </style>
 </head>
@@ -35,14 +37,14 @@
     </div>
     <div class="container-fluid">
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-sm-6 col-sm-offset-3" style="margin-top: 20px">
                 <p>{% bootstrap_messages %}</p>
-                <p class="lead">Mediathread is an open-source platform for exploration, analysis, and
+                <p class="lead text-center">Mediathread is an open-source platform for exploration, analysis, and
                 organization of web-based multimedia content.</p>
-                <p>
-                Mediathread connects to a variety of image and video collections (such as YouTube, Flickr, library databases, and course libraries), enabling users to lift items out of these collections and into an analysis environment. In Mediathread, items can then be clipped, annotated, organized, and embedded into essays and other written analysis.
+
+                <p class="lead text-center">
+                    <a class="btn btn-primary btn-lg" href="{{landing_url}}" target="_blank">Launch Mediathread</a>
                 </p>
-                <p><a class="btn btn-primary" href="{{landing_url}}" target="_blank">Launch Mediathread</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Courses can be automatically created or connected in one step for our various
ecosystems. The view keys off a custom lti parameter to structure expected
student and faculty affiliation groups. In the event that the custom parameter
is missing or in an unexpected format, the code defaults to the unique
custom_course_context parameter.

<img width="1119" alt="screen shot 2017-09-13 at 12 15 51 pm" src="https://user-images.githubusercontent.com/141369/30388318-5aa21fda-987d-11e7-9ba3-d56c1572cc0f.png">
