### PR TITLE
Revert "Composition Assignment Wizard: Remove visibility options"

### DIFF
--- a/media/js/app/projects/assignment_edit.js
+++ b/media/js/app/projects/assignment_edit.js
@@ -43,15 +43,9 @@
                 return title.length > 0 && body.length > 0;
             } else if (pageContent === 'due-date') {
                 var q1 = 'input[name="due_date"]';
-                if (jQuery(q1).val() === undefined || jQuery(q1).val() === '')
-                    return false;
-
-                var q2 = 'input[name="response_view_policy"]';
-                if (jQuery(q2).length &&
-                        jQuery(q2 + ':checked').val() === undefined) {
-                    return false;
-                }
-                return true;
+                var q2 = 'input[name="response_view_policy"]:checked';
+                return jQuery(q1).val() !== undefined &&
+                    jQuery(q1).val() !== '' && jQuery(q2).val() !== undefined;
             } else if (pageContent === 'publish') {
                 var q = 'input[name="publish"]:checked';
                 return jQuery(q).val() !== undefined;

--- a/mediathread/templates/projects/composition_assignment_edit.html
+++ b/mediathread/templates/projects/composition_assignment_edit.html
@@ -79,6 +79,13 @@
 
                                 <p>{% lorem %}</p>
 
+                                <p>Visibility of student responses can be set at one of the following levels:</p>
+                                <ul>
+                                <li>Student responses are visible only to instructors</li>
+                                <li>Students can see other responses only after submitting their own</li>
+                                <li>Students can see other responses at any time</li>
+                                </ul>
+                                <br />
                                 <div class="row mb-5">
                                     <div class="col">
                                         <a href="#" class="btn btn-primary next">Get Started</a>
@@ -121,7 +128,7 @@
                                 </div>
                             </div>
                             <div data-page="3" data-page-content="due-date" class="hidden page">
-                                <h4>Step 3. Set response due date</h4><br />
+                                <h4>Step 3. Set response due date &amp; visibility</h4><br />
                                 <div class="form-group">
                                     <label for="due_date"><strong>Due Date</strong></label>
                                     <input class="form-control" type="text"
@@ -129,6 +136,14 @@
                                 </div>
                                 <div class="help-inline">Please choose a due date.</div>
                                 <br />
+                                <label for="response_view_policy"><strong>Visibility</strong></label>
+                                <p>Choose when students can see responses submitted by other students:</p>
+                                <div class="form-group">
+                                    {{form.response_view_policy}}
+                                </div>
+                                <div class="help-inline">Please choose how responses will be viewed.</div>
+                                <div><i>Note: After students respond to an assignment, they cannot edit their 
+                                response unless an instructor "unsubmits" it for further editing.</i></div><br />
 
                                 <div class="row mb-5">
                                     <div class="col">


### PR DESCRIPTION
Reverts ccnmtl/mediathread#2828

I had not realized that submission visibility was implemented for composition assignment responses. Revert this change.