### PR TITLE
Handle html entities in asset titles

### DIFF
--- a/media/js/src/GridAsset.jsx
+++ b/media/js/src/GridAsset.jsx
@@ -219,8 +219,10 @@ export default class GridAsset extends React.Component {
                                 this.props.toggleAssetView.bind(
                                     this, this.props.asset)}
                             href={assetLink}
-                            title={this.props.asset.title}>
-                            {this.props.asset.title}
+                            title={this.props.asset.title}
+                            dangerouslySetInnerHTML={{
+                                __html: this.props.asset.title
+                            }}>
                         </a>
                     </h5>
                     <Selections


### PR DESCRIPTION
Unfortunately we need to use this trick to render HTML entities without
escaping them:
https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml

<img width="856" alt="Screen Shot 2020-04-20 at 3 58 47 PM" src="https://user-images.githubusercontent.com/59292/79794286-012add80-8320-11ea-9461-ef28a815cfdc.png">
