### PR TITLE
Only install pylibmc on linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -160,4 +160,4 @@ celery==3.1.26.post2 # pyup: <4.0.0
 django-celery==3.2.2 # pyup: <3.3.0
 
 # memcached
-pylibmc==1.6.1
+pylibmc==1.6.1; sys_platform == 'linux'


### PR DESCRIPTION
This fails on macOS. It's possible to get this package to compile with
something like:

  brew install libmemcached
  pip install pylibmc --install-option="--with-libmemcached=/usr/local/Cellar/libmemcached/1.0.18_2/"

But, I'm not sure how to hook up those path options to requirements.txt,
and besides, we don't need to test memcached stuff on our dev mac
laptops.