### PR TITLE
Delete course interface

### DIFF
--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -448,7 +448,7 @@ class CourseDeleteMaterialsView(LoggedInSuperuserMixin, FormView):
     form_class = CourseDeleteMaterialsForm
 
     def get_success_url(self):
-        return reverse('course-delete-materials')
+        return self.success_url
 
     def get_context_data(self, **kwargs):
         ctx = FormView.get_context_data(self, **kwargs)
@@ -511,8 +511,17 @@ class CourseDeleteMaterialsView(LoggedInSuperuserMixin, FormView):
 
         # @todo - kill all unreferenced tags
 
-        messages.add_message(self.request, messages.INFO,
-                             'All requested materials were deleted')
+        if 'delete-course' in form.data:
+            messages.add_message(
+                self.request, messages.INFO,
+                '{} and requested materials were deleted'.format(
+                    self.request.course.title))
+            self.request.course.delete()
+            self.success_url = '/?unset_course'
+        else:
+            self.success_url = reverse('course-delete-materials')
+            messages.add_message(self.request, messages.INFO,
+                                 'All requested materials were deleted')
 
         return super(CourseDeleteMaterialsView, self).form_valid(form)
 

--- a/mediathread/templates/dashboard/class_delete_materials.html
+++ b/mediathread/templates/dashboard/class_delete_materials.html
@@ -86,8 +86,10 @@
             </div>
 
             <br /><br />
-            <input class="btn btn-danger" type="submit" name="clear-course"
+            <input class="btn btn-warning" type="submit" name="clear-course"
                 value="Permanently Delete Materials"></input>
+            <input class="btn btn-danger" type="submit" name="delete-course"
+                value="Permanently Delete Course"></input>
             <div class="visualclear"></div>
         </div>
     </form>


### PR DESCRIPTION
Add a delete course option to the clear materials interface. This is for superusers only, and will be a convenience utility as we begin to archive courses.