### PR TITLE
Discussion Assignment View

### DIFF
--- a/media/templates/discussion.mustache
+++ b/media/templates/discussion.mustache
@@ -1,15 +1,4 @@
 <div class="panel-subcontainer discussion">
-    <div class="d-flex justify-content-between align-items-center flex-wrap">
-        <div class="col-md-6 pl-0">
-            {{#title}}
-                    <div class="panel-subcontainer-title discussion">
-                        <h1 class="page-title">
-                            {{title}}
-                        </h1>
-                    </div>
-            {{/title}}
-         </div>
-    </div>
     <div class="row no-gutters">
         <div class="col-md-6">
             <div class="threadedcomments-container pr-2">

--- a/mediathread/projects/tests/test_templatetags.py
+++ b/mediathread/projects/tests/test_templatetags.py
@@ -10,7 +10,7 @@ from mediathread.factories import UserFactory, MediathreadTestMixin, \
 from mediathread.projects.models import PUBLISH_WHOLE_CLASS, PUBLISH_DRAFT, \
     Project
 from mediathread.projects.templatetags.user_projects import (
-    published_assignment_responses, my_assignment_responses,
+    published_assignment_responses, my_comment_count, my_assignment_responses,
     assignment_responses)
 
 
@@ -98,10 +98,21 @@ class TestTemplateTags(MediathreadTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         assignment = Project.objects.get(title='Important Discussion')
         self.assertEquals(published_assignment_responses(assignment), 0)
+        self.assertEqual(
+            my_comment_count(assignment, self.instructor_one)[0], 1)
+        self.assertEqual(
+            my_comment_count(assignment, self.instructor_two)[0], 0)
+        self.assertEqual(
+            my_comment_count(assignment, self.student_one)[0], 0)
 
         # add a comment
         discussion = assignment.course_discussion()
-        self._add_comment(discussion, self.instructor_one)
+        self._add_comment(discussion, self.instructor_two)
         self.assertEquals(published_assignment_responses(assignment), 0)
         self._add_comment(discussion, self.student_one)
         self.assertEquals(published_assignment_responses(assignment), 1)
+
+        self.assertEqual(
+            my_comment_count(assignment, self.instructor_two)[0], 1)
+        self.assertEqual(
+            my_comment_count(assignment, self.student_one)[0], 1)

--- a/mediathread/projects/tests/test_templatetags.py
+++ b/mediathread/projects/tests/test_templatetags.py
@@ -3,9 +3,12 @@ from datetime import datetime
 from django.template.base import Template
 from django.template.context import Context
 from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from django_comments.forms import CommentSecurityForm
 from mediathread.factories import UserFactory, MediathreadTestMixin, \
     ProjectFactory
-from mediathread.projects.models import PUBLISH_WHOLE_CLASS, PUBLISH_DRAFT
+from mediathread.projects.models import PUBLISH_WHOLE_CLASS, PUBLISH_DRAFT, \
+    Project
 from mediathread.projects.templatetags.user_projects import (
     published_assignment_responses, my_assignment_responses,
     assignment_responses)
@@ -62,3 +65,43 @@ class TestTemplateTags(MediathreadTestMixin, TestCase):
         responses = my_assignment_responses(assignment, self.student_one)
         self.assertEqual(responses.count(), 1)
         self.assertEqual(responses.first().content_object, visible_response)
+
+    def _add_comment(self, discussion, author):
+        url = reverse('comments-post-comment')
+        data = {
+            u'comment': [u'posted'],
+            u'parent': [discussion.id],  # threadedcomment
+            u'name': [],
+            u'title': [u''],
+            u'url': [u'']
+        }
+
+        frm = CommentSecurityForm(target_object=discussion.content_object)
+        data.update(frm.generate_security_data())
+
+        self.client.login(username=author.username, password='test')
+        self.switch_course(self.client, self.sample_course)
+        response = self.client.post(url, data)
+        self.assertEquals(response.status_code, 302)
+
+    def test_discussion_assignment_response_tags(self):
+        self.client.login(username=self.instructor_one.username,
+                          password='test')
+        data = {
+            u'body': [u'<p>Talk</p>'],
+            u'project_type': [u'discussion-assignment'],
+            u'publish': [u'CourseProtected'],
+            u'title': [u'Important Discussion']}
+        url = reverse('discussion-assignment-create',
+                      args=[self.sample_course.id])
+        response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.status_code, 200)
+        assignment = Project.objects.get(title='Important Discussion')
+        self.assertEquals(published_assignment_responses(assignment), 0)
+
+        # add a comment
+        discussion = assignment.course_discussion()
+        self._add_comment(discussion, self.instructor_one)
+        self.assertEquals(published_assignment_responses(assignment), 0)
+        self._add_comment(discussion, self.student_one)
+        self.assertEquals(published_assignment_responses(assignment), 1)

--- a/mediathread/projects/urls.py
+++ b/mediathread/projects/urls.py
@@ -7,7 +7,8 @@ from mediathread.projects.views import (
     project_export_html, project_revisions,
     SequenceAssignmentEditView, CompositionAssignmentEditView,
     CompositionAssignmentResponseView, UpdateVisibilityView,
-    DiscussionAssignmentWizardView, DiscussionAssignmentCreateView
+    DiscussionAssignmentWizardView, DiscussionAssignmentCreateView,
+    DiscussionAssignmentSaveView
 )
 from rest_framework import routers
 
@@ -36,6 +37,10 @@ urlpatterns = [
     path('create/da/',
          DiscussionAssignmentCreateView.as_view(), {},
          "discussion-assignment-create"),
+
+    path('save/da/<int:project_id>',
+         DiscussionAssignmentSaveView.as_view(), {},
+         "discussion-assignment-save"),
 
     path('create/ja/', SequenceAssignmentEditView.as_view(), {},
          name='sequence-assignment-create'),

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -126,6 +126,9 @@ class ProjectCreateView(LoggedInCourseMixin, JSONResponseMixin,
 class ProjectSaveView(LoggedInCourseMixin, JSONResponseMixin,
                       ProjectEditableMixin, CreateReversionMixin, View):
 
+    def post_save(self, project):
+        return
+
     def post(self, request, *args, **kwargs):
         frm = ProjectForm(request, instance=self.project, data=request.POST)
         if frm.is_valid():
@@ -150,6 +153,8 @@ class ProjectSaveView(LoggedInCourseMixin, JSONResponseMixin,
 
             parent_id = request.POST.get('parent', None)
             project.set_parent(parent_id)
+
+            self.post_save(project)
 
             ctx = {
                 'status': 'success',
@@ -478,6 +483,15 @@ class DiscussionAssignmentCreateView(LoggedInFacultyMixin, ProjectCreateView):
         return HttpResponseRedirect(
                 reverse('project-workspace',
                         args=(request.course.pk, project.pk)))
+
+
+class DiscussionAssignmentSaveView(ProjectSaveView):
+
+    def post_save(self, project):
+        discussion = project.course_discussion()
+        discussion.content_object.title = project.title
+        discussion.content_object.comment = project.body
+        discussion.content_object.save()
 
 
 class DiscussionAssignmentWizardView(AssignmentEditView):

--- a/mediathread/reports/views.py
+++ b/mediathread/reports/views.py
@@ -281,7 +281,8 @@ class ActivityByCourseView(LoggedInSuperuserMixin, CSVResponseMixin, View):
 
         rows = []
         # Hard-coding date until we have time to code a proper ui
-        qs = Course.objects.filter(created_at__year__gte='2018')
+        qs = Course.objects.filter(
+            created_at__year__gte='2019', created_at__month__gte='6')
         for the_course in qs.order_by('-id'):
             row = []
             row.append(the_course.id)

--- a/mediathread/templates/discussions/discussion.html
+++ b/mediathread/templates/discussions/discussion.html
@@ -34,7 +34,7 @@
         jQuery(document).ready(function () {
             panelManager.init({
                 'container': 'discussion-workspace',
-                'url': MediaThread.urls['discussion-view']({{project.course_discussion.id}})
+                'url': MediaThread.urls['discussion-view']({{discussion.id}})
             });
         });
   </script>

--- a/mediathread/templates/discussions/discussion.html
+++ b/mediathread/templates/discussions/discussion.html
@@ -34,7 +34,7 @@
         jQuery(document).ready(function () {
             panelManager.init({
                 'container': 'discussion-workspace',
-                'url': MediaThread.urls['discussion-view']({{discussion.id}})
+                'url': MediaThread.urls['discussion-view']({{project.course_discussion.id}})
             });
         });
   </script>

--- a/mediathread/templates/projects/assignment_table_faculty.html
+++ b/mediathread/templates/projects/assignment_table_faculty.html
@@ -62,37 +62,38 @@
                 </td>
                 <td>
                     {% if response_count < 1 %}
-                    {% if request.user == object.author or request.user in object.participants %}
-                    <button class="btn btn-outline-secondary btn-sm" title="Delete {{object.title}}"
-                        data-toggle="modal" data-target="#delete-project-{{object.id}}">
-                        Delete
-                    </button>
-                    <div id="delete-project-{{object.id}}" class="modal" tabindex="-1" role="dialog">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Delete {{object.title}}</h5>
-                                    <button type="button" class="close"
-                                        data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-                                <div class="modal-body">
-                                    <p>Are you sure you want to delete {{object.title}}?</p>
-                                </div>
-                                <div class="modal-footer">
-                                    <button type="button"
-                                        class="btn btn-secondary" data-dismiss="modal">Close</button>
-                                    <form action="{% url 'project-delete' request.course.id object.id %}" method="post">
-                                        {% csrf_token %}
-                                        <button type="submit" data-project-id="{{object.id}}"
-                                            class="btn btn-primary btn-delete-project">Delete</button>
-                                    </form>
+                        {% if request.user == object.author or request.user in object.participants %}
+                            <button class="btn btn-outline-secondary btn-sm" title="Delete {{object.title}}"
+                                data-toggle="modal" data-target="#delete-project-{{object.id}}">
+                                Delete
+                            </button>
+                            <div id="delete-project-{{object.id}}" class="modal" tabindex="-1" role="dialog">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Delete {{object.title}}</h5>
+                                            <button type="button" class="close"
+                                                data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <p>Are you sure you want to delete {{object.title}}?</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button"
+                                                class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                            <form action="{% url 'project-delete' request.course.id object.id %}" method="post">
+                                                {% csrf_token %}
+                                                <button type="submit" data-project-id="{{object.id}}"
+                                                    class="btn btn-primary btn-delete-project">Delete</button>
+                                            </form>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    {% endif %}{% endif %}
+                        {% endif %}
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}

--- a/mediathread/templates/projects/assignment_table_student.html
+++ b/mediathread/templates/projects/assignment_table_student.html
@@ -23,84 +23,14 @@
         </thead>
         <tbody>
         {% for object in object_list %}
-            {% my_assignment_responses object request.user as responses %}
-
-            {% comment %}
-                Users can potentially have multiple responses to an assignment
-                by collaborating with fellow students.
-            {% endcomment %}
-
-            {% if responses.exists %}
-                {% for response_collaboration in responses %}
-                    {% with response=response_collaboration.content_object %}
-                    <tr>
-                        <td>
-                            {% if object.due_date %}
-                                {{object.due_date|date:"n/j/y"}}<br />
-                                {% if not response.is_submitted %}
-                                    {% if object.due_date < today %}
-                                        <div class="small text-danger">
-                                            Overdue {{object.due_date|timesince:today }}
-                                        </div>
-                                    {% else %}{% if object.due_date > today %}
-                                        <div class="small">
-                                            {{today|timeuntil:object.due_date }}
-                                        </div>
-                                    {% else %}
-                                        <div class="small">
-                                            Due today
-                                        </div>
-                                    {% endif %}{% endif %}
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            {{object.title}}
-                        </td>
-                        <td>
-                            {% if response.is_submitted %}
-                                <div>Submitted {{response.date_submitted|date:"n/j/y g:iA"}}</div>
-                                <div>{{response.visibility_short}}</div>
-                            {% else %}
-                                {{response.visibility_short}}
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if response.feedback_discussion %}
-                                <a class="btn btn-sm btn-primary btn-block"
-                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                    View Feedback
-                                </a>
-                            {% else %}{% if response.is_submitted %}
-                                <a class="btn btn-sm btn-secondary btn-block"
-                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                    View Response
-                                </a>
-                            {% else %}
-                                <a class="btn btn-sm btn-primary btn-block"
-                                    href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
-                                    Edit Response
-                                </a>
-                            {% endif %}{% endif %}
-                        </td>
-                        <td>
-                            {{object.description}}
-                        </td>
-                        <td>
-                            {{response.modified|date:"n/j/y g:iA"}}
-                        </td>
-                    </tr>
-                    {% endwith %}
-                {% endfor %}
-            {% else %}
-                {% comment %}
-                    Student has not yet created a response
-                {% endcomment %}
-                <tr>
+            {% if object.is_discussion_assignment %}
+                {% my_comment_count object request.user as comments %}
+                 <tr>
                     <td>
                         {% if object.due_date %}
-                            {{object.due_date|date:"n/j/y"}}<br />
-                            {% if object.due_date < today %}
+                            {% if comments.0 > 0 %}
+                                {{object.due_date|date:"n/j/y"}}
+                            {% else %}{% if object.due_date < today %}
                                 <div class="small text-danger">
                                     Overdue {{object.due_date|timesince:today }}
                                 </div>
@@ -112,30 +42,157 @@
                                 <div class="small">
                                     Due today
                                 </div>
-                            {% endif %}{% endif %}
+                            {% endif %}{% endif %}{% endif %}
                         {% endif %}
                     </td>
                     <td>
                         {{object.title}}
                     </td>
                     <td>
-                        No Response Yet
+                        {% if comments.0 == 0 %}
+                            No comments yet
+                        {% else %}{% if comments.0 == 1 %}
+                            Shared {{comments.0}} comment
+                        {% else %}
+                            Shared {{comments.0}} comments
+                        {% endif %}{% endif %}
                     </td>
                     <td>
-                        <form action="{% url 'project-create' request.course.id %}" method="post">
-                            {% csrf_token %}
-                            <input type="hidden" name="parent" value="{{object.id}}">
-                            <input type="hidden" name="project_type" value="composition">
-                            <input type="hidden" name="title" value="My Response">
-                            <button class="btn btn-sm btn-primary btn-block" type="submit">Add Response</button>
-                        </form>
+                        <a class="btn btn-sm btn-primary btn-block"
+                            href="{% url 'project-workspace' request.course.id object.id %}" title="{{object.title}}">
+                            Add Comments
+                        </a>
                     </td>
                     <td>
                         {{object.description}}
                     </td>
                     <td>
+                        {% if comments.0 %}
+                            {{comments.1}}
+                        {% endif %}
                     </td>
                 </tr>
+            {% else %}
+                {% my_assignment_responses object request.user as responses %}
+    
+                {% comment %}
+                    Users can potentially have multiple responses to an assignment
+                    by collaborating with fellow students.
+                {% endcomment %}
+    
+                {% if responses.exists %}
+                    {% for response_collaboration in responses %}
+                        {% with response=response_collaboration.content_object %}
+                        <tr>
+                            <td>
+                                {% if object.due_date %}
+                                    {{object.due_date|date:"n/j/y"}}<br />
+                                    {% if not response.is_submitted %}
+                                        {% if object.due_date < today %}
+                                            <div class="small text-danger">
+                                                Overdue {{object.due_date|timesince:today }}
+                                            </div>
+                                        {% else %}{% if object.due_date > today %}
+                                            <div class="small">
+                                                {{today|timeuntil:object.due_date }}
+                                            </div>
+                                        {% else %}
+                                            <div class="small">
+                                                Due today
+                                            </div>
+                                        {% endif %}{% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{object.title}}
+                            </td>
+                            <td>
+                                {% if response.is_submitted %}
+                                    <div>Submitted {{response.date_submitted|date:"n/j/y g:iA"}}</div>
+                                    <div>{{response.visibility_short}}</div>
+                                {% else %}
+                                    {{response.visibility_short}}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if response.feedback_discussion %}
+                                    <a class="btn btn-sm btn-primary btn-block"
+                                        href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                        View Feedback
+                                    </a>
+                                {% else %}{% if response.is_submitted %}
+                                    <a class="btn btn-sm btn-secondary btn-block"
+                                        href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                        View Response
+                                    </a>
+                                {% else %}
+                                    <a class="btn btn-sm btn-primary btn-block"
+                                        href="{% url 'project-workspace' request.course.id response.id %}" title="{{response.title}}">
+                                        Edit Response
+                                    </a>
+                                {% endif %}{% endif %}
+                            </td>
+                            <td>
+                                {{object.description}}
+                            </td>
+                            <td>
+                                {{response.modified|date:"n/j/y g:iA"}}
+                            </td>
+                        </tr>
+                        {% endwith %}
+                    {% endfor %}
+                {% else %}
+                    {% comment %}
+                        Student has not yet created a response or is discussing
+                    {% endcomment %}
+                    <tr>
+                        <td>
+                            {% if object.due_date %}
+                                {{object.due_date|date:"n/j/y"}}<br />
+                                {% if object.due_date < today %}
+                                    <div class="small text-danger">
+                                        Overdue {{object.due_date|timesince:today }}
+                                    </div>
+                                {% else %}{% if object.due_date > today %}
+                                    <div class="small">
+                                        {{today|timeuntil:object.due_date }}
+                                    </div>
+                                {% else %}
+                                    <div class="small">
+                                        Due today
+                                    </div>
+                                {% endif %}{% endif %}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{object.title}}
+                        </td>
+                        <td>
+                            No Response Yet
+                        </td>
+                        <td>
+                            {% if object.is_discussion_assignment %}
+                                <a href="{% url 'project-workspace' request.course.id object.id %}">
+                                    Add Comment
+                                </a>
+                            {% else %}
+                                <form action="{% url 'project-create' request.course.id %}" method="post">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="parent" value="{{object.id}}">
+                                    <input type="hidden" name="project_type" value="composition">
+                                    <input type="hidden" name="title" value="My Response">
+                                    <button class="btn btn-sm btn-primary btn-block" type="submit">Add Response</button>
+                                </form>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{object.description}}
+                        </td>
+                        <td>
+                        </td>
+                    </tr>
+                {% endif %}
             {% endif %}
         {% endfor %}
         </tbody>

--- a/mediathread/templates/projects/discussion_assignment.html
+++ b/mediathread/templates/projects/discussion_assignment.html
@@ -1,7 +1,7 @@
 {% extends "base_new.html" %}
 
 {% block title %}
-    {% if discussion.title %}{{discussion.title}}{% else %}New Discussion{% endif %}
+    {{assignment.title}}
 {% endblock %}
 
 {% block css %}
@@ -59,7 +59,77 @@
                     </nav>
                 </div>
             </div>
-            <div id="discussion-workspace" class="row">
+            <div class="d-flex justify-content-between align-items-center flex-wrap">
+                <div class="col-md-6 text-right order-md-2">
+                    {% if not is_faculty and responses|length > 1 %}
+                        <button id="assignment-responses" type="button" class="btn btn-outline-secondary dropdown-toggle"
+                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Class Responses
+                        </button>
+                        <div class="dropdown-menu" aria-labelledby="assignment-responses">
+                            {% for response in responses %}
+                                {% if response != my_response %}
+                                    <a class="dropdown-item" href="{% url 'project-workspace' request.course.id response.id %}">
+                                        {{response.attribution_last_first}}
+                                    </a>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                    {% if assignment_can_edit %}
+                        <a class="btn btn-outline-secondary btn-sm btn-edit-assignment"
+                            href="{% url 'discussion-assignment-edit-wizard' request.course.pk assignment.id %}">
+                            Edit Assignment
+                        </a>
+                    {% endif %}
+                </div>
+                <div class="col-md-6 pl-0 order-md-1">
+                    <h1 class="page-title">
+                        {{assignment.title}}
+                    </h1>
+                </div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center flex-wrap">
+                <div>
+                    <h5>
+                        {% if assignment.due_date %}
+                            Due {{assignment.due_date|date:'m/d/y'}}
+                        {% else %}
+                            No due date
+                        {% endif %}
+                    </h5>
+                </div>
+                <div>
+                    {% if is_faculty and responses|length > 0 %}
+                    <div class="input-group mb-3">
+                          <div class="input-group-prepend">
+                            <span class="input-group-text" id="student-responses-addon">
+                                Select Student Response
+                            </span>
+                          </div>
+                          <select id="student-responses"  placeholder="-----"
+                                class="form-control" aria-label="Student Responses"
+                                aria-describedby="student-response-addon">
+                                <option value=''>-----</option>
+                              {% for response in responses %}
+                                    <option {% if response.id == the_response.id %}selected="selected"{% endif %}
+                                        value="{% url 'project-workspace' request.course.id response.id %}">
+                                        {{response.attribution}}
+                                    </option>
+                                {% endfor %}
+                          </select>
+                        </div>
+                    {% endif %}
+                </div>
+                <div>
+                    {% if is_faculty %}
+                        <h5 class="pr-3 text-right project-visibility-description">
+                            {{assignment.visibility_short}}
+                        </h5>
+                    {% endif %}
+                </div>
+            </div>
+            <div id="discussion-workspace" class="row mt-3">
                 <div id="discussion-container" class="col-md-12">
                 </div>
             </div>

--- a/mediathread/templates/projects/discussion_assignment_edit.html
+++ b/mediathread/templates/projects/discussion_assignment_edit.html
@@ -69,14 +69,12 @@
                     {% endif %}
                 </div>
             </div>
-
-
             <div class="discussion-assignment">
                 <div class="row">
                     <div class="col-md-8">
                         <form name="discussion-assignment-edit"
                             {% if form.instance %}
-                                action="{% url 'project-save' request.course.pk form.instance.id %}"
+                                action="{% url 'discussion-assignment-save' request.course.pk form.instance.id %}"
                             {% else %}
                                 action="{% url 'discussion-assignment-create' request.course.pk %}"
                             {% endif %}


### PR DESCRIPTION
- Add the assignment look/feel to the Discussion Assignment view. 
- On the Assignment List page, add relevant details for students and faculty
    - Faculty will see how many students have responded
    - Students will see how many comments they have shared
- Handle the edit flow
    - Update the ThreadedComment's title & body when the assignment is edited through the wizard.
- Enhance Cypress discussion features to include the entire flow from creation to student replies.
