### PR TITLE
Assignments List: Add a logical sort order for student view

### DIFF
--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -788,7 +788,8 @@ class AssetEmbedViewsTest(MediathreadTestMixin, TestCase):
                                 title='Selection')
 
         url = view.get_iframe_url('secret', note)
-        prefix = 'http%3A%2F%2Ftestserver%2Fasset%2Fembed%2Fview%2F1%2F1%2F%3F'
+        x = 'http%3A%2F%2Ftestserver%2Fasset%2Fembed%2Fview%2F{}%2F{}%2F%3F'
+        prefix = x.format(self.sample_course.id, note.id)
         self.assertTrue(url.startswith(prefix))
         self.assertTrue('nonce' in url)
         self.assertTrue('hmac' in url)

--- a/mediathread/projects/templatetags/user_projects.py
+++ b/mediathread/projects/templatetags/user_projects.py
@@ -27,6 +27,7 @@ def assignment_responses(project, request):
 
 @register.simple_tag
 def published_assignment_responses(project):
+    # Assumes the requester is an instructor
     return project.collaboration.first().children.filter(
         policy_record__policy_name__in=PUBLISHED).count()
 

--- a/mediathread/projects/tests/test_apiviews.py
+++ b/mediathread/projects/tests/test_apiviews.py
@@ -24,7 +24,7 @@ class ProjectSequenceAssetViewSetTest(LoggedInTestMixin, APITestCase):
         psa = ProjectSequenceAssetFactory()
 
         url = '{}?project={}'.format(
-            reverse('projectsequenceasset-list'), psa.id)
+            reverse('projectsequenceasset-list'), psa.project.id)
 
         # anonymous user
         r = self.client.get(url)

--- a/mediathread/projects/tests/test_templatetags.py
+++ b/mediathread/projects/tests/test_templatetags.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from django.template.base import Template
 from django.template.context import Context
 from django.test import TestCase, RequestFactory
-from django.test.testcases import TestCase
 from mediathread.factories import UserFactory, MediathreadTestMixin, \
     ProjectFactory
 from mediathread.projects.models import PUBLISH_WHOLE_CLASS, PUBLISH_DRAFT

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -1,6 +1,7 @@
 # pylint: disable-msg=R0904
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.http.response import Http404
@@ -25,6 +26,7 @@ from mediathread.projects.views import (
 import reversion
 from reversion.models import Version
 from structuredcollaboration.models import Collaboration
+import unittest
 
 
 class ContextProcessorTest(MediathreadTestMixin, TestCase):
@@ -1290,6 +1292,10 @@ class AssignmentListViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(ctx['sortby'], 'full_name')
         self.assertEquals(ctx['direction'], 'desc')
 
+    @unittest.skipIf(
+        settings.DATABASES['default']['ENGINE'] !=
+        'django.db.backends.postgresql_psycopg2',
+        'This test exercises advanced querying functionality')
     def test_get_queryset(self):
         # Instructor assignments
         future_assignment = ProjectFactory.create(

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -819,7 +819,7 @@ class AssignmentListView(ProjectListView):
             qs = self.sort_queryset(qs, 'due_date', 'desc')
         else:
             # Assignments for the student are sorted by:
-            # * the student's response submitted date desc with nulls first
+            # * the student's response submitted date asc with nulls first
             # * timedelta between today and the due_date desc with nulls last
 
             # annotate with the timedelta between today and the due_date

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -234,16 +234,17 @@ if 'test' in sys.argv or \
     CELERY_ALWAYS_EAGER = True
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'HOST': '',
-            'PORT': 5432,
-            'USER': '',
-            'PASSWORD': '',
-            'ATOMIC_REQUESTS': True,
+    if 'integrationserver' in sys.argv:
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'HOST': '',
+                'PORT': 5432,
+                'USER': '',
+                'PASSWORD': '',
+                'ATOMIC_REQUESTS': True,
+            }
         }
-    }
 
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -234,7 +234,6 @@ if 'test' in sys.argv or \
     CELERY_ALWAYS_EAGER = True
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-if 'integrationserver' in sys.argv:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/mediathread/templates/projects/assignment_table_student.html
+++ b/mediathread/templates/projects/assignment_table_student.html
@@ -1,27 +1,23 @@
 {% load user_projects %}
 <div class="table-responsive">
-    <table class="table table-bordered table-striped w-100 tablesorter">
+    <table class="table table-bordered table-striped w-100">
         <thead class="thead-darkgray">
-            <th data-sort-by="due_date"
-                class="sortable {% if sortby == 'due_date' %}{{direction}}{% endif %}">
+            <th>
                 Due Date
             </th>
-            <th data-sort-by="title"
-                class="sortable {% if sortby == 'title' %}{{direction}}{% endif %}">
+            <th>
                 Title
             </th>
             <th>
-                Status
+                Response Status
             </th>
             <th>
                 Action
             </th>
-            <th data-sort-by="project_type"
-                class="sortable {% if sortby == 'project_type' %}{{direction}}{% endif %}">
+            <th>
                 Type
             </th>
-            <th data-sort-by="modified"
-                class="sortable {% if sortby == 'modified' %}{{direction}}{% endif %}">
+            <th>
                 Last Updated
             </th>
         </thead>
@@ -41,6 +37,21 @@
                         <td>
                             {% if object.due_date %}
                                 {{object.due_date|date:"n/j/y"}}<br />
+                                {% if not response.is_submitted %}
+                                    {% if object.due_date < today %}
+                                        <div class="small text-danger">
+                                            Overdue {{object.due_date|timesince:today }}
+                                        </div>
+                                    {% else %}{% if object.due_date > today %}
+                                        <div class="small">
+                                            {{today|timeuntil:object.due_date }}
+                                        </div>
+                                    {% else %}
+                                        <div class="small">
+                                            Due today
+                                        </div>
+                                    {% endif %}{% endif %}
+                                {% endif %}
                             {% endif %}
                         </td>
                         <td>
@@ -91,6 +102,19 @@
                     <td>
                         {% if object.due_date %}
                             {{object.due_date|date:"n/j/y"}}<br />
+                            {% if object.due_date < today %}
+                                <div class="small text-danger">
+                                    Overdue {{object.due_date|timesince:today }}
+                                </div>
+                            {% else %}{% if object.due_date > today %}
+                                <div class="small">
+                                    {{today|timeuntil:object.due_date }}
+                                </div>
+                            {% else %}
+                                <div class="small">
+                                    Due today
+                                </div>
+                            {% endif %}{% endif %}
                         {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
* the student's response submitted date asc, with nulls first (indicating no response)
* the timedelta between today and the due_date desc with nulls last

To accomplish this, I took advantage of Django's Subquery filter and advanced annotate features. This chokes sqlite3 unfortunately, so I'm also switching the tests to run on postgres. @nikolas - I'd like to verify you're okay with this switch.