### PR TITLE
Bootstrap typo fix

### DIFF
--- a/mediathread/templates/bootstrap3/messages.html
+++ b/mediathread/templates/bootstrap3/messages.html
@@ -1,6 +1,6 @@
 {% load bootstrap3 %}
 {% for message in messages %}
-    <div class="{{ message|bootstrap_message_classes }} alert-dismissable">
+    <div class="{{ message|bootstrap_message_classes }} alert-dismissible">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
         {{ message | safe }}
     </div>


### PR DESCRIPTION
The correct spelling here is actually "dismissible", and that's what
bootstrap expects.