### PR TITLE
Add Dockerfile instructions for smooth execution of 'make build'.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM ccnmtl/django.base
+RUN apt-get update \
+ && apt-get install python-urllib3 -y
+ADD requirements /requirements
 ADD wheelhouse /wheelhouse
 RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.txt \
 && rm -rf /wheelhouse


### PR DESCRIPTION
Add Dockerfile instruction to install python-urllib3.
Add Dockerfile instruction to add requirements/ directory otherwise requirements/src/lettuce-0.2.25.ccnmtl-py2.py3-none-any.whl can not be found during make install.