### PR TITLE
Fix react-select multiselect boxes

### DIFF
--- a/media/js/src/AssetFilter.jsx
+++ b/media/js/src/AssetFilter.jsx
@@ -284,12 +284,15 @@ export default class AssetFilter extends React.Component {
         const reactSelectStyles = {
             container: (provided, state) => ({
                 ...provided,
-                padding: '0'
+                padding: 0,
+                height: 'fit-content',
+                zIndex: 4
             }),
             control: (provided, state) => ({
-                // ...provided,
-                display: 'flex',
-                height: 'calc(1.5em + .5rem + 2px)'
+                ...provided,
+                borderWidth: 0,
+                minHeight: 'fit-content',
+                height: 'fit-content'
             }),
             singleValue: (provided, state) => ({
                 ...provided,
@@ -301,13 +304,21 @@ export default class AssetFilter extends React.Component {
             }),
             menu: (provided, state) => ({
                 ...provided,
-                zIndex: '3',
-                backgroundColor: 'white'
+                backgroundColor: 'white',
+                zIndex: 4
             }),
             menuList: (provided, state) => ({
                 ...provided,
                 backgroundColor: 'white',
-                zIndex: '3'
+                zIndex: 4
+            }),
+            indicatorsContainer: (provided, state) => ({
+                ...provided,
+                height: '29px'
+            }),
+            input: (provided, state) => ({
+                ...provided,
+                height: '21px'
             })
         };
 


### PR DESCRIPTION
![2020-04-13-201024_1158x141_scrot](https://user-images.githubusercontent.com/59292/79172953-2ec5d300-7dc4-11ea-935e-425d7632236b.png)

![2020-04-13-201245_1168x214_scrot](https://user-images.githubusercontent.com/59292/79172732-8152bf80-7dc3-11ea-82fb-abed6f241ebb.png)

Yeah, the multiselect box grows slightly in height when a single selection is made. We can change that if we want, but I think it's okay behavior.

https://github.com/JedWatson/react-select/issues/1322
Many people here have run into this problem - how to resize react-select
in a way that works with multiselect. I'll be posting my solution there.

It looks like there's a z-index issue with the Date dropdown and
pagination... I haven't solved it yet but probably just requires some
more messing with.