### PR TITLE
Scaffold the discussion assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APP=mediathread
 #JS_FILES=media/js/app media/js/lib/sherdjs/src media/js/lib/sherdjs/lib/tinymce/plugins/citation media/js/lib/sherdjs/lib/tinymce/plugins/editorwindow media/js/lib/sherdjs/src/configs
 # sherdjs isn't jscs clean yet so for now:
 JS_FILES=media/js/app media/js/src cypress/**/*.js
-MAX_COMPLEXITY=8
+MAX_COMPLEXITY=9
 PY_DIRS=$(APP) lti_auth structuredcollaboration
 FLAKE8_IGNORE=W605
 

--- a/cypress/integration/6.discussions/discussion.feat.js
+++ b/cypress/integration/6.discussions/discussion.feat.js
@@ -68,10 +68,8 @@ describe('Discussion View: Create Discussion', () => {
             // all searches are automatically rooted to the found tr element
             cy.get('td').eq(1).contains('Discussion: Scenario 1');
             cy.get('td').eq(2).contains('Shared with Class');
-            cy.get('td').eq(3).contains('0 / 3');
             cy.get('td').eq(4).contains('Instructor One');
             cy.get('td').eq(5).contains('Discussion Assignment');
-            cy.get('td').eq(7).contains('Delete');
         });
     });
 });

--- a/cypress/integration/6.discussions/discussion.feat.js
+++ b/cypress/integration/6.discussions/discussion.feat.js
@@ -14,28 +14,64 @@ describe('Discussion View: Create Discussion', () => {
 
     it('Instructor Creates Discussion', () => {
         cy.visit('/course/1/assignments/');
+        cy.get('#cu-privacy-notice-icon').click();
 
         cy.log('Create a discussion');
         cy.get('button').contains('Add an assignment').should('be.visible');
         cy.get('button').contains('Add an assignment').click()
         cy.get('#discussion-assignment-card').should('be.visible');
-        cy.get('#discussion-assignment-card button')
+        cy.get('#discussion-assignment-card a')
             .contains('Add Assignment').click()
 
-        cy.log('create discussion');
-        cy.get('#cu-privacy-notice-icon').click();
-        //TODO: test discussion creation from homepage
-        cy.title().should('contain', 'Discussion');
-        cy.getIframeBody().find('p').click()
-            .type('Adding a comment');
-        cy.get('#comment-form-submit').click();
-        cy.get('.respond_prompt').should('be.visible');
-        cy.get('.edit_prompt').contains('Edit').should('be.visible');
+        cy.log('create discussion wizard');
+        cy.title().should('eq', 'Mediathread Create Assignment');
+        cy.wait(500);
+        cy.get('a.nav-link.active').contains('Assignments');
+        cy.get('.breadcrumb-item').contains('Back to all assignments');
+        cy.get('.page-title').contains('Create Discussion Assignment');
+        cy.get('h4:visible').contains('Step 1');
+        cy.get('#page2').contains('Get Started');
+        cy.get('#page2').click();
 
-        cy.visit('/course/1/oldhome/');
-        cy.get('#loaded').should('exist');
-        cy.contains('Discussion Title').should('have.attr', 'href');
-        cy.contains('Discussion Title').click();
-        cy.title().should('contain', 'Discussion');
+        cy.log('Add a title and some text');
+        cy.get('h4:visible').contains('Step 2');
+        cy.get('input[name="title"]').should('be.visible');
+        cy.get('input[name="title"]').click().clear()
+            .type('Discussion: Scenario 1');
+        cy.getIframeBody().find('p').click()
+            .type('A suitable discussion prompt');
+        cy.get('#page3').should('be.visible').contains('Next');
+        cy.get('#page3:visible').click();
+
+        cy.log('Add a due date');
+        cy.get('h4:visible').contains('Step 3');
+        cy.get('input[name="due_date"]').should('be.visible');
+        cy.get('input[name="due_date"]:visible').click()
+        cy.get('.ui-state-default.ui-state-highlight').click();
+        cy.get('input[name="due_date"]:visible').invoke('val').should('not.be.empty')
+        cy.get('#ui-datepicker-div').should('not.be.visible');
+        cy.get('#page4').focus().click();
+
+        cy.log('add publish options & save');
+        cy.get('h4:visible').contains('Step 4');
+        cy.get('#id_publish_1').should('be.visible');
+        cy.get('#id_publish_1').click();
+        cy.get('#save-assignment').click();
+
+        cy.title().should('eq', 'Mediathread New Discussion');
+    });
+
+    it('should show on assignments page', () => {
+        cy.visit('/course/1/assignments');
+        cy.get('#cu-privacy-notice-icon').click();
+        cy.contains('Discussion: Scenario 1').parent('td').parent('tr').within(() => {
+            // all searches are automatically rooted to the found tr element
+            cy.get('td').eq(1).contains('Discussion: Scenario 1');
+            cy.get('td').eq(2).contains('Shared with Class');
+            cy.get('td').eq(3).contains('0 / 3');
+            cy.get('td').eq(4).contains('Instructor One');
+            cy.get('td').eq(5).contains('Discussion Assignment');
+            cy.get('td').eq(7).contains('Delete');
+        });
     });
 });

