### PR TITLE
List View Improvements: add selection count column, fix sorting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ python:
 matrix:
   exclude:
   - python: '2.7'
+    env: TEST_SUITE=jenkins
+  - python: '2.7'
     env: TEST_SUITE=jstest
   - python: '2.7'
     env: TEST_SUITE=cypress

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -50,17 +50,17 @@ export default class CollectionListView extends React.Component {
             {
                 name: 'Selections',
                 selector: 'annotation_count',
-                sortable: true
+                sortable: false
             },
             {
                 name: 'Tags',
                 selector: 'tags',
-                sortable: true
+                sortable: false
             },
             {
                 name: 'Terms',
                 selector: 'terms',
-                sortable: true
+                sortable: false
             },
             {
                 name: 'Media',

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -21,7 +21,7 @@ export default class CollectionListView extends React.Component {
         if (sortField === 'owner') {
             sortField = 'author';
         } else if (sortField === 'date') {
-            sortField = 'modified';
+            sortField = 'added';
         }
 
         const orderBy = sortDirection === 'asc' ? sortField : '-' + sortField;
@@ -79,7 +79,7 @@ export default class CollectionListView extends React.Component {
             {
                 name: 'Date',
                 format: formatDay,
-                selector: 'modified',
+                selector: 'added',
                 sortable: true
             }
         ];

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -45,7 +45,8 @@ export default class CollectionListView extends React.Component {
             {
                 name: 'Title',
                 selector: 'title',
-                sortable: true
+                sortable: true,
+                wrap: true
             },
             {
                 name: 'Selections',
@@ -55,12 +56,14 @@ export default class CollectionListView extends React.Component {
             {
                 name: 'Tags',
                 selector: 'tags',
-                sortable: false
+                sortable: false,
+                wrap: true
             },
             {
                 name: 'Terms',
                 selector: 'terms',
-                sortable: false
+                sortable: false,
+                wrap: true
             },
             {
                 name: 'Media',
@@ -69,7 +72,7 @@ export default class CollectionListView extends React.Component {
             },
             {
                 name: 'Owner',
-                selector: 'author.public_name',
+                selector: 'author.username',
                 sortable: true
             },
             {
@@ -126,6 +129,7 @@ export default class CollectionListView extends React.Component {
                 customStyles={styles}
                 className="react-data-table"
                 columns={columns}
+                dense
                 highlightOnHover
                 striped
                 sortServer

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -68,7 +68,7 @@ export default class CollectionListView extends React.Component {
             {
                 name: 'Media',
                 selector: 'primary_type',
-                sortable: true
+                sortable: false
             },
             {
                 name: 'Owner',
@@ -132,9 +132,10 @@ export default class CollectionListView extends React.Component {
                 dense
                 highlightOnHover
                 striped
-                sortServer
                 progressPending={this.state.loading}
                 progressComponent={<LoadingAssets />}
+                sortServer
+                defaultSortField="title"
                 onSort={this.handleSort}
                 data={this.props.assets} />
         );

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -48,6 +48,11 @@ export default class CollectionListView extends React.Component {
                 sortable: true
             },
             {
+                name: 'Selections',
+                selector: 'annotation_count',
+                sortable: true
+            },
+            {
                 name: 'Tags',
                 selector: 'tags',
                 sortable: true

--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -72,8 +72,9 @@ export default class CollectionListView extends React.Component {
             },
             {
                 name: 'Owner',
-                selector: 'author.username',
-                sortable: true
+                selector: 'author.public_name',
+                sortable: true,
+                wrap: true
             },
             {
                 name: 'Date',

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -196,7 +196,7 @@ const capitalizeFirstLetter = function(str) {
  * Returns a string.
  */
 const formatDay = function(obj) {
-    const dateStr = obj.modified;
+    const dateStr = obj.added;
     const date = new Date(Date.parse(dateStr));
     return date.toLocaleDateString(undefined, {
         month: '2-digit',

--- a/mediathread/api.py
+++ b/mediathread/api.py
@@ -13,10 +13,10 @@ from tastypie.authorization import Authorization
 from tastypie.constants import ALL
 from tastypie.resources import ModelResource
 
-from courseaffils.lib import get_public_name
 from courseaffils.models import Course, CourseInfo
-from mediathread.djangosherd.models import SherdNote
 from tastypie import fields
+from mediathread.djangosherd.models import SherdNote
+from mediathread.main.util import user_display_name_last_first
 
 
 class ClassLevelAuthentication(Authentication):
@@ -68,8 +68,7 @@ class UserResource(ModelResource):
         filtering = {'id': ALL, 'username': ALL}
 
     def dehydrate(self, bundle):
-        bundle.data['public_name'] = get_public_name(bundle.obj,
-                                                     bundle.request)
+        bundle.data['public_name'] = user_display_name_last_first(bundle.obj)
         return bundle
 
     def render_one(self, request, user):

--- a/mediathread/assetmgr/api.py
+++ b/mediathread/assetmgr/api.py
@@ -34,7 +34,7 @@ class AssetResource(ModelResource):
         list_allowed_methods = []
         detail_allowed_methods = []
         authentication = ClassLevelAuthentication()
-        ordering = ['modified', 'id', 'title', 'author']
+        ordering = ['added', 'modified', 'id', 'title', 'author']
 
     def __init__(self, *args, **kwargs):
         # @todo: extras is a side-effect of the Mustache templating system
@@ -79,6 +79,7 @@ class AssetResource(ModelResource):
         bundle.data['annotations'] = []
         bundle.data['annotation_count'] = 0
         bundle.data['my_annotation_count'] = 0
+        bundle.data['added'] = self.format_time(bundle.obj.added)
         bundle.data['modified'] = self.format_time(bundle.obj.modified)
 
         sources = {}

--- a/mediathread/assetmgr/features/collection.feature
+++ b/mediathread/assetmgr/features/collection.feature
@@ -35,8 +35,8 @@ Feature: Collection View
         And the Collection panel has a "Mediathread: Introduction" item
 
         When I clear all tags
-        When I select "Student One" as the owner
-        Then the owner is "Student One" in the Collection column
+        When I select "One, Student" as the owner
+        Then the owner is "One, Student" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 0 by me
 
@@ -95,8 +95,8 @@ Feature: Collection View
 
         # Instructor One
         Given the collection workspace is loaded
-        When I select "Instructor One" as the owner
-        Then the owner is "Instructor One" in the Collection column
+        When I select "One, Instructor" as the owner
+        Then the owner is "One, Instructor" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 0 by me
 
@@ -106,7 +106,7 @@ Feature: Collection View
 
         # Student One
         When I clear all tags
-        And I select "Student One" as the owner
+        And I select "One, Student" as the owner
         Then the owner is "Me" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 1 by me
@@ -117,8 +117,8 @@ Feature: Collection View
 
         # Student Two
         When I clear all tags
-        And I select "Student Two" as the owner
-        Then the owner is "Student Two" in the Collection column
+        And I select "Two, Student" as the owner
+        Then the owner is "Two, Student" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 0 by me
 
@@ -168,7 +168,7 @@ Feature: Collection View
         Given the collection workspace is loaded
 
         # Instructor One
-        When I select "Instructor One" as the owner
+        When I select "One, Instructor" as the owner
         Then the owner is "Me" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 1 by me
@@ -180,8 +180,8 @@ Feature: Collection View
 
         # Student One
         When I clear all tags
-        And I select "Student One" as the owner
-        Then the owner is "Student One" in the Collection column
+        And I select "One, Student" as the owner
+        Then the owner is "One, Student" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 0 by me
 
@@ -237,8 +237,8 @@ Feature: Collection View
         # Except the fact that the item is in his collection
 
         # Instructor One
-        When I select "Instructor One" as the owner
-        Then the owner is "Instructor One" in the Collection column
+        When I select "One, Instructor" as the owner
+        Then the owner is "One, Instructor" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 0 by me
 
@@ -247,7 +247,7 @@ Feature: Collection View
 
         # Student One
         When I clear all tags
-        When I select "Student One" as the owner
+        When I select "One, Student" as the owner
         Then the owner is "Me" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And the "MAAP Award Reception" item has 1 selections, 1 by me
@@ -259,8 +259,8 @@ Feature: Collection View
 
         # Student Two
         When I clear all tags
-        When I select "Student Two" as the owner
-        Then the owner is "Student Two" in the Collection column
+        When I select "Two, Student" as the owner
+        Then the owner is "Two, Student" in the Collection column
         Then the Collection panel has a "MAAP Award Reception" item
         And I can filter by "student_two_selection (0)" in the Collection column
         When I clear all tags

--- a/mediathread/assetmgr/models.py
+++ b/mediathread/assetmgr/models.py
@@ -47,14 +47,12 @@ class AssetManager(models.Manager):
         assets = Asset.objects.filter(course=course,
                                       sherdnote_set__author=user,
                                       sherdnote_set__range1=None).distinct()
-        assets = assets.order_by('-sherdnote_set__modified')
         return assets.select_related('course', 'author')
 
     def by_course(self, course):
         assets = Asset.objects.filter(course=course) \
             .extra(select={'lower_title': 'lower(assetmgr_asset.title)'}) \
             .distinct()
-        assets = assets.order_by('-sherdnote_set__modified')
         return assets.select_related('course', 'author')
 
     def migrate(self, assets, course, user, faculty, object_map,

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -29,9 +29,11 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.sample_course = Course.objects.get(title='Sample Course')
         self.alt_course = Course.objects.get(title="Alternate Course")
 
-        self.asset1 = AssetFactory.create(course=self.sample_course,
-                                          author=self.instructor_one,
-                                          primary_source='image')
+        self.asset1 = AssetFactory.create(
+            title="Test Asset 1",
+            course=self.sample_course,
+            author=self.instructor_one,
+            primary_source='image')
 
         self.student_note = SherdNoteFactory(
             asset=self.asset1, author=self.student_one,
@@ -52,9 +54,11 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
             body='instructor one global note',
             title=None, range1=None, range2=None)
 
-        self.asset2 = AssetFactory.create(course=self.sample_course,
-                                          author=self.instructor_one,
-                                          primary_source='video')
+        self.asset2 = AssetFactory.create(
+            title='Test Asset 2',
+            course=self.sample_course,
+            author=self.instructor_one,
+            primary_source='video')
         self.asset2_instructor_note = SherdNoteFactory(
             asset=self.asset2, author=self.instructor_one,
             tags=',video, instructor_one_selection,',
@@ -640,7 +644,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
                 password='test'))
 
         asset1 = AssetFactory.create(
-            title='ABCDE',
+            title='abcde',
             course=self.sample_course,
             author=self.student_one,
             primary_source='image')
@@ -656,17 +660,25 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
             asset=asset2, author=self.student_one)
 
         asset3 = AssetFactory.create(
-            title='Zelda',
+            title='maurice',
             course=self.sample_course,
             author=self.instructor_one,
             primary_source='image')
         SherdNoteFactory(
             asset=asset3, author=self.student_one)
 
-        # Make 60 more items in this course to trigger pagination
+        asset4 = AssetFactory.create(
+            title='ZZzzzzz',
+            course=self.sample_course,
+            author=self.student_one,
+            primary_source='image')
+        SherdNoteFactory(
+            asset=asset4, author=self.student_one)
+
+        # Make 50 more items in this course to trigger pagination
         for i in range(50):
             asset = AssetFactory.create(
-                title='Item {}'.format(i),
+                title='item {}'.format(i),
                 course=self.sample_course,
                 author=self.student_one,
                 primary_source='image')
@@ -676,24 +688,28 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         url = '/api/asset/?order_by=title'
         response = self.client.get(url)
         the_json = json.loads(response.content)
+        self.assertEqual(the_json.get('asset_count'), 56)
         objects = the_json['assets']
         self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
-        self.assertEqual(objects[0]['title'], 'ABCDE')
-        self.assertEqual(objects[19]['title'], 'Item 25')
+        self.assertEqual(objects[0]['title'], 'abcde')
+        self.assertEqual(objects[10]['title'], 'item 17')
+        self.assertEqual(objects[19]['title'], 'item 25')
 
         url = '/api/asset/?order_by=-title'
         response = self.client.get(url)
         the_json = json.loads(response.content)
+        self.assertEqual(the_json.get('asset_count'), 56)
         objects = the_json['assets']
         self.assertEqual(len(objects), 20)
-        self.assertEqual(objects[0]['primary_type'], 'image')
         self.assertEqual(objects[0]['title'], 'zebra')
-        self.assertEqual(objects[4]['title'], 'Item 9')
+        self.assertEqual(objects[0]['primary_type'], 'image')
+        self.assertEqual(objects[19]['title'], 'item 38')
 
         url = '/api/asset/?order_by=author'
         response = self.client.get(url)
         the_json = json.loads(response.content)
+        self.assertEqual(the_json.get('asset_count'), 56)
         objects = the_json['assets']
         self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
@@ -701,6 +717,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         url = '/api/asset/?order_by=-author'
         response = self.client.get(url)
         the_json = json.loads(response.content)
+        self.assertEqual(the_json.get('asset_count'), 56)
         objects = the_json['assets']
         self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -702,9 +702,9 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertEqual(the_json.get('asset_count'), 56)
         objects = the_json['assets']
         self.assertEqual(len(objects), 20)
-        self.assertEqual(objects[0]['title'], 'zebra')
+        self.assertEqual(objects[0]['title'], 'ZZzzzzz')
         self.assertEqual(objects[0]['primary_type'], 'image')
-        self.assertEqual(objects[19]['title'], 'item 38')
+        self.assertEqual(objects[19]['title'], 'item 40')
 
         url = '/api/asset/?order_by=author'
         response = self.client.get(url)

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -632,3 +632,80 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         the_json = json.loads(response.content)
         objects = the_json['assets']
         self.assertEqual(len(objects), 2)
+
+    def test_order_by(self):
+        self.assertTrue(
+            self.client.login(
+                username=self.student_one.username,
+                password='test'))
+
+        asset1 = AssetFactory.create(
+            title='ABCDE',
+            course=self.sample_course,
+            author=self.student_one,
+            primary_source='image')
+        SherdNoteFactory(
+            asset=asset1, author=self.student_one)
+
+        asset2 = AssetFactory.create(
+            title='zebra',
+            course=self.sample_course,
+            author=self.student_one,
+            primary_source='image')
+        SherdNoteFactory(
+            asset=asset2, author=self.student_one)
+
+        asset3 = AssetFactory.create(
+            title='Zelda',
+            course=self.sample_course,
+            author=self.student_one,
+            primary_source='image')
+        SherdNoteFactory(
+            asset=asset3, author=self.student_one)
+
+        url = '/api/asset/?order_by=title'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 5)
+        self.assertEqual(objects[0]['primary_type'], 'image')
+        self.assertEqual(objects[0]['title'], 'ABCDE')
+        self.assertEqual(objects[4]['title'], 'Zelda')
+
+        url = '/api/asset/?order_by=-title'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 5)
+        self.assertEqual(objects[0]['primary_type'], 'image')
+        self.assertEqual(objects[4]['title'], 'ABCDE')
+        self.assertEqual(objects[0]['title'], 'Zelda')
+
+        url = '/api/asset/?order_by=author'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 5)
+        self.assertEqual(objects[0]['primary_type'], 'image')
+
+        url = '/api/asset/?order_by=selections'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 5)
+        self.assertEqual(objects[0]['primary_type'], 'video')
+        self.assertEqual(objects[0]['title'], 'asset 31')
+        self.assertEqual(objects[0]['annotation_count'], 1)
+        self.assertEqual(objects[4]['title'], 'asset 30')
+        self.assertEqual(objects[4]['annotation_count'], 2)
+
+        url = '/api/asset/?order_by=-selections'
+        response = self.client.get(url)
+        the_json = json.loads(response.content)
+        objects = the_json['assets']
+        self.assertEqual(len(objects), 5)
+        self.assertEqual(objects[0]['primary_type'], 'image')
+        self.assertEqual(objects[0]['title'], 'asset 30')
+        self.assertEqual(objects[0]['annotation_count'], 2)
+        self.assertEqual(objects[4]['title'], 'Zelda')
+        self.assertEqual(objects[4]['annotation_count'], 1)

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -680,7 +680,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
         self.assertEqual(objects[0]['title'], 'ABCDE')
-        self.assertEqual(objects[4]['title'], 'Item 11')
+        self.assertEqual(objects[19]['title'], 'Item 25')
 
         url = '/api/asset/?order_by=-title'
         response = self.client.get(url)

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -658,54 +658,49 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         asset3 = AssetFactory.create(
             title='Zelda',
             course=self.sample_course,
-            author=self.student_one,
+            author=self.instructor_one,
             primary_source='image')
         SherdNoteFactory(
             asset=asset3, author=self.student_one)
+
+        # Make 60 more items in this course to trigger pagination
+        for i in range(50):
+            asset = AssetFactory.create(
+                title='Item {}'.format(i),
+                course=self.sample_course,
+                author=self.student_one,
+                primary_source='image')
+            SherdNoteFactory(
+                asset=asset, author=self.student_one)
 
         url = '/api/asset/?order_by=title'
         response = self.client.get(url)
         the_json = json.loads(response.content)
         objects = the_json['assets']
-        self.assertEqual(len(objects), 5)
+        self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
         self.assertEqual(objects[0]['title'], 'ABCDE')
-        self.assertEqual(objects[4]['title'], 'Zelda')
+        self.assertEqual(objects[4]['title'], 'Item 11')
 
         url = '/api/asset/?order_by=-title'
         response = self.client.get(url)
         the_json = json.loads(response.content)
         objects = the_json['assets']
-        self.assertEqual(len(objects), 5)
+        self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
-        self.assertEqual(objects[4]['title'], 'ABCDE')
-        self.assertEqual(objects[0]['title'], 'Zelda')
+        self.assertEqual(objects[0]['title'], 'zebra')
+        self.assertEqual(objects[4]['title'], 'Item 9')
 
         url = '/api/asset/?order_by=author'
         response = self.client.get(url)
         the_json = json.loads(response.content)
         objects = the_json['assets']
-        self.assertEqual(len(objects), 5)
+        self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
 
-        url = '/api/asset/?order_by=selections'
+        url = '/api/asset/?order_by=-author'
         response = self.client.get(url)
         the_json = json.loads(response.content)
         objects = the_json['assets']
-        self.assertEqual(len(objects), 5)
-        self.assertEqual(objects[0]['primary_type'], 'video')
-        self.assertEqual(objects[0]['title'], 'asset 31')
-        self.assertEqual(objects[0]['annotation_count'], 1)
-        self.assertEqual(objects[4]['title'], 'asset 30')
-        self.assertEqual(objects[4]['annotation_count'], 2)
-
-        url = '/api/asset/?order_by=-selections'
-        response = self.client.get(url)
-        the_json = json.loads(response.content)
-        objects = the_json['assets']
-        self.assertEqual(len(objects), 5)
+        self.assertEqual(len(objects), 20)
         self.assertEqual(objects[0]['primary_type'], 'image')
-        self.assertEqual(objects[0]['title'], 'asset 30')
-        self.assertEqual(objects[0]['annotation_count'], 2)
-        self.assertEqual(objects[4]['title'], 'Zelda')
-        self.assertEqual(objects[4]['annotation_count'], 1)

--- a/mediathread/assetmgr/tests/test_api.py
+++ b/mediathread/assetmgr/tests/test_api.py
@@ -102,12 +102,12 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
 
         selections = [self.student_note.id, self.instructor_note.id]
         self.assertAssetEquals(objects[0], self.asset1.title,
-                               'Instructor One', 'image', selections)
+                               'One, Instructor', 'image', selections)
         self.assertFalse('global_annotation' in objects[0])
 
         self.assertAssetEquals(
             objects[1], self.asset2.title,
-            'Instructor One', 'video', [self.asset2_instructor_note.id])
+            'One, Instructor', 'video', [self.asset2_instructor_note.id])
         self.assertFalse('global_annotation' in objects[1])
 
     def test_restricted_getall_as_student(self):
@@ -130,12 +130,12 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
 
         selections = [self.instructor_note.id]
         self.assertAssetEquals(objects[0], self.asset1.title,
-                               'Instructor One', 'image', selections)
+                               'One, Instructor', 'image', selections)
         self.assertFalse('global_annotation' in objects[0])
 
         self.assertAssetEquals(
             objects[1], self.asset2.title,
-            'Instructor One', 'video', [self.asset2_instructor_note.id])
+            'One, Instructor', 'video', [self.asset2_instructor_note.id])
         self.assertFalse('global_annotation' in objects[1])
 
     def test_getall_as_instructor(self):
@@ -156,14 +156,14 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertEquals(len(match), 1)
         selections = [self.student_note.id, self.instructor_note.id]
         self.assertAssetEquals(match[0], self.asset1.title,
-                               'Instructor One', 'image', selections)
+                               'One, Instructor', 'image', selections)
         self.assertFalse('global_annotation' in objects[0])
 
         match = [x for x in objects if x['id'] == self.asset2.id]
         self.assertEquals(len(match), 1)
         self.assertAssetEquals(
             match[0], self.asset2.title,
-            'Instructor One', 'video', [self.asset2_instructor_note.id])
+            'One, Instructor', 'video', [self.asset2_instructor_note.id])
         self.assertFalse('global_annotation' in objects[1])
 
     def test_restricted_getall_as_instructor(self):
@@ -325,7 +325,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertAssetEquals(
             asset,
             self.asset1.title,
-            'Instructor One', 'image', selections)
+            'One, Instructor', 'image', selections)
 
         self.assertTrue('global_annotation' in asset)
         self.assertEquals(asset['global_annotation']['id'],
@@ -353,7 +353,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertAssetEquals(
             asset,
             self.asset1.title,
-            'Instructor One', 'image', selections)
+            'One, Instructor', 'image', selections)
 
         self.assertTrue('global_annotation' in asset)
         self.assertEquals(asset['global_annotation']['id'],
@@ -380,7 +380,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertAssetEquals(
             asset,
             self.asset1.title,
-            'Instructor One', 'image', selections)
+            'One, Instructor', 'image', selections)
 
         self.assertFalse('global_annotation' in asset)
 
@@ -404,7 +404,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         self.assertAssetEquals(
             asset,
             self.asset1.title,
-            'Instructor One', 'image', selections)
+            'One, Instructor', 'image', selections)
 
         self.assertFalse('global_annotation' in asset)
 
@@ -488,7 +488,7 @@ class AssetApiTest(MediathreadTestMixin, TestCase):
         selections = [self.instructor_note.id, self.student_note.id]
         asset = the_json['assets'][str(self.asset1.id)]
         self.assertAssetEquals(asset, self.asset1.title,
-                               'Instructor One', 'image', selections)
+                               'One, Instructor', 'image', selections)
 
         self.assertFalse('global_annotation' in asset)
 

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.db.models.functions import Lower
 from django.db.models.query_utils import Q
 from django.http import HttpResponse, HttpResponseForbidden, \
     HttpResponseRedirect, Http404
@@ -1136,7 +1137,10 @@ class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
 
         # Order by title, by default.
         ordering = request.GET.get('order_by', 'title')
-        assets = assets.order_by(ordering)
+        if ordering == 'title' or ordering == 'author':
+            assets = assets.order_by(Lower(ordering))
+        else:
+            assets = assets.order_by(ordering)
 
         offset = int(request.GET.get("offset", 0))
         limit = int(request.GET.get("limit", 20))

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -1137,8 +1137,20 @@ class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
 
         # Order by title, by default.
         ordering = request.GET.get('order_by', 'title')
-        if ordering == 'title' or ordering == 'author':
-            assets = assets.order_by(Lower(ordering))
+
+        if 'title' in ordering:
+            if ordering[0] == '-':
+                ordering = ordering[1:]
+                assets = assets.order_by(Lower(ordering)).reverse()
+            else:
+                assets = assets.order_by(Lower(ordering))
+        elif 'author' in ordering:
+            assets = assets.order_by(
+                Lower('author__last_name'),
+                Lower('author__first_name'),
+                Lower('author__username'))
+            if ordering[0] == '-':
+                assets = assets.reverse()
         else:
             assets = assets.order_by(ordering)
 

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -1054,67 +1054,6 @@ class ReactAssetDetailView(WaffleFlagMixin, LoggedInCourseMixin, DetailView):
         return context
 
 
-def sort_by_title(x):
-    return x.get('title', '').strip().lower()
-
-
-def sort_by_selections(x):
-    count = x.get('annotation_count', 0)
-    try:
-        return int(count)
-    except ValueError:
-        return 0
-
-
-def sort_by_author(x):
-    return x.get('author').get('public_name')
-
-
-def sort_by_default(order_by, x):
-    return x.get(order_by, None)
-
-
-def get_sort_function(order_by):
-    if order_by == 'title':
-        return sort_by_title
-    elif order_by == 'selections':
-        return sort_by_selections
-    elif order_by == 'author':
-        return sort_by_author
-
-    return sort_by_default(order_by)
-
-
-def sort_assets(assets, ordering):
-    return assets.order_by('title')
-    order_by = ordering.get('order_by')
-    sort_func = get_sort_function(order_by)
-
-    return sorted(
-        assets,
-        key=sort_func,
-        reverse=ordering.get('reverse'))
-
-
-def get_ordering(request):
-    """
-    Get the ordering from a request object
-
-    Returns a dict with order_by (field name) and reverse (asc or
-    desc) values.
-    """
-    order_by = request.GET.get('order_by', 'title')
-    order_reverse = False
-    if order_by.startswith('-'):
-        order_by = order_by[1:]
-        order_reverse = True
-
-    return {
-        'order_by': order_by,
-        'reverse': order_reverse,
-    }
-
-
 class AssetCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                           JSONResponseMixin, View):
     """

--- a/mediathread/main/features/homepage.delete.feature
+++ b/mediathread/main/features/homepage.delete.feature
@@ -14,8 +14,8 @@ Feature: Homepage Delete Operations. Project, Item
         Given there is a sample response
         Given I am instructor_one in Sample Course
         
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has 1 response named "Sample Assignment Response"
         The "Sample Assignment Response" project has no delete icon
         

--- a/mediathread/main/tests/test_api.py
+++ b/mediathread/main/tests/test_api.py
@@ -23,7 +23,7 @@ class UserApiTest(TestCase):
 
         member = UserResource().render_one(None, student_one)
 
-        self.assertEquals(member['public_name'], "Student One")
+        self.assertEquals(member['public_name'], "One, Student")
 
     def test_render_list(self):
         u = UserFactory(username='test_student_one',
@@ -53,10 +53,10 @@ class UserApiTest(TestCase):
         self.assertEquals(len(members), 6)
         self.assertEquals(members[0]['public_name'], "test_instructor_two")
         self.assertEquals(members[1]['public_name'], "test_student_three")
-        self.assertEquals(members[2]['public_name'], "Teacher's Assistant")
-        self.assertEquals(members[3]['public_name'], "Instructor One")
-        self.assertEquals(members[4]['public_name'], "Student One")
-        self.assertEquals(members[5]['public_name'], "Student Two")
+        self.assertEquals(members[2]['public_name'], "Assistant, Teacher's")
+        self.assertEquals(members[3]['public_name'], "One, Instructor")
+        self.assertEquals(members[4]['public_name'], "One, Student")
+        self.assertEquals(members[5]['public_name'], "Two, Student")
 
     def test_get_course_list(self):
         g1 = GroupFactory(name="group1")

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -454,7 +454,7 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         the_json = json.loads(response.content)
         self.assertEquals(the_json['course']['title'], 'Sample Course')
-        self.assertEquals(len(the_json['assets']), 1)
+        self.assertEquals(len(the_json['assets']), 2)
 
         self.assertEquals(the_json['assets'][0]['title'],
                           self.asset1.title)

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -454,7 +454,7 @@ class MigrateCourseViewTest(MediathreadTestMixin, TestCase):
 
         the_json = json.loads(response.content)
         self.assertEquals(the_json['course']['title'], 'Sample Course')
-        self.assertEquals(len(the_json['assets']), 2)
+        self.assertEquals(len(the_json['assets']), 1)
 
         self.assertEquals(the_json['assets'][0]['title'],
                           self.asset1.title)

--- a/mediathread/main/util.py
+++ b/mediathread/main/util.py
@@ -36,6 +36,18 @@ def user_display_name(user):
     return user.get_full_name() or user.username
 
 
+def user_display_name_last_first(user):
+    if user is None or \
+       (hasattr(user, 'is_anonymous') and user.is_anonymous):
+        return 'Anonymous'
+
+    if user.first_name and user.last_name:
+        return '{}, {}'.format(
+            user.last_name, user.first_name)
+
+    return user.username
+
+
 def make_pmt_item(data):
     """Make a PMT item containing the given data.
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -344,7 +344,10 @@ class MigrateMaterialsView(LoggedInFacultyMixin, AjaxRequiredMixin,
         if settings.SURELINK_URL:
             assets = assets.exclude(
                 source__url__startswith=settings.SURELINK_URL)
-        assets = assets.filter(sherdnote_set__author__id__in=faculty)
+        assets = assets.filter(
+            sherdnote_set__author__id__in=faculty
+        ).exclude(source__label='flv_pseudo')
+
         notes = SherdNote.objects.get_related_notes(
             assets, None, faculty, True).exclude_primary_types(['flv_pseudo'])
 

--- a/mediathread/projects/features/assignment.feature
+++ b/mediathread/projects/features/assignment.feature
@@ -117,8 +117,8 @@ Feature: Assignment
         Given there is a sample response
         Given I am instructor_one in Sample Course
 
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has 1 project named "Sample Assignment"
         Then the composition panel has 1 response named "Sample Assignment Response"
 
@@ -155,12 +155,12 @@ Feature: Assignment
         Then there is a comment from "Instructor One"
 
         Give I am student_two in Sample Course
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has 0 projects named "Sample Assignment Response"
         And there is not a "Read Instructor Feedback" link
 
-        When I select "Student Two" as the owner in the Composition column
+        When I select "Two, Student" as the owner in the Composition column
         Then the owner is "Me" in the Composition column
 
         When I click the "Sample Assignment" link
@@ -188,8 +188,8 @@ Feature: Assignment
         Then there is a "<status>" link
 
         Give I am <username> in Sample Course 
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has <count> responses named "Sample Assignment Response"
 
         # the response must be deleted

--- a/mediathread/projects/features/composition.feature
+++ b/mediathread/projects/features/composition.feature
@@ -145,14 +145,14 @@ Feature: Composition
 
         # Try to view as student two
         Given I am student_two in Sample Course
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has <count> projects named "<title>"
 
         # Try to view as test_instructor
         Given I am instructor_one in Sample Course
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has <count> projects named "<title>"
 
         Finished using Selenium

--- a/mediathread/projects/features/selectionassignment.feature
+++ b/mediathread/projects/features/selectionassignment.feature
@@ -72,8 +72,8 @@ Feature: Selection Assignment
         Given there is a sample selection assignment and response
         Given I am instructor_one in Sample Course
 
-        When I select "Student One" as the owner in the Composition column
-        Then the owner is "Student One" in the Composition column
+        When I select "One, Student" as the owner in the Composition column
+        Then the owner is "One, Student" in the Composition column
         Then the composition panel has 1 project named "Sample Selection Assignment"
         Then the composition panel has 1 response named "My Response"
 


### PR DESCRIPTION
Use database sort to sort assets. Use title for default asset sort. The
"assets" variable was getting passed around in assetmgr/views.py, but
ultimately ignored by the AssetResource.render_list() function. This
function can actually use the list of assets and preserve ordering.

This fixes the bugs we were seeing with asset ordering. And all the new
sorting code I added turned out to be unnecessary!

I realized that unit tests were only failing on python 2.7, because Python dictionary ordering behavior wasn't always defined clearly. I've disable these tests because they're not useful anymore: we're only running on python 3 on production. The lettuce tests on python 2 are still being run.