### PR TITLE
Panopto waffle: remove one flag

### DIFF
--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -10,7 +10,6 @@ from django.core.urlresolvers import reverse
 from django.http.response import Http404, HttpResponseRedirect
 from django.test import TestCase
 from django.test.client import RequestFactory
-from waffle.testutils import override_flag
 
 from mediathread.assetmgr.models import Asset, ExternalCollection
 from mediathread.assetmgr.views import (
@@ -503,11 +502,8 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         view.request = request
         self.assertEquals(view.get_upload_folder(), '')
 
-        with override_flag('panopto_upload', active=True):
-            self.assertEquals(view.get_upload_folder(), '')
-
-            self.sample_course.add_detail(UPLOAD_FOLDER_KEY, 'z')
-            self.assertEquals(view.get_upload_folder(), 'z')
+        self.sample_course.add_detail(UPLOAD_FOLDER_KEY, 'z')
+        self.assertEquals(view.get_upload_folder(), 'z')
 
     def test_redirect_uploader(self):
         # no collection id

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -24,7 +24,6 @@ from django.shortcuts import render, get_object_or_404
 from django.template import loader
 from django.views.generic.base import View, TemplateView
 from djangohelpers.lib import allow_http
-import waffle
 
 from mediathread.api import UserResource, TagResource
 from mediathread.assetmgr.api import AssetResource
@@ -449,9 +448,6 @@ class RedirectToExternalCollectionView(LoggedInCourseMixin, View):
 class RedirectToUploaderView(LoggedInCourseMixin, View):
 
     def get_upload_folder(self):
-        if not waffle.flag_is_active(self.request, 'panopto_upload'):
-            return ''
-
         return course_details.get_upload_folder(self.request.course)
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Removing the `panopto_upload` flag at the point of upload. If a Panopto folder has been associated with the course, the upload now always goes through Panopto. The waffle flag remains in place in `course_details`, which controls whether the Panopto folder is created when upload is enabled.