### PR TITLE
Use memcached in production

### DIFF
--- a/mediathread/settings_production.py
+++ b/mediathread/settings_production.py
@@ -13,6 +13,13 @@ locals().update(
         s3static=True,
     ))
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 3600  # One Hour
+    }
+}
 
 TEMPLATES[0]['DIRS'].insert(
     0,

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -28,10 +28,10 @@ PROJECT_APPS = [
     'structuredcollaboration',
 ]
 
-CACHE_BACKEND = 'locmem:///'
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'mediathread',
         'TIMEOUT': 3600  # One Hour
     }
 }

--- a/mediathread/settings_staging.py
+++ b/mediathread/settings_staging.py
@@ -13,6 +13,13 @@ locals().update(
         s3static=True,
     ))
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 3600  # One Hour
+    }
+}
 
 TEMPLATES[0]['DIRS'].insert(
     0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,3 +154,5 @@ kombu==3.0.37 # pyup: <4.0.0
 celery==3.1.26.post2 # pyup: <4.0.0
 django-celery==3.2.2 # pyup: <3.3.0
 
+# memcached
+pylibmc==1.6.1


### PR DESCRIPTION
Based on our settings in carr.

* Default to LocMemCache - this will get used for development. Add in
  "LOCATION" string for uniqueness
* Use Memcached in staging and production.

Using DummyCache for testing, like we're doing in carr, caused test
failures in mediathread.
