### PR TITLE
Course list - move into the new style

### DIFF
--- a/cypress/integration/8.Login/login_spec.js
+++ b/cypress/integration/8.Login/login_spec.js
@@ -8,7 +8,7 @@ describe('Log In Feature: Test Instructor Login', () => {
         cy.get('#id_username').type('instructor_one').blur();
         cy.get('#id_password').type('test').blur();
         cy.get('#login-local input[type="submit"]').click();
-        cy.get('#course_information').contains('My Courses');
+        cy.get('#course-title').contains('My Courses');
         cy.get('#sandboxes_link').click();
         cy.get('.choose-course').should('contain', 'Sample Course');
         cy.get('.choose-course').click();

--- a/cypress/integration/8.Login/vanilla_login_spec.js
+++ b/cypress/integration/8.Login/vanilla_login_spec.js
@@ -8,6 +8,6 @@ describe('Log In', function() {
         cy.get('#id_username').type('instructor_one').blur();
         cy.get('#id_password').type('test').blur();
         cy.get('#login-local input[type="submit"]').click();
-        cy.get('#course_information').contains('My Courses');
+        cy.get('#course-title').contains('My Courses');
     });
 });

--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -696,25 +696,8 @@ div.column-contents {
 }
 
 table.course-choices {
-    padding:5px;
-    margin-left: 10px;
-    max-width: 960px;
-    border-top: 1px solid #ddd;
+    font-size: 1rem!important;
 }
-
-table.course-choices th {
-    padding: 6px;
-}
-
-td.course-choice {
-    list-style-type:none;
-    padding:6px;
-}
-
-td.manage-course {
-    text-align:center;
-}
-
 
 div.button-form {
     display: block;
@@ -2583,10 +2566,6 @@ a.hs-control.hs-control-show.plist.float
 
 #staff-switchcourse {
     margin: 10px 10px;
-}
-
-#course-list {
-    margin-bottom: 25px;
 }
 
 .collection_button {

--- a/mediathread/templates/base_new.html
+++ b/mediathread/templates/base_new.html
@@ -112,7 +112,7 @@ A new base.html without the course context overwritten in the template.
                             {% if messages %}
                                 <ul class="messages">
                                     {% for message in messages %}
-                                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|safe }}</li>
                                     {% endfor %}
                                 </ul>
                             {% endif %}

--- a/mediathread/templates/courseaffils/course_list.html
+++ b/mediathread/templates/courseaffils/course_list.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base_new.html' %}
 {% load coursetags %}
 {% load static %}
 
@@ -35,46 +35,6 @@
 {% endblock %}
 
 {% block content %}
-    <div id="course-list">
-        <ul class="nav nav-tabs" aria-label="select timeframe">
-            <li class="{% if semester_view == 'past' %}active{% endif %}">
-                <a id="pastsemesters"
-                   href="?semester_view=past"
-                >Past</a>
-            </li>
-            <li class="{% if semester_view == 'current' %}active{% endif %}">
-                <a id="currentsemester"
-                   href="?semester_view=current"
-                >Current</a>
-            </li>
-            <li class="{% if semester_view == 'future' %}active{% endif %}">
-                <a id="future_semesters" href="?semester_view=future">Future</a>
-            </li>
-            {% if add_privilege %}
-            <li class="navbar-right">
-                <a id="create-course" class="create-course"
-                   href="{%url 'admin:courseaffils_course_add' %}"
-                >Create new course</a>
-            </li>
-            {% endif %}
-            <li class="{% if semester_view == 'sandbox' %}active{% endif %} navbar-right">
-                <a id="sandboxes_link"
-                   href="?semester_view=sandbox">Sandboxes</a>
-            </li>
-        </ul>
-    </div>
-
-    {% if courses|length > 5 %}
-    <form class="form-inline" role="search">
-        <div class="form-group">
-            <label for="course-title-filter">Filter: </label>
-            <input id="course-title-filter" class="course-search form-control"
-                   type="search"
-                   data-column="all"
-                   autofocus>
-        </div>
-    </form>
-    {% endif %}
 
     {% if semester_view == 'past' %}
         <h2>Past Courses</h2>
@@ -86,48 +46,104 @@
         <h2>Sandbox Courses</h2>
     {% endif %}
 
