### PR TITLE
Scroll to top when entering asset detail view - MEDT-3507

### DIFF
--- a/media/js/src/CollectionTab.jsx
+++ b/media/js/src/CollectionTab.jsx
@@ -40,6 +40,9 @@ export default class CollectionTab extends React.Component {
 
         if (!this.state.selectedAsset && asset) {
             this.setState({selectedAsset: asset});
+
+            // Scroll to top when entering asset detail view.
+            window.scrollTo(0, 0);
         } else {
             this.setState({selectedAsset: null});
         }


### PR DESCRIPTION
As recommended by react router. I looked this up because this feels a
bit like "old school" javascript, but it's still being used!

https://reacttraining.com/react-router/web/guides/scroll-restoration