### PR TITLE
on selection create: update accordion and open the new one

### DIFF
--- a/media/js/src/CollectionTab.jsx
+++ b/media/js/src/CollectionTab.jsx
@@ -83,12 +83,24 @@ export default class CollectionTab extends React.Component {
         }
     }
 
+    /**
+     * onUpdateAsset()
+     *
+     * This is used to update the asset's selections when a new
+     * selection is created by the user.
+     */
     onUpdateAsset(asset) {
-        this.setState({selectedAsset: asset});
+        // TODO: Reset SelectionFilter to default
+        this.setState({
+            selectedAsset: asset,
+            filteredSelections: asset.annotations
+        });
     }
+
     onFilterSelections(selections) {
         this.setState({filteredSelections: selections});
     }
+
     render() {
         let assets = [];
         let assetsDom = <LoadingAssets />;

--- a/media/js/src/filters/Filter.jsx
+++ b/media/js/src/filters/Filter.jsx
@@ -58,7 +58,7 @@ export default class Filter extends React.Component {
             currentPage: 0
         };
         this.filters = {
-            owner: 'all',
+            owner: this.props.defaultOwner ? null : 'all',
             title: null,
             tags: [],
             terms: [],
@@ -310,7 +310,8 @@ export default class Filter extends React.Component {
                                     className="form-control form-control-sm"
                                     placeholder="Search for..."
                                     onChange={this.handleTitleChange}
-                                    onKeyDown={this.handleTitleSearch} />
+                                    onKeyDown={this.handleTitleSearch}
+                                />
                                 <div className="input-group-append">
                                     <a
                                         href="#"


### PR DESCRIPTION
I'm guessing we also want to clear the search filters on selection
create. This requires switching the SelectionFilter to use managed
inputs... which needs some more work that I'll do separately.