### PR TITLE
Use .tab-content instead of .container for asset detail

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -394,7 +394,7 @@ export default class AssetDetail extends React.Component {
         }
 
         return (
-            <div className="container asset-detail">
+            <div className="tab-content asset-detail">
                 <Alert
                     variant="success" show={this.state.showCreatedDialog}
                     onClose={this.hideCreatedDialog} dismissible


### PR DESCRIPTION
This follows Marc's design and fixes some spacing problems.