### PR TITLE
LTI role configuration: elevate TAs to instructors

### DIFF
--- a/lti_auth/tests/factories.py
+++ b/lti_auth/tests/factories.py
@@ -23,6 +23,7 @@ BASE_LTI_PARAMS = {
         u'urn:lti:instrole:ims/lis/Instructor,urn:lti:instrole:ims/lis/Staff',
     u'resource_link_id': u'-724d6c2b5fcc4a17a26b9120a1d463aa',
     u'user_id': u'student',
+    u'custom_canvas_api_domain': u'instructure.edu'
 }
 
 CONSUMERS = {

--- a/lti_auth/tests/test_views.py
+++ b/lti_auth/tests/test_views.py
@@ -22,6 +22,33 @@ class LTIViewTest(TestCase):
         self.assertTrue(user in ctx.group.user_set.all())
         self.assertTrue(user in ctx.faculty_group.user_set.all())
 
+    def test_join_groups_student(self):
+        mixin = LTIAuthMixin()
+        ctx = LTICourseContextFactory()
+        user = UserFactory()
+
+        self.lti.lti_params['roles'] = u'Learner'
+
+        mixin.join_groups(self.lti, ctx, user)
+        self.assertTrue(user in ctx.group.user_set.all())
+        self.assertFalse(user in ctx.faculty_group.user_set.all())
+
+    def test_join_groups_teachingassistant(self):
+        mixin = LTIAuthMixin()
+        ctx = LTICourseContextFactory()
+        user = UserFactory()
+
+        self.lti.lti_params['roles'] = u'urn:lti:role:ims/lis/TeachingAssistant'
+
+        mixin.join_groups(self.lti, ctx, user)
+        self.assertTrue(user in ctx.group.user_set.all())
+        self.assertFalse(user in ctx.faculty_group.user_set.all())
+
+        with self.settings(LTI_ELEVATE_TEACHINGASSISTANTS=['instructure.edu']):
+            mixin.join_groups(self.lti, ctx, user)
+            self.assertTrue(user in ctx.group.user_set.all())
+            self.assertTrue(user in ctx.faculty_group.user_set.all())
+
     def test_launch_invalid_user(self):
         request = generate_lti_request()
 

--- a/lti_auth/tests/test_views.py
+++ b/lti_auth/tests/test_views.py
@@ -38,7 +38,8 @@ class LTIViewTest(TestCase):
         ctx = LTICourseContextFactory()
         user = UserFactory()
 
-        self.lti.lti_params['roles'] = u'urn:lti:role:ims/lis/TeachingAssistant'
+        self.lti.lti_params['roles'] = \
+            u'urn:lti:role:ims/lis/TeachingAssistant'
 
         mixin.join_groups(self.lti, ctx, user)
         self.assertTrue(user in ctx.group.user_set.all())

--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -28,6 +28,11 @@ class LTIAuthMixin(object):
                 user.groups.add(ctx.faculty_group)
                 break
 
+            domains = getattr(settings, 'LTI_ELEVATE_TEACHINGASSISTANTS', [])
+            if 'teachingassistant' in role and lti.canvas_domain() in domains:
+                user.groups.add(ctx.faculty_group)
+                break
+
     def dispatch(self, request, *args, **kwargs):
         lti = LTI(self.request_type, self.role_type)
 


### PR DESCRIPTION
The Canvas teaching assistant role can now be elevated to a Mediathread instructor when connecting via LTI.