-    {% if courses|length > 0 %}
-        <table class="table course-choices tablesorter">
-            <thead>
-                <tr>
-                    <th>Course Title</th>
-                    <th>Term</th>
-                    <th>Instructor</th>
-                    <th>Role</th>
-                    {% if add_privilege %}
-                        <th class="nosort">Actions</th>
-                    {% endif %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for course in courses %}
-                    {% include 'courseaffils/course_row.html' %}
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        No courses match this criteria.
-    {% endif %}
+    <div id="course-list">
+        <div class="row">
+            <div class="col-md-7">
+                <div class="btn-group mb-3" role="group" aria-label="Select timeframe">
+                    <a id="pastsemesters"
+                        class="btn btn-outline-primary {% if semester_view == 'past' %}active{% endif %}"
+                           href="?semester_view=past">
+                           Past
+                    </a>
+                    <a id="currentsemester"
+                        class="btn btn-outline-primary {% if semester_view == 'current' %}active{% endif %}"
+                           href="?semester_view=current">
+                           Current
+                    </a>
+                    <a id="future_semesters"
+                        class="btn btn-outline-primary {% if semester_view == 'future' %}active{% endif %}"
+                        href="?semester_view=future">
+                        Future
+                    </a>
+                    <a id="sandboxes_link"
+                        class="btn btn-outline-primary {% if semester_view == 'sandbox' %}active{% endif %}"
+                       href="?semester_view=sandbox">Sandboxes</a>
+                </div>
+            </div>
+            <div class="col-md-5 text-right">
+                {% if courses|length > 10 %}
+                <form class="form-inline" role="search">
+                    <div class="form-group w-100">
+                        <div class="input-group mb-3 w-100">
+                          <div class="input-group-prepend">
+                            <span class="input-group-text" id="filter-addon">Filter</span>
+                          </div>
+                          <input id="course-title-filter" class="course-search form-control"
+                               type="search" placeholder="by course title or instructor"
+                               aria-label="Filter courses" aria-describedby="filter-addon"
+                               data-column="all" />
+                        </div>
+                    </div>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 
+    <div class="row">
+        <div class="col">
+            {% if courses|length > 0 %}
+                <table class="table table-bordered table-striped tablesorter course-choices">
+                    <thead>
+                        <tr>
+                            <th class="w-25">Course Title</th>
+                            <th>Your Role</th>
+                            {% if semester_view != 'sandbox' %}
+                                <th>Term</th>
+                            {% endif %}
+                            <th class="w-50">Instructor</th>
+                            {% if add_privilege %}
+                                <th class="nosort">Actions</th>
+                            {% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for course in courses %}
+                            {% include 'courseaffils/course_row.html' %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <h6>No courses match this criteria.</h6>
+            {% endif %}
+        </div>
     </div>
 
     {% if user.is_staff %}
-        <h3>Mediathread Demo (Staff only)</h3>
-        <p>To demo a class you can (mostly) anonymize the class, by setting this cookie:</p>
-        <ul>
-            <li>
-                <span id="anonymize_status"></span>
-                <a href="#anonymize" onclick="document.cookie='ANONYMIZE=on; path=/';anonymizeStatus();">Enable</a>
-                <a href="#anonymize" onclick="document.cookie='ANONYMIZE=OFF; expires='+new Date().toGMTString()+'; path=/';anonymizeStatus();">Disable</a>
-            </li>
-        </ul>
-        <script>
-        function anonymizeStatus() {
-            document.getElementById('anonymize_status').innerHTML = 'Anonymizing Status: ' +
-                ((document.cookie.match(/ANONYMIZE/)) ? 'ON' : 'OFF');
-        }
-        anonymizeStatus();
-        </script>
+    <div class="row mt-5">
+        <div class="col">
+            <div class="card bg-light">
+                <div class="card-body">
+                    <h3>Mediathread Demo (Staff only)</h3>
+                    <p>To demo a class you can (mostly) anonymize the class, by setting this cookie:</p>
+                    <ul>
+                        <li>
+                            <span id="anonymize_status"></span>
+                            <a href="#anonymize" onclick="document.cookie='ANONYMIZE=on; path=/';anonymizeStatus();">Enable</a>
+                            <a href="#anonymize" onclick="document.cookie='ANONYMIZE=OFF; expires='+new Date().toGMTString()+'; path=/';anonymizeStatus();">Disable</a>
+                        </li>
+                    </ul>
+                    <script>
+                    function anonymizeStatus() {
+                        document.getElementById('anonymize_status').innerHTML = 'Anonymizing Status: ' +
+                            ((document.cookie.match(/ANONYMIZE/)) ? 'ON' : 'OFF');
+                    }
+                    anonymizeStatus();
+                    </script>
+                </div>
+            </div>
+        </div>
+    </div>
     {% endif %}
 
 {% endblock %}

--- a/mediathread/templates/courseaffils/course_row.html
+++ b/mediathread/templates/courseaffils/course_row.html
@@ -14,23 +14,6 @@
         {% endif %}
     </td>
     <td>
-        {% if course.info.termyear %}
-            {{course.info.termyear}}
-        {% elif course.to_dict %}
-            {{course.to_dict.term|int_to_term}} {{course.to_dict.year}}
-        {% endif %}
-    </td>
-    <td>
-        {% for user in course.faculty_group.user_set.all %}
-        {% firstof user.get_full_name user.username %},
-            {% with exceptions='swav,swinstructor' %}
-                {% if not user.is_staff and not user.username in exceptions %}
-                    {% firstof user.get_full_name user.username %},
-                {% endif %}
-            {% endwith %}
-        {% endfor %}
-    </td>
-    <td>
         {% if course in as_instructor %}
             Instructor
         {% elif course in as_student %}
@@ -40,6 +23,25 @@
         {% else %}
             Non-member
         {% endif %}
+    </td>
+    {% if semester_view != 'sandbox' %}
+        <td>
+            {% if course.info.termyear %}
+                {{course.info.termyear}}
+            {% elif course.to_dict %}
+                {{course.to_dict.term|int_to_term}} {{course.to_dict.year}}
+            {% endif %}
+        </td>
+    {% endif %}
+    <td>
+        {% for user in course.faculty_group.user_set.all %}
+        {% firstof user.get_full_name user.username %},
+            {% with exceptions='swav,swinstructor' %}
+                {% if not user.is_staff and not user.username in exceptions %}
+                    {% firstof user.get_full_name user.username %},
+                {% endif %}
+            {% endwith %}
+        {% endfor %}
     </td>
     {% if add_privilege %}
         <td class="manage-course">


### PR DESCRIPTION
This PR simply restyles the course list page. There's more we can do afa optimization, but I'm leaving it until another time. Note: the table font-size `!important` is needed here as the table sorter style is included after `mediathread_new.css` and specifies a much smaller font.

<img width="844" alt="Screen Shot 2020-08-02 at 9 47 09 AM" src="https://user-images.githubusercontent.com/141369/89124467-2db8ce80-d4a5-11ea-8fd1-237bc58d4c5b.png">
