### PR TITLE
Don't compress react bundle with django-compressor

### DIFF
--- a/mediathread/templates/courseaffils/course_detail.html
+++ b/mediathread/templates/courseaffils/course_detail.html
@@ -14,8 +14,8 @@
     </div>
 {% endblock %}
 
-{% block js %}
-    <script src="{% static 'js/bundle.js' %}?cachebust=v1"></script>
+{% block uncompressable_js %}
+    <script src="{% static 'js/bundle.js' %}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This looks like the real issue we've been having with this out of date
JS bundle.

It's currently getting fetched at a URL like this:
https://ccnmtl-mediathread-static-stage.s3.amazonaws.com/media/CACHE/js/output.e1cd2de86eb9.js

In any case, we never want to compress this - that's already handled and
optimized by webpack. If this doesn't fix the issue, we'll look further.