### PR TITLE
Optimize assignments view

### DIFF
--- a/mediathread/projects/templatetags/user_projects.py
+++ b/mediathread/projects/templatetags/user_projects.py
@@ -1,6 +1,7 @@
 from django import template
+from django.db.models import Q
 from djangohelpers.templatetags import TemplateTagNode
-from mediathread.projects.models import Course
+from mediathread.projects.models import Course, PUBLISHED
 
 
 register = template.Library()
@@ -25,10 +26,12 @@ def assignment_responses(project, request):
 
 
 @register.simple_tag
-def filter_responses(user, responses):
-    for response in responses:
-        if user == response.author or \
-                response.participants.filter(id=user.id).exists():
-            return response
+def published_assignment_responses(project):
+    return project.collaboration.first().children.filter(
+        policy_record__policy_name__in=PUBLISHED).count()
 
-    return None
+
+@register.simple_tag
+def my_assignment_responses(project, user):
+    return project.collaboration.first().children.filter(
+        Q(project__author=user) | Q(project__participants=user)).distinct()

--- a/mediathread/projects/tests/test_templatetags.py
+++ b/mediathread/projects/tests/test_templatetags.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from django.template.base import Template
 from django.template.context import Context
 from django.test import TestCase, RequestFactory
-from django.test.testcases import TestCase
 from mediathread.factories import UserFactory, MediathreadTestMixin, \
     ProjectFactory
 from mediathread.projects.models import PUBLISH_WHOLE_CLASS, PUBLISH_DRAFT

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -24,7 +24,8 @@ from mediathread.assetmgr.api import AssetResource
 from mediathread.assetmgr.models import Asset
 from mediathread.discussions.views import threaded_comment_json
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
-from mediathread.main.course_details import allow_public_compositions
+from mediathread.main.course_details import allow_public_compositions, \
+    cached_course_is_faculty, cached_course_is_member
 from mediathread.main.models import UserSetting
 from mediathread.mixins import (
     LoggedInCourseMixin, RestrictedMaterialsMixin, AjaxRequiredMixin,
@@ -798,7 +799,8 @@ class ProjectListView(LoggedInCourseMixin, ListView):
         qs = Project.objects.projects_visible_by_course_and_owner(
             self.request.course, self.request.user, self.get_project_owner())
         qs = self.sort_queryset(qs, 'title', 'asc')
-        return qs.select_related('author').prefetch_related('participants')
+        return qs.select_related('author').prefetch_related(
+            'participants', 'collaboration__policy_record')
 
 
 class AssignmentListView(ProjectListView):
@@ -810,7 +812,10 @@ class AssignmentListView(ProjectListView):
         qs = Project.objects.visible_assignments_by_course(
             self.request.course, self.request.user)
         qs = self.sort_queryset(qs, 'due_date', 'desc')
-        return qs.select_related('author').prefetch_related('participants')
+        return qs.select_related('author').prefetch_related(
+            'participants', 'collaboration__children',
+            'collaboration__policy_record',
+            'collaboration__children__content_object')
 
 
 class ProjectCollectionView(LoggedInCourseMixin, RestrictedMaterialsMixin,

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -24,8 +24,7 @@ from mediathread.assetmgr.api import AssetResource
 from mediathread.assetmgr.models import Asset
 from mediathread.discussions.views import threaded_comment_json
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
-from mediathread.main.course_details import allow_public_compositions, \
-    cached_course_is_faculty, cached_course_is_member
+from mediathread.main.course_details import allow_public_compositions
 from mediathread.main.models import UserSetting
 from mediathread.mixins import (
     LoggedInCourseMixin, RestrictedMaterialsMixin, AjaxRequiredMixin,

--- a/mediathread/templates/projects/assignment_list.html
+++ b/mediathread/templates/projects/assignment_list.html
@@ -1,5 +1,5 @@
 {% extends "base_new.html" %}
-{% load coursetags static user_projects %}
+{% load coursetags static %}
 
 {% block title %}
 Assignments
@@ -62,139 +62,21 @@ Assignments
                     <input type="hidden" name="direction" value="{{direction}}">
                     <input type="hidden" name="page" value="{{page_obj.number}}">
                 </form>
-                <div class="row">
-                    <div class="col-12">
-                        {% if object_list.exists %}
-                            <div class="table-responsive">
-                                <table class="table table-bordered table-striped w-100 tablesorter">
-                                    <thead class="thead-darkgray">
-                                        <th data-sort-by="due_date"
-                                            class="sortable {% if sortby == 'due_date' %}{{direction}}{% endif %}">
-                                            Due Date
-                                        </th>
-                                        <th data-sort-by="title"
-                                            class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
-                                            Title
-                                        </th>
-                                        <th>
-                                            Status
-                                        </th>
-                                        <th>
-                                            Action
-                                        </th>
-                                        {% if role_in_course != 'student' %}
-                                            <th>
-                                                Responses
-                                            </th>
-                                            <th data-sort-by="full_name"
-                                                class="sortable {% if sortby == 'full_name' %}{{direction}}{% endif %}">
-                                                Authors
-                                            </th>
-                                        {% endif %}
-                                        <th data-sort-by="project_type"
-                                            class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
-                                            Type
-                                        </th>
-                                        <th data-sort-by="modified"
-                                            class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
-                                            Last Updated
-                                        </th>
-                                    </thead>
-                                    <tbody>
-                                    {% for object in object_list %}
-                                        {% with responses=object|assignment_responses:request %}
-                                        {% filter_responses request.user responses as response %}
-                                        <tr>
-                                            <td>
-                                                {% if object.due_date %}
-                                                    {{object.due_date|date:"n/j/y"}}<br />
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                <div>
-                                                    {{object.title}}
-                                                </div>
-                                            </td>
-                                            <td>
-                                                {% if role_in_course == "student" %}
-                                                    {% if response %}
-                                                        {% if response.is_submitted %}
-                                                            <div>Submitted {{response.date_submitted|date:"n/j/y g:iA"}}</div>
-                                                            <div>{{response.visibility_short}}</div>
-                                                        {% else %}
-                                                            {{response.visibility_short}}
-                                                        {% endif %}
-                                                    {% endif %}
-                                                {% else %}
-                                                    {{object.visibility_short}}
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if role_in_course == "student" %}
-                                                    {% if not response %}
-                                                        <form action="{% url 'project-create' request.course.id %}" method="post">
-                                                            <input type="hidden" name="parent" value="{{object.id}}">
-                                                            <input type="hidden" name="project_type" value="composition">
-                                                            <input type="hidden" name="title" value="My Response">
-                                                            <button class="btn btn-sm btn-primary btn-block" type="submit">Add Response</button>
-                                                        </form>
-                                                    {% else %}{% if response.feedback_discussion %}
-                                                        <a class="btn btn-sm btn-primary btn-block"
-                                                            href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                                            View Feedback
-                                                        </a>
-                                                    {% else %}{% if response.is_submitted %}
-                                                        <a class="btn btn-sm btn-secondary btn-block"
-                                                            href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                                            View Response
-                                                        </a>
-                                                    {% else %}
-                                                        <a class="btn btn-sm btn-primary btn-block"
-                                                            href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                                            Edit Response
-                                                        </a>
-                                                    {% endif %}{% endif %}{% endif %}
-                                                {% else %}
-                                                    <a class="btn btn-sm btn-primary btn-block"
-                                                        href="{% url 'project-workspace' request.course.id object.id %}" title="{{object.title}}">
-                                                        View
-                                                    </a>
-                                                {% endif %}
-                                            </td>
-                                            {% if role_in_course != "student" %}
-                                                <td class="text-center">
-                                                    {% if role_in_course != "student" %}
-                                                        {{responses|length}} / {{request.course.students|length}}
-                                                    {% endif %}
-                                                </td>
-                                                <td>
-                                                    {{object.attribution}}
-                                                </td>
-                                            {% endif %}
-                                            <td>
-                                                {{object.description}}
-                                            </td>
-                                            <td>
-                                                {% if role_in_course == "student" %}
-                                                    {% if response %}
-                                                    {{response.modified|date:"n/j/y g:iA"}}
-                                                {% endif %}
-                                                {% else %}
-                                                    {{object.modified}}
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                        {% endwith %}
-                                    {% empty %}
-                                        No projects found
-                                    {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                        {% else %}
-                        {% endif %}
+                {% if object_list.exists %}
+                    <div class="row">
+                        <div class="col-12">
+                            {% if role_in_course == 'student' %}
+                                {% include 'projects/assignment_table_student.html' %}
+                            {% else %}
+                                {% include 'projects/assignment_table_faculty.html' %}
+                            {% endif %}
+                        </div>
                     </div>
-                </div>
+                {% else %}
+                    <div class="text-center w-100">
+                        <h4>You have no assignments yet.</h4>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/mediathread/templates/projects/assignment_table_faculty.html
+++ b/mediathread/templates/projects/assignment_table_faculty.html
@@ -1,0 +1,83 @@
+{% load user_projects %}
+
+<div class="table-responsive">
+    <table class="table table-bordered table-striped w-100 tablesorter">
+        <thead class="thead-darkgray">
+            <th data-sort-by="due_date"
+                class="sortable {% if sortby == 'due_date' %}{{direction}}{% endif %}">
+                Due Date
+            </th>
+            <th data-sort-by="title"
+                class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
+                Title
+            </th>
+            <th>
+                Status
+            </th>
+            <th>
+                Action
+            </th>
+            <th>
+                Responses
+            </th>
+            <th data-sort-by="full_name"
+                class="sortable {% if sortby == 'full_name' %}{{direction}}{% endif %}">
+                Authors
+            </th>
+            <th data-sort-by="project_type"
+                class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
+                Type
+            </th>
+            <th data-sort-by="modified"
+                class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
+                Last Updated
+            </th>
+        </thead>
+        <tbody>
+        {% for object in object_list %}
+            <tr>
+                <td>
+                    {% if object.due_date %}
+                        {{object.due_date|date:"n/j/y"}}<br />
+                    {% endif %}
+                </td>
+                <td>
+                    <div>
+                        {{object.title}}
+                    </div>
+                </td>
+                <td>
+                    {{object.visibility_short}}
+                </td>
+                <td>
+                    {% if request.user == object.author or request.user in object.participants %}
+                        <a class="btn btn-sm btn-primary btn-block"
+                            href="{% url 'project-workspace' request.course.id object.id %}" title="{{object.title}}">
+                                Edit
+                        </a>
+                    {% else %}
+                        <a class="btn btn-sm btn-secondary btn-block"
+                            href="{% url 'project-workspace' request.course.id object.id %}" title="{{object.title}}">
+                                View
+                        </a>
+                    {% endif %}
+                    </a>
+                </td>
+                <td class="text-center">
+                    {% published_assignment_responses object as response_count %}
+                    {{response_count}} / {{request.course.students|length}}
+                </td>
+                <td>
+                    {{object.attribution}}
+                </td>
+                <td>
+                    {{object.description}}
+                </td>
+                <td>
+                    {{object.modified}}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/mediathread/templates/projects/assignment_table_student.html
+++ b/mediathread/templates/projects/assignment_table_student.html
@@ -1,0 +1,120 @@
+{% load user_projects %}
+<div class="table-responsive">
+    <table class="table table-bordered table-striped w-100 tablesorter">
+        <thead class="thead-darkgray">
+            <th data-sort-by="due_date"
+                class="sortable {% if sortby == 'due_date' %}{{direction}}{% endif %}">
+                Due Date
+            </th>
+            <th data-sort-by="title"
+                class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
+                Title
+            </th>
+            <th>
+                Status
+            </th>
+            <th>
+                Action
+            </th>
+            <th data-sort-by="project_type"
+                class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
+                Type
+            </th>
+            <th data-sort-by="modified"
+                class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
+                Last Updated
+            </th>
+        </thead>
+        <tbody>
+        {% for object in object_list %}
+            {% my_assignment_responses object request.user as responses %}
+            
+            {% comment %}
+                Users can potentially have multiple responses to an assignment
+                by collaborating with fellow students.
+            {% endcomment %}
+            
+            {% if responses.exists %}
+                {% for response_collaboration in responses %}
+                    {% with response=response_collaboration.content_object %}
+                    <tr>
+                        <td>
+                            {% if object.due_date %}
+                                {{object.due_date|date:"n/j/y"}}<br />
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div>
+                                {{object.title}}
+                            </div>
+                        </td>
+                        <td>
+                            {% if response.is_submitted %}
+                                <div>Submitted {{response.date_submitted|date:"n/j/y g:iA"}}</div>
+                                <div>{{response.visibility_short}}</div>
+                            {% else %}
+                                {{response.visibility_short}}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if response.feedback_discussion %}
+                                <a class="btn btn-sm btn-primary btn-block"
+                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                    View Feedback
+                                </a>
+                            {% else %}{% if response.is_submitted %}
+                                <a class="btn btn-sm btn-secondary btn-block"
+                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                    View Response
+                                </a>
+                            {% else %}
+                                <a class="btn btn-sm btn-primary btn-block"
+                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                    Edit Response
+                                </a>
+                            {% endif %}{% endif %}
+                        </td>
+                        <td>
+                            {{object.description}}
+                        </td>
+                        <td>
+                            {{response.modified|date:"n/j/y g:iA"}}
+                        </td>
+                    </tr>
+                    {% endwith %}
+                {% endfor %}
+            {% else %}
+                {% comment %}
+                    Student has not yet created a response
+                {% endcomment %}
+                <tr>
+                    <td>
+                        {% if object.due_date %}
+                            {{object.due_date|date:"n/j/y"}}<br />
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{object.title}}
+                    </td>
+                    <td>
+                        No Response
+                    </td>
+                    <td>
+                        <form action="{% url 'project-create' request.course.id %}" method="post">
+                            <input type="hidden" name="parent" value="{{object.id}}">
+                            <input type="hidden" name="project_type" value="composition">
+                            <input type="hidden" name="title" value="My Response">
+                            <button class="btn btn-sm btn-primary btn-block" type="submit">Add Response</button>
+                        </form>
+                    </td>
+                    <td>
+                        {{object.description}}
+                    </td>
+                    <td>
+                    </td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
* Refactor the visible_assignments_for_course query to start with the Collaboration object, taking advantage of the new GenericRelation to create a more readable query.
* Avoid the "can_read" manual permissions test for this view. The complexity there deals with viewing peer work. In this view, we just care about viewing your own work.
* Break apart the templates to make these views more readable and less fractured by conditional statements