### PR TITLE
Pin djangorestframework to <3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ ipython==5.6.0 # pyup: <6.0.0
 ipdb==0.11
 freezegun==0.3.10
 django-smtp-ssl==1.0
-djangorestframework==3.7.7
+djangorestframework==3.7.7  # pyup: <3.8
 
 ccnmtlsettings==1.3.0 # pyup: <1.4.0
 django-extensions==2.0.7


### PR DESCRIPTION
The changes with default/read_only serialized fields affects the juxtapose API, and I haven't resolved this yet. For now, let's stick to drf 3.7.


http://www.django-rest-framework.org/topics/3.8-announcement/