### PR TITLE
Fix back button for new course page URL

### DIFF
--- a/media/js/src/CollectionTab.jsx
+++ b/media/js/src/CollectionTab.jsx
@@ -109,7 +109,8 @@ export default class CollectionTab extends React.Component {
 
         let backButton = null;
         if (this.state.selectedAsset) {
-            const courseUrl = window.location.href.replace(/\/asset\/\d+/, '');
+            const courseUrl = window.location.href.replace(
+                /react\/asset\/\d+/, '');
             backButton = (
                 <div className="btn-group mb-1" role="group"
                      aria-label="View Toggle">


### PR DESCRIPTION
Remove `/react/` from the path for the course page when clicked.