### PR TITLE
Add SameSite=None flag for session cookies

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -40,6 +40,9 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
     'mediathread.main.views.django_settings'
 )
 
+MIDDLEWARE = ['django_cookies_samesite.middleware.CookiesSameSite'] + \
+    MIDDLEWARE  # noqa
+
 MIDDLEWARE += [  # noqa
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -179,6 +182,8 @@ ACCOUNT_ACTIVATION_DAYS = 7
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_METHODS = ('GET',)
 CORS_ALLOW_CREDENTIALS = True
+
+SESSION_COOKIE_SAMESITE = 'None'
 
 
 def default_url_processor(url, label=None, request=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,6 +91,10 @@ django-impersonate==1.5
 django-registration-redux==2.7
 django-waffle==0.20.0
 django-cors-headers==3.0.2 # pyup: <3.1.0
+
+# needed for django <2.1
+django-cookies-samesite==0.5.1
+
 httplib2==0.17.0
 oauth==1.0.1
 oauth2==1.9.0.post1


### PR DESCRIPTION
Chrome 80 needs this flag set on our session cookie, in order to use it
for media collection.

* https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
* https://www.chromestatus.com/feature/5088147346030592
* https://www.chromestatus.com/feature/5633521622188032