### PR TITLE
Add assignment list

### DIFF
--- a/cypress/integration/2.composition/composition.visibility.js
+++ b/cypress/integration/2.composition/composition.visibility.js
@@ -31,7 +31,7 @@ describe('Student Project Visibility', () => {
         cy.contains('Whole Class - all class members can view').click();
         cy.get('.btn-primary').contains('Save').click();
         cy.get('.project-savebutton').should('contain', 'Saved');
-        cy.get('.project-visibility-link').should('contain', 'Published to Class');
+        cy.get('.project-visibility-link').should('contain', 'Shared with Class');
     });
 
     // it('views composition as a Student', () => {
@@ -62,7 +62,7 @@ describe('Student Project Visibility', () => {
         cy.contains('Whole Class - all class members can view').click();
         cy.get('.btn-primary').contains('Save').click();
         cy.get('.project-savebutton').should('contain', 'Saved');
-        cy.get('.project-visibility-link').should('contain', 'Published to Class');
+        cy.get('.project-visibility-link').should('contain', 'Shared with Class');
     });
 
     // it('views Student One composition as Student Two', () => {

--- a/cypress/integration/2.composition/publishtoworld.composition.js
+++ b/cypress/integration/2.composition/publishtoworld.composition.js
@@ -48,7 +48,7 @@ describe('Publish To World Public Composition', () => {
         cy.get('.project-savebutton').click();
         cy.contains('Whole World - a public url is provided').click();
         cy.get('.btn-primary').contains('Save').click();
-        cy.get('.project-visibility-link').should('contain', 'Published to World');
+        cy.get('.project-visibility-link').should('contain', 'Shared with World');
 
         cy.log('log out and go to permalink');
         //TODO: Figure out a cleaner way to do this?

--- a/cypress/integration/3.assignments/assignment.creation_instructor.js
+++ b/cypress/integration/3.assignments/assignment.creation_instructor.js
@@ -42,7 +42,7 @@ describe('Assignment Feature: Instructor Creation', () => {
         cy.get('.btn-primary').contains('Save');
         cy.get('.btn-primary').click();
         cy.get('.project-visibility-link')
-            .should('contain', 'Published to Class');
+            .should('contain', 'Shared with Class');
         cy.get('.panel-container.open.assignment').should('exist');
         cy.get('.project-savebutton').should('contain', 'Saved');
 
@@ -66,7 +66,7 @@ describe('Assignment Feature: Instructor Creation', () => {
         cy.get('.participants_chosen').should('contain', 'Instructor One');
         cy.get('.project-visibility-link').should('have.attr', 'href');
         cy.get('.project-visibility-description')
-            .should('contain', 'Published to Class');
+            .should('contain', 'Shared with Class');
         cy.get('td.panel-container.open.assignment').should('exist');
         cy.get('.project-revisionbutton').should('exist');
         cy.get('.participant_list').should('not.be', 'visible');

--- a/cypress/integration/3.assignments/assignment.response_student.js
+++ b/cypress/integration/3.assignments/assignment.response_student.js
@@ -53,12 +53,12 @@ describe('Assignment Feature: Student Response', () => {
         cy.get('.btn-primary').contains('Save');
         cy.get('.btn-primary').click();
         cy.get('.project-visibility-link')
-            .should('contain', 'Submitted to Instructor');
+            .should('contain', 'Shared with Instructor');
 
         cy.log('Verify home display');
         cy.visit('/course/1/oldhome/');
         cy.get('#loaded').should('exist');
-        cy.contains('Submitted to Instructor').should('exist');
+        cy.contains('Shared with Instructor').should('exist');
         cy.contains('Sample Assignment Response').should('exist');
         cy.contains('by Student One').should('exist');
     });

--- a/cypress/integration/9.instructor/instructor.feat.4.js
+++ b/cypress/integration/9.instructor/instructor.feat.4.js
@@ -20,7 +20,7 @@ describe('Instructor Feat: Test Assignment Responses', () => {
         cy.contains('Assignment Report: Sample Assignment').should('exist');
         cy.contains('Student One').should('exist');
         cy.contains('Sample Assignment Response').should('have.attr', 'href');
-        cy.contains('Submitted to Instructor').should('exist');
+        cy.contains('Shared with Instructor').should('exist');
         cy.contains('No').should('exist');
 
         cy.contains('Sample Assignment Response').click();

--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -8,6 +8,12 @@ a, a.page-link {
     cursor: pointer;
 }
 
+.nav-pills .nav-link.active, .nav-pills .show>.nav-link:focus,
+.nav-pills .nav-link.active, .nav-pills .show>.nav-link:hover,
+.nav-pills .nav-link.active, .nav-pills .show>.nav-link {
+    background-color: #0056b3;
+}
+
 .page-item.active .page-link {
     background-color: #0056b3;
     border-color: #0056b3;
@@ -17,6 +23,8 @@ a, a.page-link {
     color: #0056b3;
 }
 
+.badge-primary,
+.btn-primary,
 .btn-outline-primary:not(:disabled):not(.disabled).active {
     background-color: #0056b3;
     border-color: #0056b3;
@@ -4331,6 +4339,7 @@ ul.section-tabs>li>a.active {
     font-weight: 700;
     background-color: #cccccc;
     border-color: #cccccc;
+    vertical-align: middle;
 }
 
 .table th.sortable {

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -40,9 +40,9 @@ PUBLISH_WHOLE_WORLD = \
 
 SHORT_NAME = {
     'PrivateEditorsAreOwners': 'Draft',
-    'InstructorShared': 'Submitted to Instructor',
-    'CourseProtected': 'Published to Class',
-    'PublicEditorsAreOwners': 'Published to World',
+    'InstructorShared': 'Shared with Instructor',
+    'CourseProtected': 'Shared with Class',
+    'PublicEditorsAreOwners': 'Shared with World',
     'PrivateStudentAndFaculty': 'with Instructors',
 }
 
@@ -272,7 +272,7 @@ class ProjectManager(models.Manager):
         exclude = [PROJECT_TYPE_COMPOSITION, PROJECT_TYPE_SEQUENCE]
         qs = Project.objects.filter(
             course=course, author__in=course.faculty_group.user_set.all())
-        qs = qs.exclude(project_type__in=[exclude])
+        qs = qs.exclude(project_type__in=exclude)
 
         collabs = Collaboration.objects.get_for_object_list(qs)
 

--- a/mediathread/projects/templatetags/user_projects.py
+++ b/mediathread/projects/templatetags/user_projects.py
@@ -19,8 +19,16 @@ class UserCourses(TemplateTagNode):
 register.tag('num_courses', UserCourses.process_tag)
 
 
+@register.filter(name='assignment_responses')
 def assignment_responses(project, request):
     return project.responses(request.course, request.user)
 
 
-register.filter(assignment_responses)
+@register.simple_tag
+def filter_responses(user, responses):
+    for response in responses:
+        if user == response.author or \
+                response.participants.filter(id=user.id).exists():
+            return response
+
+    return None

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -140,16 +140,16 @@ class ProjectTest(MediathreadTestMixin, TestCase):
 
         project = Project.objects.get(id=self.project_class_shared.id)
         self.assertEquals(project.description(), 'Composition')
-        self.assertEquals(project.visibility_short(), 'Published to Class')
+        self.assertEquals(project.visibility_short(), 'Shared with Class')
 
         project = Project.objects.get(id=self.project_instructor_shared.id)
         self.assertEquals(project.description(), 'Composition')
         self.assertEquals(project.visibility_short(),
-                          'Submitted to Instructor')
+                          'Shared with Instructor')
 
         assignment = Project.objects.get(id=self.assignment.id)
         self.assertEquals(assignment.description(), 'Composition Assignment')
-        self.assertEquals(assignment.visibility_short(), 'Published to Class')
+        self.assertEquals(assignment.visibility_short(), 'Shared with Class')
 
         sassignment = Project.objects.get(id=self.selection_assignment.id)
         self.assertEquals(sassignment.description(), 'Selection Assignment')
@@ -187,7 +187,7 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         self.assertEquals(new_project.author, self.alt_instructor)
         self.assertEquals(new_project.course, self.alt_course)
         self.assertEquals(new_project.description(), 'Composition Assignment')
-        self.assertEquals(new_project.visibility_short(), 'Published to Class')
+        self.assertEquals(new_project.visibility_short(), 'Shared with Class')
         self.assertEquals(AssignmentItem.objects.count(), 0)
 
     def test_migrate_selection_assignment(self):
@@ -263,7 +263,7 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         project = self.alt_course.project_set.all()[0]
         self.assertEquals(project.title, self.assignment.title)
         self.assertEquals(project.description(), 'Composition Assignment')
-        self.assertEquals(project.visibility_short(), 'Published to Class')
+        self.assertEquals(project.visibility_short(), 'Shared with Class')
         self.assertEquals(project.author, self.alt_instructor)
 
         citations = SherdNote.objects.references_in_string(project.body,

--- a/mediathread/projects/tests/test_templatetags.py
+++ b/mediathread/projects/tests/test_templatetags.py
@@ -1,8 +1,9 @@
 from django.template.base import Template
 from django.template.context import Context
 from django.test.testcases import TestCase
-
-from mediathread.factories import UserFactory, MediathreadTestMixin
+from mediathread.factories import UserFactory, MediathreadTestMixin, \
+    ProjectFactory
+from mediathread.projects.templatetags.user_projects import filter_responses
 
 
 class TestTemplateTags(MediathreadTestMixin, TestCase):
@@ -24,3 +25,18 @@ class TestTemplateTags(MediathreadTestMixin, TestCase):
             "{{user_courses}}"
         ).render(Context({'user': self.instructor_three}))
         self.assertEqual(out, "2")
+
+    def test_filter_responses(self):
+        p1 = ProjectFactory.create(
+            course=self.sample_course, author=self.student_two,
+            title='B', policy='PrivateEditorsAreOwners')
+        p2 = ProjectFactory.create(
+            course=self.sample_course, author=self.student_one,
+            title='A', policy='PrivateEditorsAreOwners')
+        self.assertEquals(p2, filter_responses(self.student_one, [p1, p2]))
+
+        shared = ProjectFactory.create(
+            course=self.sample_course, author=self.student_two,
+            title='B', policy='PrivateEditorsAreOwners')
+        shared.participants.add(self.student_one)
+        self.assertEquals(shared, filter_responses(self.student_one, [shared]))

--- a/mediathread/reports/tests/test_views.py
+++ b/mediathread/reports/tests/test_views.py
@@ -332,7 +332,7 @@ class TestAssignmentDetailReport(MediathreadTestMixin, TestCase):
         self.assertEquals(row[0], 'Student One')
         self.assertEquals(row[1], 'student_one')
         self.assertEquals(row[2], 'Response 1')
-        self.assertEquals(row[3], 'Submitted to Instructor')
+        self.assertEquals(row[3], 'Shared with Instructor')
         self.assertIsNone(row[4])
         # row[5] modified date
         self.assertFalse(row[6])

--- a/mediathread/templates/projects/assignment_list.html
+++ b/mediathread/templates/projects/assignment_list.html
@@ -1,7 +1,18 @@
 {% extends "base_new.html" %}
+{% load coursetags static user_projects %}
+
+{% block title %}
+Assignments
+{% endblock %}
+
+{% block css %}
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.min.css' %}">
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.custom.css' %}">
+{% endblock %}
 
 {% block content %}
-<div>
+{% course_role for request.user in request.course as role_in_course %}
+<div class="">
     <div>
         <nav id="three-section-tabs" class="nav nav-tabs flex-column flex-sm-row"
             role="tablist">
@@ -11,17 +22,231 @@
             </a>
             <a class="flex-sm-fill text-sm-center nav-link active" role="tab"
                 href="{% url 'assignment-list' course.pk %}"
-                title="Assignments" href="assignments/">Assignments</a>
+                title="Assignments" href="assignments/">
+                    Assignments
+                    {% if role_in_course == 'student' and unresponded > 0 %}
+                        <span class="badge badge-primary ml-2">{{unresponded}}</span>
+                    {% endif %}
+            </a>
             <a class="flex-sm-fill text-sm-center nav-link" role="tab"
                 href="{% url 'project-list' course.pk %}"
                 title="Projects" href="projects/">Projects</a>
         </nav>
         <div class="tab-content">
             <div role="tabpanel">
-                <h1 class="page-title">Assignments</h1>
+                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                    <div class="col-md-6">
+                        <h1 class="page-title">Assignments</h1>
+                    </div>
+                    <div class="col-md-6 text-right">
+                        {% if role_in_course != "student" %}
+                            <div class="form-group col-md-12">
+                                <div class="btn-group" role="group">
+                                    <form action="{% url 'project-create' course.id %}" method="post">
+                                        <input type="hidden" name="project_type" value="assignment" />
+                                        <button id="add-sequence-button" type="submit" class="btn btn-sm btn-outline-secondary mr-2">
+                                            Add Composition Assignment
+                                        </button>
+                                    </form>
+                                    <a class="btn btn-sm btn-outline-secondary mr-2"
+                                        href="{% url 'selection-assignment-create' course.id %}">
+                                        Add Selection Assignment
+                                    </a>
+                                    <a class="btn btn-sm btn-outline-secondary"
+                                        href="{% url 'sequence-assignment-create' course.id %}">
+                                        Add Sequence Assignment
+                                    </a>
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div id="search-well">
+                </div>
+                {% if paginator.num_pages > 1 %}
+                <div class="row">
+                    <div class="col-md-6 offset-md-6">
+                        <div class="text-right">
+                            {% include 'projects/pagination.html' %}
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+                <form id="search-form" action="." method="get">
+                    <input type="hidden" name="sortby" value="{{sortby}}">
+                    <input type="hidden" name="direction" value="{{direction}}">
+                    <input type="hidden" name="page" value="{{page_obj.number}}">
+                </form>
+                <div class="row">
+                    <div class="col-12">
+                        {% if object_list.exists %}
+                            <div class="table-responsive">
+                                <table class="table table-bordered table-striped w-100 tablesorter">
+                                    <thead class="thead-darkgray">
+                                        <th data-sort-by="due_date"
+                                            class="sortable {% if sortby == 'due_date' %}{{direction}}{% endif %}">
+                                            Due Date
+                                        </th>
+                                        <th data-sort-by="title"
+                                            class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
+                                            Title
+                                        </th>
+                                        <th>
+                                            Status
+                                        </th>
+                                        <th>
+                                            Action
+                                        </th>
+                                        {% if role_in_course != 'student' %}
+                                            <th>
+                                                Responses
+                                            </th>
+                                            <th data-sort-by="full_name"
+                                                class="sortable {% if sortby == 'full_name' %}{{direction}}{% endif %}">
+                                                Authors
+                                            </th>
+                                        {% endif %}
+                                        <th data-sort-by="project_type"
+                                            class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
+                                            Type
+                                        </th>
+                                        <th data-sort-by="modified"
+                                            class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
+                                            Modified
+                                        </th>
+                                    </thead>
+                                    <tbody>
+                                    {% for object in object_list %}
+                                        {% with responses=object|assignment_responses:request %}
+                                        {% filter_responses request.user responses as response %}
+                                        <tr>
+                                            <td>
+                                                {% if object.due_date %}
+                                                    {{object.due_date|date:"n/j/y g:iA"}}<br />
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <div>
+                                                    {% if role_in_course == "student" %}
+                                                        {{object.title}}
+                                                    {% else %}
+                                                        <a href="{% url 'project-workspace' course.id object.id %}" title="{{object.title}}">
+                                                            {{object.title}}
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                            <td>
+                                                {% if role_in_course == "student" %}
+                                                    {% if response %}
+                                                        {% if response.is_submitted %}
+                                                            <div>Submitted {{response.date_submitted|date:"n/j/y g:iA"}}</div>
+                                                            <div>{{response.visibility_short}}</div>
+                                                        {% else %}
+                                                            {{response.visibility_short}}
+                                                        {% endif %}
+                                                    {% endif %}
+                                                {% else %}
+                                                    {{object.visibility_short}}
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if role_in_course == "student" %}
+                                                    {% if not response %}
+                                                        <form action="{% url 'project-create' course.id %}" method="post">
+                                                            <input type="hidden" name="parent" value="{{object.id}}">
+                                                            <input type="hidden" name="project_type" value="{{object.project_type}}">
+                                                            <input type="hidden" name="title" value="My Response">
+                                                            <button class="btn btn-sm btn-primary btn-block" type="submit">Add Response</button>
+                                                        </form>
+                                                    {% else %}{% if response.feedback_discussion %}
+                                                        <a class="btn btn-sm btn-primary btn-block"
+                                                            href="{% url 'project-workspace' course.id response.id %}" title="{{response.title}}">
+                                                            View Feedback
+                                                        </a>
+                                                    {% else %}{% if response.is_submitted %}
+                                                        <a class="btn btn-sm btn-secondary btn-block"
+                                                            href="{% url 'project-workspace' course.id response.id %}" title="{{response.title}}">
+                                                            View Response
+                                                        </a>
+                                                    {% else %}
+                                                        <a class="btn btn-sm btn-primary btn-block"
+                                                            href="{% url 'project-workspace' course.id response.id %}" title="{{response.title}}">
+                                                            Edit Response
+                                                        </a>
+                                                    {% endif %}{% endif %}{% endif %}
+                                                {% else %}
+                                                    <a class="btn btn-sm btn-primary btn-block"
+                                                        href="{% url 'project-workspace' course.id object.id %}" title="{{object.title}}">
+                                                        Edit
+                                                    </a>
+                                                {% endif %}
+                                            </td>
+                                            {% if role_in_course != "student" %}
+                                                <td class="text-center">
+                                                    {% if role_in_course != "student" %}
+                                                        {{responses|length}} / {{course.students|length}}
+                                                    {% endif %}
+                                                </td>
+                                                <td>
+                                                    {{object.attribution}}
+                                                </td>
+                                            {% endif %}
+                                            <td>
+                                                {{object.description}}
+                                            </td>
+                                            <td>
+                                                {% if role_in_course == "student" %}
+                                                    {% if response %}
+                                                    {{response.modified|date:"n/j/y g:iA"}}
+                                                {% endif %}
+                                                {% else %}
+                                                    {{object.modified}}
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% endwith %}
+                                    {% empty %}
+                                        No projects found
+                                    {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                        {% endif %}
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
+{% endblock %}
 
+{% block js %}
+    <script>
+        jQuery(document).ready(function() {
+            jQuery('.sortable').on('click', (evt) => {
+                const $frm = jQuery('#search-form');
+
+                let direction = 'asc';
+                const sortBy = jQuery(evt.currentTarget).data('sort-by');
+                if (sortBy === $frm.find('[name="sortby"]').val()) {
+                    if ($frm.find('[name="direction"]').val() === 'asc') {
+                        direction = 'desc';
+                    }
+                }
+
+                $frm.find('[name="page"]').val(1);
+                $frm.find('[name="direction"]').val(direction);
+                $frm.find('[name="sortby"]').val(sortBy);
+                $frm.submit();
+            });
+            jQuery('a.page-link').on('click', (evt) => {
+                const $frm = jQuery('#search-form');
+                const pageNo = jQuery(evt.currentTarget).data('page-number');
+                $frm.find('[name="page"]').val(pageNo);
+                $frm.submit();
+            });
+        });
+    </script>
 {% endblock %}

--- a/mediathread/templates/projects/project_list.html
+++ b/mediathread/templates/projects/project_list.html
@@ -1,6 +1,10 @@
 {% extends "base_new.html" %}
 {% load static %}
 
+{% block title %}
+Projects
+{% endblock %}
+
 {% block css %}
     <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.min.css' %}">
     <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.custom.css' %}">
@@ -17,25 +21,48 @@
             </a>
             <a class="flex-sm-fill text-sm-center nav-link" role="tab"
                 href="{% url 'assignment-list' course.pk %}"
-                title="Assignments" href="assignments/">Assignments</a>
+                title="Assignments" href="assignments/">
+                Assignments
+                {% if role_in_course == 'student' and unresponded > 0 %}
+                    <span class="badge badge-primary ml-2">{{unresponded}}</span>
+                {% endif %}
+            </a>
             <a class="flex-sm-fill text-sm-center nav-link active" role="tab"
                 href="{% url 'project-list' course.pk %}"
                 title="Projects" href="projects/">Projects</a>
         </nav>
         <div class="tab-content">
             <div role="tabpanel">
-                <div class="row">
-                    <div class="col-md-12">
+                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                    <div class="col-md-6">
                         <h1 class="page-title">Projects</h1>
+                    </div>
+                    <div class="col-md-6 text-right">
+                        <div class="form-group col-md-12">
+                            <div class="btn-group" role="group">
+                                <form action="{% url 'project-create' course.id %}" method="post">
+                                    <input type="hidden" name="project_type" value="composition" />
+                                    <button id="add-composition-button" type="submit" class="btn btn-outline-secondary btn-sm mr-2">
+                                        Add Composition
+                                    </button> 
+                                </form>
+                                <form action="{% url 'project-create' course.id %}" method="post">
+                                    <input type="hidden" name="project_type" value="sequence" />
+                                    <button id="add-sequence-button" type="submit" class="btn btn-outline-secondary btn-sm">
+                                        Add Sequence
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div id="search-well">
                     <div class="form-row">
                         <div class="form-group col-md-4">
-                            <label for="owner-filter">Owner</label>
-                            <select id="select-owner" name="owner" class="form-control form-control-sm">
+                            <label for="select-owner">Owner</label>
+                            <select id="select-owner" name="owner" class="form-control form-control-sm mb-3">
                                 <option {% if not owner or owner == user %}selected{% endif %} value="{{user.username}}">Me</option>
-                                {% for o in owners %}
+                                {% for o in course.members %}
                                     {% if o != user %}
                                         <option {% if o == owner %}selected{% endif %} value="{{o.username}}">
                                             {% if o.last_name %}
@@ -49,24 +76,17 @@
                                 {% endfor %}
                             </select>
                         </div>
-                        <div class="form-group col-md-4 offset-md-4">
-                            <div class="btn-group float-right mt-4" role="group">
-                                <form action="{% url 'project-create' course.id %}" method="post">
-                                    <input type="hidden" name="project_type" value="composition" />
-                                    <button id="add-composition-button" type="submit" class="btn btn-outline-secondary mr-2">
-                                        Add Composition
-                                    </button> 
-                                </form>
-                                <form action="{% url 'project-create' course.id %}" method="post">
-                                    <input type="hidden" name="project_type" value="sequence" />
-                                    <button id="add-sequence-button" type="submit" class="btn btn-outline-secondary">
-                                        Add Sequence
-                                    </button>
-                                </form>
-                            </div>
+                    </div>
+                </div>
+                {% if paginator.num_pages > 1 %}
+                <div class="row">
+                    <div class="col-md-6 offset-md-6">
+                        <div class="text-right">
+                            {% include 'projects/pagination.html' %}
                         </div>
                     </div>
                 </div>
+                {% endif %}
                 <form id="search-form" action="." method="get">
                     <input type="hidden" name="owner" value="{{owner}}">
                     <input type="hidden" name="sortby" value="{{sortby}}">
@@ -80,17 +100,18 @@
                                         <thead class="thead-darkgray">
                                             <th data-sort-by="title"
                                                 class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
-                                                Project Title
+                                                Title
                                             </th>
-                                            <th>
+                                            <th data-sort-by="visibility">
+                                                Status
+                                            </th>
+                                            <th data-sort-by="full_name"
+                                                class="sortable {% if sortby == 'full_name' %}{{direction}}{% endif %}">
                                                 Authors
                                             </th>
                                             <th data-sort-by="project_type"
                                                 class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
                                                 Type
-                                            </th>
-                                            <th data-sort-by="visibility">
-                                                Visibility
                                             </th>
                                             <th data-sort-by="modified"
                                                 class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
@@ -105,24 +126,26 @@
                                                         {{object.title}}
                                                     </a>
                                                 </td>
+                                                <td>{{object.visibility_short}}</td>
                                                 <td>{{object.attribution}}</td>
                                                 <td>{{object.description}}</td>
-                                                <td>{{object.visibility}}</td>
-                                                <td>{{object.modified}}</td>
+                                                <td>{{object.modified|date:"n/j/y g:iA"}}</td>
                                             </tr>
-                                        {% empty %}
-                                            No projects found
                                         {% endfor %}
                                         </tbody>
                                     </table>
                                 </div>
                             {% else %}
+                                <div class="text-center w-100">
+                                    {% if owner == request.user %}
+                                        <h4 class="ml-1">You have no projects yet.</h4>
+                                    {% else %}{% if owner.last_name %}
+                                        <h4 class="ml-1">{{owner.first_name}} {{owner.last_name}} has not shared any projects.</h4>
+                                    {% else %}
+                                        <h4 class="ml-1">{{owner.username}} has not shared any projects.</h4>
+                                    {% endif %}{% endif %}
+                                </div>
                             {% endif %}
-                        </div>
-                    </div>
-                    <div class="row mb-2">
-                        <div class="col-md-6 offset-md-6">
-                            {% include 'projects/pagination.html' %}
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
This PR adds an assignment list view. Assignments are shown in a tabular / sortable view to boost scannability. Instructors can create assignments directly from this screen and view the number of responses submitted. Students have a simplified view that lists assignments in order due with action buttons to add / edit / view their responses. A few other things happening in this PR:

* Updated “Published to Class” and “Submitted to Instructor” to more consistent language “Shared with Instructor”, “Shared with Class”
* Project create logic now redirects to the course-aware urls
* Additional sorting logic added around author name
* Accessibility and Responsiveness verified
* On the student view, a badge indicates how many assignments need responses

@todo add a "duration until due" metric as the sanest sortable field and address performance issues.

**Student View**
<img width="1009" alt="Screen Shot 2020-07-04 at 1 18 59 PM" src="https://user-images.githubusercontent.com/141369/86517762-796e4e80-bdf9-11ea-9b3f-85c6fae256df.png">

**Instructor View**
![Screen Shot 2020-07-04 at 1 18 46 PM](https://user-images.githubusercontent.com/141369/86517789-8ab75b00-bdf9-11ea-85f8-7c21f7d6c312.png)
