### PR TITLE
Remove librabbitmq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -155,7 +155,6 @@ vine==1.3.0
 amqp==2.4.2 # pyup: < 2.5
 amqplib==1.0.2
 kombu==3.0.37 # pyup: <4.0.0
-librabbitmq==2.0.0
 celery==3.1.26.post2 # pyup: <4.0.0
 django-celery==3.2.2 # pyup: <3.3.0
 


### PR DESCRIPTION
librabbitmq 2.0.0 fails to compile in Linux

See:
* https://github.com/celery/librabbitmq/issues/118
* https://github.com/ccnmtl/capsim/commit/ff43409946b15d249f6e0c1acc46f666934220be