### PR TITLE
Fix sequence save failure - PMT #112865

### DIFF
--- a/mediathread/sequence/apiviews.py
+++ b/mediathread/sequence/apiviews.py
@@ -7,9 +7,20 @@ from mediathread.sequence.serializers import (
     SequenceAssetSerializer, SequenceMediaElementSerializer,
     SequenceTextElementSerializer,
 )
+from rest_framework.authentication import (
+    SessionAuthentication, BasicAuthentication
+)
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+    # https://stackoverflow.com/a/30875830/173630
+    def enforce_csrf(self, request):
+        return
 
 
 class SequenceAssetViewSet(viewsets.ModelViewSet):
+    authentication_classes = (
+        CsrfExemptSessionAuthentication, BasicAuthentication)
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, SingleAuthor,)
     queryset = SequenceAsset.objects.all()
     serializer_class = SequenceAssetSerializer


### PR DESCRIPTION
CSRF is disabled in MediaThread, but django-rest-framework uses
SessionAuthentication by default, which requires it. I wasn't able to
add CSRF to the project view, because we would need to add CSRF
middleware. But, I've made the api view exempt from csrf checking.