### PR TITLE
Pin pylti to 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ httplib2==0.10.3
 oauth==1.0.1
 oauth2==1.9.0.post1
 oauthlib==2.0.6
-pylti>=0.1.3
+pylti==0.4.0
 nameparser==0.5.3
 django-bootstrap3==9.0.0
 ua_parser==0.7.3


### PR DESCRIPTION
I think this has only been tested with pylti 0.4.0 so far. We were
allowing pretty much any version in the requirements.txt - let's pin
this to 0.4.0 so it's easier to understand if something breaks.