### PR TITLE
ClearActiveSelection when switching to any tab in asset detail

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -612,11 +612,8 @@ export default class AssetDetail extends React.Component {
             }
         }
 
-        if (
-            prevState.tab !== this.state.tab &&
-                (this.state.tab === 'createSelection' ||
-                 this.state.tab === 'viewItem')
-        ) {
+        // Clear active selection when switching to any tab.
+        if (prevState.tab !== this.state.tab) {
             this.onClearActiveSelection();
         }
 


### PR DESCRIPTION
This fixes a minor problem where if you draw a shape without saving
it, then switch to "View Selections", the shape is still visible.