--- a/media/js/app/discussion/discussionpanel.js
+++ b/media/js/app/discussion/discussionpanel.js
@@ -1,3 +1,4 @@
+
 /* global CitationView: true, djangosherd: true, CollectionList: true */
 /* global MediaThread: true */
 /* global tinymce: true, tinymceSettings: true, showMessage: true */

--- a/media/js/app/projects/assignment_edit.js
+++ b/media/js/app/projects/assignment_edit.js
@@ -43,9 +43,15 @@
                 return title.length > 0 && body.length > 0;
             } else if (pageContent === 'due-date') {
                 var q1 = 'input[name="due_date"]';
-                var q2 = 'input[name="response_view_policy"]:checked';
-                return jQuery(q1).val() !== undefined &&
-                    jQuery(q1).val() !== '' && jQuery(q2).val() !== undefined;
+                if (jQuery(q1).val() === undefined || jQuery(q1).val() === '')
+                    return false;
+
+                var q2 = 'input[name="response_view_policy"]';
+                if (jQuery(q2).length &&
+                        jQuery(q2 + ':checked').val() === undefined) {
+                    return false;
+                }
+                return true;
             } else if (pageContent === 'publish') {
                 var q = 'input[name="publish"]:checked';
                 return jQuery(q).val() !== undefined;
@@ -95,8 +101,6 @@
             this.showPage($current.data('page-content'));
         },
         onSave: function(evt) {
-            evt.preventDefault();
-
             var $current = jQuery('div[data-page="' + this.currentPage + '"]');
             var content = $current.data('page-content');
             if (!this.validate(content)) {
@@ -106,20 +110,7 @@
 
             jQuery(window).unbind('beforeunload');
             tinymce.activeEditor.save();
-            var frm = jQuery(evt.currentTarget).parents('form')[0];
-            jQuery.ajax({
-                type: 'POST',
-                url: frm.action,
-                dataType: 'json',
-                data: jQuery(frm).serializeArray(),
-                success: function(json) {
-                    // eslint-disable-next-line scanjs-rules/assign_to_location
-                    window.location = json.context.project.url;
-                },
-                error: function() {
-                    // do something useful here
-                }
-            });
+            return true;
         },
         onFormKeyPress: function(evt) {
             if (evt.keyCode === 13) {

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -77,9 +77,6 @@ class DiscussionCreateView(LoggedInFacultyMixin, View):
         collaboration_context = cached_course_collaboration(request.course)
         disc_sc = Collaboration(_parent=obj_sc,
                                 title=title,
-                                # or we could point it at the root
-                                # threadedcomments object.
-                                # content_object=None,
                                 context=collaboration_context,
                                 )
         disc_sc.set_policy(request.POST.get('publish', None))

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -528,17 +528,19 @@ class Project(models.Model):
         return thread
 
     def course_discussion(self):
-        '''returns the course-level discussion'''
+        '''returns the ThreadedComment object for a
+        course discussion. This is distinguished from instructor feedback
+        by the access policy.'''
         thread = None
         col = self.get_collaboration()
         if col:
             comm_type = ContentType.objects.get_for_model(ThreadedComment)
 
-            feedback = col.children.filter(
+            discussion = col.children.filter(
                 policy_record__policy_name='CourseProtected',
                 content_type=comm_type)
-            if feedback:
-                thread = feedback[0].content_object
+            if discussion:
+                thread = discussion[0].content_object
 
         return thread
 

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -146,9 +146,14 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
             self.client.login(username=self.student_one.username,
                               password='test'))
 
+        data = {u'body': [u'<p>no ajax here</p>'],
+                u'participants': [self.student_one.id],
+                u'publish': [u'PrivateEditorsAreOwners'],
+                u'title': [u'Private Student Essay']}
+
         url = '/project/save/%s/' % self.project_private.id
-        response = self.client.post(url)
-        self.assertEquals(response.status_code, 405)
+        response = self.client.post(url, data)
+        self.assertEquals(response.status_code, 302)
 
     def test_project_save_valid(self):
         versions = Version.objects.get_for_object(
@@ -279,12 +284,8 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
                 u'publish': [u'PrivateEditorsAreOwners'],
                 u'parent': self.assignment.pk}
 
-        response = self.client.post('/project/create/', data,
-                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEquals(response.status_code, 200)
-        the_json = json.loads(response.content)
-        project = the_json['context']['project']
-        self.assertTrue(project['is_response'])
+        response = self.client.post('/project/create/', data)
+        self.assertEquals(response.status_code, 302)
 
     def test_project_delete(self):
         ctype = ContentType.objects.get(model='project', app_label='projects')

--- a/mediathread/projects/urls.py
+++ b/mediathread/projects/urls.py
@@ -6,7 +6,8 @@ from mediathread.projects.views import (
     UnsubmitResponseView, ProjectReadOnlyView, project_export_msword,
     project_export_html, project_revisions,
     SequenceAssignmentEditView, CompositionAssignmentEditView,
-    CompositionAssignmentResponseView, UpdateVisibilityView
+    CompositionAssignmentResponseView, UpdateVisibilityView,
+    DiscussionAssignmentWizardView, DiscussionAssignmentCreateView
 )
 from rest_framework import routers
 
@@ -24,6 +25,17 @@ urlpatterns = [
     path('edit/ca/<int:project_id>/',
          CompositionAssignmentEditView.as_view(), {},
          name='composition-assignment-edit'),
+
+    path('wizard/create/da/', DiscussionAssignmentWizardView.as_view(), {},
+         name='discussion-assignment-create-wizard'),
+
+    path('wizard/edit/da/<int:project_id>/',
+         DiscussionAssignmentWizardView.as_view(), {},
+         name='discussion-assignment-edit-wizard'),
+
+    path('create/da/',
+         DiscussionAssignmentCreateView.as_view(), {},
+         "discussion-assignment-create"),
 
     path('create/ja/', SequenceAssignmentEditView.as_view(), {},
          name='sequence-assignment-create'),

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -443,7 +443,7 @@ class DiscussionAssignmentCreateView(LoggedInFacultyMixin, ProjectCreateView):
         # create a project
         project = self.create_project()
 
-        # get the project's collaboration object 
+        # get the project's collaboration object
         project_collab = project.get_collaboration()
 
         # construct a collaboration for this discussion

--- a/mediathread/templates/projects/assignment_list_cards.html
+++ b/mediathread/templates/projects/assignment_list_cards.html
@@ -98,14 +98,10 @@
                         </a>
                     </div>
                     <div class="col text-right">
-                        <form action="{% url 'discussion-create' request.course.id %}" method="post">
-                            {% csrf_token %} 
-                            <input type="hidden" name="comment_html" value="Discussion Title" />
-                            <input type="hidden" name="app_label" value="courseaffils" />
-                            <input type="hidden" name="model" value="course" />
-                            <input type="hidden" name="obj_pk" value="{{request.course.id}}" />
-                            <button type="submit" class="btn btn-sm btn-outline-primary">Add Assignment</button>
-                        </form>
+                        <a class="btn btn-sm btn-outline-primary" title="Add Discussion Assignment"
+                            href="{% url 'discussion-assignment-create-wizard' request.course.pk%}">
+                            Add Assignment
+                        </a>
                     </div>
                 </div>
             </div>

--- a/mediathread/templates/projects/discussion_assignment.html
+++ b/mediathread/templates/projects/discussion_assignment.html
@@ -1,0 +1,70 @@
+{% extends "base_new.html" %}
+
+{% block title %}
+    {% if discussion.title %}{{discussion.title}}{% else %}New Discussion{% endif %}
+{% endblock %}
+
+{% block css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{{STATIC_URL}}js/select2/select2.css" media="screen" />
+    <link rel="stylesheet" href="{{STATIC_URL}}css/project.css" />
+    <link rel="stylesheet" href="{{STATIC_URL}}js/lib/sherdjs/lib/tinymce/plugins/citation/css/citation.css" />
+
+    <!--All the annotation css -->
+    {% include "djangosherd/annotator_resources_css.html" %}
+{% endblock %}
+
+{% block uncompressable_css %}
+    <script type="text/javascript" src="{{STATIC_URL}}js/select2/select2.min.js"></script>
+{% endblock %}
+
+{% block js %}
+    <!--All the annotation javascript -->
+    {% include "djangosherd/annotator_resources.html" %}
+{% endblock %}
+
+{% block uncompressable_js %}
+    {% include "djangosherd/player_resources.html" %}
+    <script type="text/javascript" src="{{STATIC_URL}}jquery/js/masonry.pkgd.min.js"></script>
+
+    <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/lib/tinymce/tinymce.min.js"></script>
+    <script type="text/javascript" src="{{STATIC_URL}}js/app/tinymce_init.js"></script>
+
+    <script type="text/javascript">
+        jQuery(document).ready(function () {
+            panelManager.init({
+                'container': 'discussion-workspace',
+                'url': MediaThread.urls['discussion-view']({{assignment.course_discussion.id}})
+            });
+        });
+  </script>
+{% endblock %}
+
+{% block content %}
+    {% with active='assignments' %}
+        {% include 'main/three_section_tabs.html' %}
+    {% endwith %}
+    <div class="tab-content">
+        <div role="tabpanel">
+            <div class="row mt-2">
+                <div class="col-md-auto">
+                    <nav aria-label="breadcrumb">
+                      <ol class="breadcrumb bg-light mb-0">
+                        <li class="breadcrumb-item" aria-current="page">
+                            <a href="{% url 'assignment-list' request.course.pk %}">
+                                Back to assignments
+                            </a>
+                        </li>
+                      </ol>
+                    </nav>
+                </div>
+            </div>
+            <div id="discussion-workspace" class="row">
+                <div id="discussion-container" class="col-md-12">
+                </div>
+            </div>
+            <div id="asset-container" class="col-md-12">
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/mediathread/templates/projects/discussion_assignment_edit.html
+++ b/mediathread/templates/projects/discussion_assignment_edit.html
@@ -21,8 +21,6 @@
 {% endblock %}
 
 {% block uncompressable_js %}
-    {% include "djangosherd/player_resources.html" %}
-
     <!-- required project functionality -->
     <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/lib/tinymce/tinymce.min.js"></script>
     <script type="text/javascript" src="{{STATIC_URL}}js/app/tinymce_init.js"></script>
@@ -30,7 +28,7 @@
     <script type="text/javascript">
         jQuery(document).ready(function () {
             var view = new AssignmentEditView({
-                el: jQuery('.composition-assignment').first()
+                el: jQuery('.discussion-assignment').first()
             });
         });
     </script>
@@ -67,41 +65,35 @@
                     {% if form.instance %}
                         <h1 class="page-title pl-0">Edit {{form.instance.title}}</h1>
                     {% else %}
-                        <h1 class="page-title pl-0">Create Composition Assignment</h1>
+                        <h1 class="page-title pl-0">Create Discussion Assignment</h1>
                     {% endif %}
                 </div>
             </div>
 
-            <div class="composition-assignment">
+
+            <div class="discussion-assignment">
                 <div class="row">
                     <div class="col-md-8">
-                        <form name="composition-assignment-edit"
+                        <form name="discussion-assignment-edit"
                             {% if form.instance %}
                                 action="{% url 'project-save' request.course.pk form.instance.id %}"
                             {% else %}
-                                action="{% url 'project-create' request.course.pk %}"
+                                action="{% url 'discussion-assignment-create' request.course.pk %}"
                             {% endif %}
                             method="post">
 
                             {% csrf_token %}
-                            <input type="hidden" name="project_type" value="assignment" />
+                            <input type="hidden" name="project_type" value="discussion-assignment" />
 
                             <div data-page="1" data-page-content="instructions" class="page">
                                 <h4>Step 1: Introduction</h4><br />
 
-                                <p>A composition assignment is....</p>
+                                <p>A discussion assignment is....</p>
 
                                 <p>{% lorem %}</p>
 
-                                <p>Visibility of student responses can be set at one of the following levels:</p>
-                                <ul>
-                                <li>Student responses are visible only to instructors</li>
-                                <li>Students can see other responses only after submitting their own</li>
-                                <li>Students can see other responses at any time</li>
-                                </ul>
-                                <br />
                                 <div class="row mb-5">
-                                    <div class="col">
+                                    <div class="col text-right">
                                         <button id="page2" class="btn btn-primary next">
                                             Get Started
                                         </button>
@@ -112,9 +104,8 @@
                                 <h4>Step 2. Write title &amp; instructions</h4><br />
                                 <div class="form-group">
                                     <label><strong>Assignment Title</strong></label><br />
-                                    {% if form.instance %}{{form.instance.title}}{% endif %}
                                     <input type="text" name="title" class="form-control"
-                                        value="{% if form.instance.title != form.instance.DEFAULT_TITLE %}{{form.instance.title}}{% endif %}"/>
+                                        value="{% ifnotequal form.instance.title form.instance.DEFAULT_TITLE %}{{form.instance.title}}{% endifnotequal %}"/>
                                     <div class="help-inline">Title is a required field</div>
                                 </div>
                                 <div class="form-group">
@@ -152,13 +143,6 @@
                                         name="due_date" value="{{form.instance.due_date|date:'m/d/y'}}">
                                 </div>
                                 <div class="help-inline">Please choose a due date.</div>
-                                <br />
-                                <label for="response_view_policy"><strong>Visibility</strong></label>
-                                <p>Choose when students can see responses submitted by other students:</p>
-                                <div class="form-group">
-                                    {{form.response_view_policy}}
-                                </div>
-                                <div class="help-inline">Please choose how responses will be viewed.</div>
 
                                 <div class="row mb-5">
                                     <div class="col">
@@ -185,9 +169,7 @@
                                         <button class="btn btn-secondary prev">Previous</button>
                                     </div>
                                     <div class="col text-right">
-                                        <button id="save-assignment" class="btn btn-primary save" type="submit">
-                                            Save
-                                        </button>
+                                        <button id="save-assignment" class="btn btn-primary save" type="submit">Save</button>
                                     </div>
                                 </div>
                             </div>

--- a/mediathread/templates/projects/selection_assignment_edit.html
+++ b/mediathread/templates/projects/selection_assignment_edit.html
@@ -65,9 +65,9 @@
         <div class="row">
             <div class="col-md-12">
                 {% if form.instance %}
-                    <h1 class="page-title">Edit Selection Assignment</h1>
+                    <h1 class="page-title pl-0">Edit {{form.instance.title}}</h1>
                 {% else %}
-                    <h1 class="page-title">Create Selection Assignment</h1>
+                    <h1 class="page-title pl-0">Create Selection Assignment</h1>
                 {% endif %}
             </div>
         </div>
@@ -207,7 +207,9 @@
                                         <button class="btn btn-secondary prev">Previous</button>
                                     </div>
                                     <div class="col text-right">
-                                        <button class="btn btn-primary save">Save</button>
+                                        <button class="btn btn-primary save" type="submit">
+                                            Save
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/mediathread/templates/projects/sequence_assignment_edit.html
+++ b/mediathread/templates/projects/sequence_assignment_edit.html
@@ -64,9 +64,9 @@
             <div class="row">
                 <div class="col-md-12">
                     {% if form.instance %}
-                        <h1 class="page-title">Edit Sequence Assignment</h1>
+                        <h1 class="page-title pl-0">Edit {{form.instance.title}}</h1>
                     {% else %}
-                        <h1 class="page-title">Create Sequence Assignment</h1>
+                        <h1 class="page-title pl-0">Create Sequence Assignment</h1>
                     {% endif %}
                 </div>
             </div>
@@ -278,7 +278,9 @@
                                             <button class="btn btn-secondary prev">Previous</button>
                                         </div>
                                         <div class="col text-right">
-                                            <button class="btn btn-primary save">Save</button>
+                                            <button class="btn btn-primary save" type="submit">
+                                                Save
+                                            </button>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
- Add a discussion assignment project type.
- Add discussion assignment create/edit wizard views.
    - Hook this up to the AssignmentListView.
- ProjectCreateView refactoring
    - The assignment wizards were updated to post assignment data to the server for creation. All projects now go through this more typical POST flow. The ajax creation path was removed.
   - The "create_project" logic was broken out into a separate function within the view
- DiscussionAssignmentCreateView inherits from  ProjectCreateView.
    - After project creation, a ThreadedComment discussion is created and attached to the project via a "CourseProtected" collaboration.
- ProjectSave refactoring
    - add a more typical post form flow. This supports a more standard project edit wizard flow.
- Add unit tests
- Update cypress tests
- Add tons of comments because the discussion / collaboration relationship is confusing as hell.