### PR TITLE
Drawing improvements - MEDT-3596

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -4436,14 +4436,12 @@ ul.section-tabs>li>a.active {
     background-color: black;
 }
 
-.toolbar-annotations .input-group:focus-within,
-.toolbar-annotations button.polygon-button:focus-within {
+.toolbar-annotations .input-group:focus-within {
     background-color: #ffc107;
     border: 6px solid #ffc107;
 }
 
-.toolbar-annotations .input-group:focus-within button,
-.toolbar-annotations button.polygon-button:focus-within {
+.toolbar-annotations .input-group:focus-within button {
     color: #212529;
     border-color: #212529;
 }

--- a/media/js/src/assetDetail/CreateSelection.jsx
+++ b/media/js/src/assetDetail/CreateSelection.jsx
@@ -176,9 +176,6 @@ export default class CreateSelection extends React.Component {
     componentDidMount() {
         const me = this;
 
-        // Clear active selection
-        this.props.onClearActiveSelection();
-
         const titleField = this.titleFieldRef.current;
         titleField.addEventListener('invalid', function(e) {
             me.props.onShowValidationError(
@@ -199,7 +196,6 @@ CreateSelection.propTypes = {
     onEndTimeClick: PropTypes.func.isRequired,
     onCreateSelection: PropTypes.func.isRequired,
     onShowValidationError: PropTypes.func.isRequired,
-    onClearActiveSelection: PropTypes.func.isRequired,
     showCreateError: PropTypes.bool.isRequired,
     createError: PropTypes.string
 };

--- a/media/js/src/assetDetail/ViewSelections.jsx
+++ b/media/js/src/assetDetail/ViewSelections.jsx
@@ -119,7 +119,6 @@ export default class ViewSelections extends React.Component {
     renderSelectionGroup(selections) {
         const me = this;
         const groupedSelections = [];
-        let i = 0;
         for (const key in selections) {
             let selectionGroup = selections[key];
             let tagName = null;
@@ -181,8 +180,6 @@ export default class ViewSelections extends React.Component {
                     s, reactKey, tags, terms));
 
             });
-
-            i++;
         }
 
         return groupedSelections;

--- a/media/js/src/openlayersUtils.js
+++ b/media/js/src/openlayersUtils.js
@@ -69,6 +69,7 @@ const displaySelection = function(a, map) {
     const styles = getCoordStyles();
 
     const geometry = a.annotation.geometry;
+    console.log('displaying', geometry);
 
     const view = map.getView();
     const projection = view.getProjection();
@@ -98,6 +99,36 @@ const displaySelection = function(a, map) {
     return newLayer;
 };
 
+const clearVectorLayer = function(map) {
+    // Remove all features from the vector layer.
+    const layers = map.getLayers().getArray();
+
+    // There should always be at least two layers, with the vector
+    // layer as the second one.
+    if (layers.length > 1) {
+        const vectorLayer = layers[1];
+        const source = vectorLayer.getSource();
+
+        source.getFeatures().forEach(function(feature) {
+            source.removeFeature(feature);
+        });
+    }
+};
+
+/**
+ * Given an openlayers map and image, reset its view to that image.
+ *
+ * Remove all polygon vectors and fit the view appropriately.
+ */
+const resetMap = function(map, img) {
+    clearVectorLayer(map);
+
+    const extent = objectProportioned(img.width, img.height);
+    const view = map.getView();
+    view.fit(extent);
+};
+
 export {
-    objectProportioned, getCoordStyles, displaySelection
+    objectProportioned, getCoordStyles, displaySelection,
+    clearVectorLayer, resetMap
 };


### PR DESCRIPTION
* Disable panning and zooming when drawing
* Fix a problem with onClearActiveSelection, where it wasn't clearing
  everything
* Enable Clear button
* Only allow one shape per selection
* Update onCreateSelection to only save one feature. This fixes a bug
  where selections created in the new tool weren't displaying correctly,
  because the coordinates were nested incorrectly.
* Removed focus style from Shape button. This fixes the issue where you
  have to click twice on the image map after clicking the Shape button.
