### PR TITLE
anonymize GA

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -347,6 +347,7 @@
             {% if settings.GOOGLE_ANALYTICS_ID %}
                 var _gaq = _gaq || [];
                 _gaq.push(['_setAccount', '{{settings.GOOGLE_ANALYTICS_ID}}']);
+                _gaq.push (['_gat._anonymizeIp']);
                 _gaq.push(['_trackPageview']);
 
                 (function () {

--- a/mediathread/templates/base_new.html
+++ b/mediathread/templates/base_new.html
@@ -347,6 +347,7 @@ A new base.html without the course context overwritten in the template.
         {% if settings.GOOGLE_ANALYTICS_ID %}
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', '{{settings.GOOGLE_ANALYTICS_ID}}']);
+        _gaq.push (['_gat._anonymizeIp']);
         _gaq.push(['_trackPageview']);
 
         (function () {


### PR DESCRIPTION
Mediathread uses a different GA method - ga.js instead of analytics.js.
I got the anonymizeIp snippet from here:

https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizeIp