### PR TITLE
Downgrade coverage to 4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-mimeparse==1.6.0  # tastypie
 python-dateutil==2.8.1  # tastypie
 defusedxml==0.6.0  # tastypie
 django-tastypie==0.14.2 # pyup: < 0.14.3
-coverage==5.1
+coverage>=4.5.4,<5
 logilab-common>=1.4.4,<1.5
 lazy-object-proxy==1.4.3
 wrapt==1.12.1


### PR DESCRIPTION
jenkins was working, but then failed with my django.mk updates.
https://github.com/ccnmtl/mediathread/pull/2537

It's failing on a coverage report command.

See if this fixes the problem on jenkins.