### PR TITLE
Course Details - update instructor display

### DIFF
--- a/mediathread/templates/courseaffils/course_row.html
+++ b/mediathread/templates/courseaffils/course_row.html
@@ -23,11 +23,13 @@
         {% endif %}
     </td>
     <td>
-        {% if course.details.instructor %}
-            {{course.details.instructor.value}}
-        {% elif course.to_dict %}
-            {% firstof request.user.get_full_name request.user.username %}
-        {% endif %}
+        {% for user in course.faculty_group.user_set.all %}
+            {% with exceptions='swav,swinstructor' %}
+                {% if not user.is_staff and not user.username in exceptions %}
+                    {% firstof user.get_full_name user.username %},
+                {% endif %}
+            {% endwith %}
+        {% endfor %}
     </td>
     <td>
         {% if course in as_instructor %}


### PR DESCRIPTION
The course details object uses a hard-coded value to display instructors. Swap
this out for a dynamic rendering of the faculty group. 

I think this approach will work better in the long run. Noting that some exceptions are already in place.