### PR TITLE
Validate that recipient is a valid email before sending

### DIFF
--- a/mediathread/main/util.py
+++ b/mediathread/main/util.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.exceptions import ImproperlyConfigured
+from django.core.validators import validate_email
 from django.template import loader
 import requests
 from requests.exceptions import SSLError
@@ -9,6 +10,8 @@ from raven import Client
 
 
 def send_template_email(subject, template_name, params, recipient):
+    validate_email(recipient)
+
     template = loader.get_template(template_name)
     message = template.render(params)
     send_mail(subject, message, settings.SERVER_EMAIL, [recipient])


### PR DESCRIPTION
This should address the Sentry error:

> SMTPDataError: (554, b'Transaction failed: Local address contains
> control or whitespace')

This email address should always be valid. If it's not, a
ValidationError is thrown, which we'll see in Sentry.