### PR TITLE
Use auto width and height for ReactPlayer video

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -437,6 +437,8 @@ export default class AssetDetail extends React.Component {
                     <div className="embed-responsive embed-responsive-4by3">
                         <ReactPlayer
                             className="react-player embed-responsive-item"
+                            width="auto"
+                            height="auto"
                             onPlay={this.onPlayerPlay.bind(this)}
                             onProgress={this.onPlayerProgress.bind(this)}
                             playing={this.state.playing}


### PR DESCRIPTION
We could also try setting these to `inherit` or `100%` if this doesn't work.