### PR TITLE
Cypress makefile: remove redundant js_sentinel definition

### DIFF
--- a/cypress.mk
+++ b/cypress.mk
@@ -1,13 +1,3 @@
-JS_FILES ?= media/js
-
-NODE_MODULES ?= ./node_modules
-JS_SENTINAL ?= $(NODE_MODULES)/sentinal
-
-$(JS_SENTINAL): package.json
-	rm -rf $(NODE_MODULES)
-	npm install
-	touch $(JS_SENTINAL)
-
 cypress: $(JS_SENTINAL)
 	npm run cypress:test
 


### PR DESCRIPTION
This was causing a warning.