### PR TITLE
Composition Revisions: Turn into a straight list view

### DIFF
--- a/media/js/app/mediathread_setup.js
+++ b/media/js/app/mediathread_setup.js
@@ -102,17 +102,14 @@
             return '/project/view/' + projectId + '/feedback/';
         },
         'project-readonly': function(projectId, version) {
-            return '/project/view/' + projectId +
-                '/version/' + version + '/';
+            return '/course/' + MediaThread.current_course +
+                '/project/' + projectId + '/version/' + version + '/';
         },
         'project-create': function() {
             return '/project/create/';
         },
         'project-save': function(projectId) {
             return '/project/save/' + projectId + '/';
-        },
-        'project-revisions': function(projectId) {
-            return '/project/revisions/' + projectId + '/';
         },
         'project-response': function(courseId, projectId) {
             return '/course/' + courseId + '/project/response/'

--- a/media/js/app/panel.js
+++ b/media/js/app/panel.js
@@ -1,7 +1,6 @@
 /* global AssetPanelHandler: true */
 /* global DiscussionPanelHandler: true, MediaThread: true */
 /* global Mustache: true, panelFactory: true, ProjectPanelHandler: true */
-/* global urlWithCourse */
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
 (function() {
@@ -34,7 +33,7 @@
             self.$el = jQuery('#' + options.container);
 
             jQuery.ajax({
-                url: urlWithCourse(options.url),
+                url: options.url,
                 method: 'GET',
                 dataType: 'json',
                 cache: false, // Chrome & IE cache aggressively

--- a/media/templates/project.mustache
+++ b/media/templates/project.mustache
@@ -6,174 +6,159 @@
             </h1>
             <input name="title" value="{{context.project.title}}" type="hidden" />
         </div>
-        <div class="col-md-6 text-right">
-            <div class="mt-1">
-                {{#context.can_edit}}
-                    <button class="project-authorsbutton btn btn-outline-secondary btn-sm"
-                        data-toggle="modal" data-target="#authors-modal" data-keyboard="false">
-                        Authors
-                    </button>
-                    <div id="authors-modal" class="add-authors modal" tabindex="-1" role="dialog">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Authors</h5>
+        <div class="col-md-6 text-right pr-0">
+            {{#context.can_edit}}
+                <button class="project-authorsbutton btn btn-outline-secondary btn-sm"
+                    data-toggle="modal" data-target="#authors-modal" data-keyboard="false">
+                    Authors
+                </button>
+                <div id="authors-modal" class="add-authors modal" tabindex="-1" role="dialog">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Authors</h5>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-left">Select additional authors</p>
+                                {{{context.form.participants}}}
+                                <div class="invalid-feedback">
+                                    Please specify one or more authors, including yourself.
                                 </div>
-                                <div class="modal-body">
-                                    <p class="text-left">Select additional authors</p>
-                                    {{{context.form.participants}}}
-                                    <div class="invalid-feedback">
-                                        Please specify one or more authors, including yourself.
-                                    </div>
-                                </div>
-                                <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                    <button type="button" class="btn btn-primary btn-save-authors">Save</button>
-                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                <button type="button" class="btn btn-primary btn-save-authors">Save</button>
                             </div>
                         </div>
                     </div>
-                {{/context.can_edit}}
+                </div>
+            {{/context.can_edit}}
 
-                {{#context.can_edit}}
-                    <button class="project-revisionbutton btn btn-outline-secondary btn-sm">
-                        Revisions
+            {{#context.can_edit}}
+                <a class="project-revisionbutton btn btn-outline-secondary btn-sm"
+                    href="{{project_revisions_url}}" title="View project revisions" />
+                    Revisions
+                </a>
+            {{/context.can_edit}}
+
+            {{#context.my_response}}
+                {{^context.viewing_my_response}}
+                    <button class="project project-my-response btn btn-outline-secondary btn-sm"
+                        type="button" data-url="{{context.my_response.url}}">
+                        My Response
                     </button>
+                {{/context.viewing_my_response}}
+            {{/context.my_response}}
 
-                    <div id="project-revisions" class="revision-list" style="display: none" title="Revisions">
-                    </div>
-                {{/context.can_edit}}
-
-                {{#context.my_response}}
-                    {{^context.viewing_my_response}}
-                        <button class="project project-my-response btn btn-outline-secondary btn-sm"
-                            type="button" data-url="{{context.my_response.url}}">
-                            My Response
-                        </button>
-                    {{/context.viewing_my_response}}
-                {{/context.my_response}}
-
-                {{#context.my_responses.length}}
-                    <button class="project project-my-responses btn btn-outline-secondary btn-sm"
-                        type="button">
-                        My Responses ({{context.my_responses_count}})
-                    </button>
-                    <div class="my-response-list" style="display: none" title="My Responses">
-                        <div>Select an assignment response, then click "View"</div>
-                        <select name="my-responses" multiple="multiple">
-                            {{#context.my_responses}}
-                                <option value="{{url}}">
-                                    {{ modified }} &mdash;
-                                    {{#attribution_list}}
-                                        {{ name }}{{^last}}, {{/last}} 
-                                    {{/attribution_list}}
-                                </option>
-                            {{/context.my_responses}}
-                        </select> 
-                    </div>
-                {{/context.my_responses.length}}
-
-                {{#context.responses.length}}
-                    <button class="project project-responsesbutton btn btn-outline-secondary btn-sm"
-                        type="button">
-                        Class Responses ({{context.response_count}})
-                    </button>
-                    <div class="response-list" style="display: none" title="Responses">
-                        <div>Select an assignment response, then click "View"</div>
-                        <select name="responses" multiple="multiple">
-                          {{#context.responses}}
+            {{#context.my_responses.length}}
+                <button class="project project-my-responses btn btn-outline-secondary btn-sm"
+                    type="button">
+                    My Responses ({{context.my_responses_count}})
+                </button>
+                <div class="my-response-list" style="display: none" title="My Responses">
+                    <div>Select an assignment response, then click "View"</div>
+                    <select name="my-responses" multiple="multiple">
+                        {{#context.my_responses}}
                             <option value="{{url}}">
-                              {{#attribution_list}}
-                                {{ name }}{{^last}}, {{/last}} 
-                              {{/attribution_list}}
-                               &mdash; {{ submitted }}
+                                {{ modified }} &mdash;
+                                {{#attribution_list}}
+                                    {{ name }}{{^last}}, {{/last}} 
+                                {{/attribution_list}}
                             </option>
-                          {{/context.responses}}
-                        </select>
-                    </div>
-                {{/context.responses.length}}
+                        {{/context.my_responses}}
+                    </select> 
+                </div>
+            {{/context.my_responses.length}}
 
-                <a class="project-export btn btn-outline-secondary btn-sm" href="/project/export/msword/{{context.project.id}}/">
-                    Export to Word
-                </a>
+            {{#context.responses.length}}
+                <button class="project project-responsesbutton btn btn-outline-secondary btn-sm"
+                    type="button">
+                    Class Responses ({{context.response_count}})
+                </button>
+                <div class="response-list" style="display: none" title="Responses">
+                    <div>Select an assignment response, then click "View"</div>
+                    <select name="responses" multiple="multiple">
+                      {{#context.responses}}
+                        <option value="{{url}}">
+                          {{#attribution_list}}
+                            {{ name }}{{^last}}, {{/last}} 
+                          {{/attribution_list}}
+                           &mdash; {{ submitted }}
+                        </option>
+                      {{/context.responses}}
+                    </select>
+                </div>
+            {{/context.responses.length}}
 
-                <a class="project-print btn btn-outline-secondary btn-sm" href="/project/export/html/{{context.project.id}}/" target="_blank">
-                    Print
-                </a>
+            <a class="project-export btn btn-outline-secondary btn-sm" href="/project/export/msword/{{context.project.id}}/">
+                Export to Word
+            </a>
 
-                {{#context.can_edit}}
-                    <button class="project-savebutton btn btn-primary btn-sm" type="button">
-                        Save
-                    </button>
-                    <div class="save-publish-status modal" tabindex="-1" role="dialog">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Save Changes</h4>
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-                                <div class="modal-body">
-                                    <div class="row">
-                                        <div class="col-10">
-                                            <h6>Visibility</h6>
-                                            <p>Select who can see your work.</p>
-                                        </div>
-                                        <div class="col small text-right text-danger mr-2">
-                                            required
-                                        </div>
+            <a class="project-print btn btn-outline-secondary btn-sm" href="/project/export/html/{{context.project.id}}/" target="_blank">
+                Print
+            </a>
+
+            {{#context.can_edit}}
+                <button class="project-savebutton btn btn-primary btn-sm" type="button">
+                    Save
+                </button>
+                <div class="save-publish-status modal" tabindex="-1" role="dialog">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Save Changes</h4>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="row">
+                                    <div class="col-10">
+                                        <h6>Visibility</h6>
+                                        <p>Select who can see your work.</p>
                                     </div>
-                                    <div class="form-group">
-                                        {{{context.form.publish}}}
+                                    <div class="col small text-right text-danger mr-2">
+                                        required
                                     </div>
                                 </div>
-                                <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                    <button type="button" class="btn btn-primary btn-save-project">Save</button>
+                                <div class="form-group">
+                                    {{{context.form.publish}}}
                                 </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                <button type="button" class="btn btn-primary btn-save-project">Save</button>
                             </div>
                         </div>
                     </div>
-                {{/context.can_edit}}
-            </div>
+                </div>
+            {{/context.can_edit}}
+        </div>
+    </div>
+    <div class="d-flex justify-content-between align-items-center flex-wrap">
+        <div class="participant-container">
+            <h5>by <span class="participants_chosen">
+                {{#context.project.participants}}
+                    {{public_name}}{{^last}}, {{/last}}
+                {{/context.project.participants}}
+                </span>
+            </h5>
+        </div>
+        {{#context.project.current_version}}
+            <h5>Viewing version from {{context.project.modified}}</h5>
+        {{/context.project.current_version}}
+        <div>
+            <h5 class="project-visibility-description d-inline">
+                {{context.project.visibility}}
+            </h5>
+            <h5 class="d-inline">
+                <a class="last-version-public"
+                    style="display: {{#context.project.public_url}}inline{{/context.project.public_url}}{{^context.project.public_url}}none{{/context.project.public_url}}"
+                    href="{{context.project.public_url}}">(permalink)</a>
+            </h5>
         </div>
     </div>
     <div class="row">
-        <div class="col-md-12">
-            <div class="row no-gutters">
-                <div class="col">
-                    <div class="participant-container">
-                        <h5>by <span class="participants_chosen">
-                            {{#context.project.participants}}
-                                {{public_name}}{{^last}}, {{/last}}
-                            {{/context.project.participants}}
-                            </span>
-                        </h5>
-                    </div>
-                </div>
-                <div class="col text-right text-secondary pr-3">
-                    {{#context.project.visibility_long}}
-                        <span class="project-visibility-description">
-                            {{context.project.visibility_long}}
-                        </span>
-                        <span class="project-due-date">
-                            {{#context.project.due_date}}Due {{context.project.due_date}}{{/context.project.due_date}}
-                        </span>
-                        <a class="last-version-public"
-                            style="display: {{#context.project.public_url}}inline{{/context.project.public_url}}{{^context.project.public_url}}none{{/context.project.public_url}}" href="{{context.project.public_url}}">(permalink)</a>
-                        {{#context.project.current_version}}
-                            <span class="project-current-version" style="display: inline">
-                                | Version {{context.project.modified}}
-                            </span>
-                        {{/context.project.current_version}}
-                    {{/context.project.visibility_long}}
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row no-gutters">
         {{! Media Display Window and or a Collections box }}
         <div class="col-md-6 order-md-2">
             <div class="collection-materials"

--- a/media/templates/project_readonly.mustache
+++ b/media/templates/project_readonly.mustache
@@ -144,6 +144,9 @@
                 </span>
             </h5>
         </div>
+        {{#context.project.current_version}}
+            <h5>Viewing version from {{context.project.modified}}</h5>
+        {{/context.project.current_version}}
         <div>
             <h5 class="project-visibility-description d-inline">
                 {{context.project.visibility}}

--- a/media/templates/project_response.mustache
+++ b/media/templates/project_response.mustache
@@ -55,12 +55,10 @@
                                     {{/context.can_edit}}
 
                                     {{#context.can_edit}}
-                                        <button class="project-revisionbutton btn btn-outline-secondary btn-sm">
+                                        <a class="project-revisionbutton btn btn-outline-secondary btn-sm"
+                                            href="{{project_revisions_url}}" title="View project revisions" />
                                             Revisions
-                                        </button>
-
-                                        <div id="project-revisions" class="revision-list" style="display: none" title="Revisions">
-                                        </div>
+                                        </a>
                                     {{/context.can_edit}}
 
                                     {{#context.responses.length}}
@@ -141,21 +139,22 @@
                                     {{#context.project.submitted_on}}
                                         <h5>Submitted {{context.project.submitted_on}}</h5>
                                     {{/context.project.submitted_on}}
-                                {{/is_faculty}} 
-                                {{#context.project.visibility}}
-                                    <h5 class="project-visibility-description">
+                                {{/is_faculty}}
+                                {{#context.project.current_version}}
+                                    <h5>Viewing version from {{context.project.modified}}</h5>
+                                {{/context.project.current_version}}
+                                <div>
+                                    <h5 class="project-visibility-description d-inline">
                                         {{context.project.visibility}}
                                     </h5>
-                                {{/context.project.visibility}}
-                                <a class="last-version-public"
-                                    style="display: {{#context.project.public_url}}inline{{/context.project.public_url}}{{^context.project.public_url}}none{{/context.project.public_url}}" href="{{context.project.public_url}}">(permalink)</a>
-                                {{#context.project.current_version}}
-                                    <span class="project-current-version" style="display: inline">
-                                        | Version {{context.project.modified}}
-                                    </span>
-                                {{/context.project.current_version}}
+                                    <h5 class="d-inline">
+                                        <a class="last-version-public"
+                                            style="display: {{#context.project.public_url}}inline{{/context.project.public_url}}{{^context.project.public_url}}none{{/context.project.public_url}}"
+                                            href="{{context.project.public_url}}">(permalink)</a>
+                                    </h5>
+                                </div>
                             </div>
-                            <div class="row no-gutters">
+                            <div class="row">
                                 {{! Media Display Window and or a Collections box }}
                                 <div class="col-md-6 order-md-2">
                                     <div class="collection-materials"

--- a/media/templates/project_revisions.mustache
+++ b/media/templates/project_revisions.mustache
@@ -1,7 +1,0 @@
-<div>Select a revision, then click "View". The revision view will open in a separate window.</div>
-
-<select name="revisions" multiple="multiple">
-  {{#revisions}}
-    <option value="/project/view/{{versioned_id}}/version/{{version_number}}/">{{modified}} by {{author}}&nbsp;</option>
-  {{/revisions}}
-</select>

--- a/mediathread/assetmgr/api.py
+++ b/mediathread/assetmgr/api.py
@@ -62,7 +62,7 @@ class AssetResource(ModelResource):
         if hasattr(self, 'request') and hasattr(self.request, 'course'):
             bundle.data['local_url'] = reverse(
                 'asset-view', kwargs={
-                    'course_pk': self.request.course.pk,
+                    'course_pk': bundle.obj.course.pk,
                     'asset_id': bundle.obj.pk,
                 })
         else:

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -441,7 +441,8 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertIsNotNone(assignment_response.public_url())
 
     def test_project_revisions(self):
-        url = reverse('project-revisions', args=[self.project_private.id])
+        url = reverse('project-revisions',
+                      args=[self.sample_course.id, self.project_private.id])
 
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 302)
@@ -450,7 +451,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.client.login(username=self.alt_student.username, password='test')
         self.switch_course(self.client, self.alt_course)
         response = self.client.get(url, {})
-        self.assertEquals(response.status_code, 404)
+        self.assertEquals(response.status_code, 403)
 
         # forbidden as non project-participant
         self.client.login(username=self.student_two.username, password='test')
@@ -464,8 +465,7 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         response = self.client.get(url, {},
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
-        the_json = json.loads(response.content)
-        self.assertEquals(len(the_json['revisions']), 1)
+        self.assertEquals(len(response.context['versions']), 1)
 
     def test_project_view_readonly(self):
         version = next(self.project_private.versions())

--- a/mediathread/projects/tests/test_views.py
+++ b/mediathread/projects/tests/test_views.py
@@ -494,8 +494,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
 
         the_json = json.loads(response.content)
         self.assertTrue('panels' in the_json)
-        self.assertEquals(the_json['panels'][0]['panel_state_label'],
-                          'Version View')
 
     def test_project_public_view(self):
         url = self.project_private.get_collaboration().get_absolute_url()
@@ -543,7 +541,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context['project'], self.project_private)
         self.assertEquals(response.context['space_owner'], 'student_one')
-        self.assertFalse(response.context['show_feedback'])
 
     def test_project_workspace_ajax(self):
         project_id = self.project_private.id
@@ -557,7 +554,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         the_json = json.loads(response.content)
 
         self.assertEquals(the_json['space_owner'], 'student_one')
-        self.assertFalse(the_json['show_feedback'])
 
         self.assertEquals(len(the_json['panels']), 2)
 
@@ -565,7 +561,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertFalse(panel['is_faculty'])
         self.assertEquals(len(panel['owners']), 6)
         self.assertEquals(panel['vocabulary'], [])
-        self.assertEquals(panel['panel_state'], 'open')
         self.assertEquals(panel['template'], 'project')
         self.assertEquals(len(panel['context']['annotations']), 2)
         self.assertEquals(len(panel['context']['assets']), 1)
@@ -590,7 +585,6 @@ class ProjectViewTest(MediathreadTestMixin, TestCase):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context['project'], self.project_private)
         self.assertEquals(response.context['space_owner'], 'student_two')
-        self.assertFalse(response.context['show_feedback'])
 
 
 class TestProjectSortView(MediathreadTestMixin, TestCase):

--- a/mediathread/projects/urls.py
+++ b/mediathread/projects/urls.py
@@ -4,11 +4,11 @@ from mediathread.projects.views import (
     ProjectCreateView, ProjectDeleteView, ProjectSortView,
     SelectionAssignmentEditView, ProjectSaveView, ProjectDispatchView,
     UnsubmitResponseView, ProjectReadOnlyView, project_export_msword,
-    project_export_html, project_revisions,
+    project_export_html,
     SequenceAssignmentEditView, CompositionAssignmentEditView,
     CompositionAssignmentResponseView, UpdateVisibilityView,
     DiscussionAssignmentWizardView, DiscussionAssignmentCreateView,
-    DiscussionAssignmentSaveView
+    DiscussionAssignmentSaveView, ProjectVersionListView
 )
 from rest_framework import routers
 
@@ -89,14 +89,14 @@ urlpatterns = [
     path('visibility/<int:project_id>/',
          UpdateVisibilityView.as_view(), {}, 'project-visibility'),
 
-    path('revisions/<int:project_id>/',
-         project_revisions,
-         name='project-revisions'),
-
     # view versioned read only
-    path('view/<int:project_id>/version/<int:version_number>/',
+    path('<int:project_id>/version/<int:version_number>/',
          ProjectReadOnlyView.as_view(),
          name='project-view-readonly'),
+
+    path('<int:project_id>/version/',
+         ProjectVersionListView.as_view(),
+         name='project-revisions'),
 
     # instructor information reorder
     path('sort/', ProjectSortView.as_view(), name='project-sort'),

--- a/mediathread/templates/projects/composition.html
+++ b/mediathread/templates/projects/composition.html
@@ -54,9 +54,17 @@
 {% endblock %}
 
 {% block content %}
-    {% with active='projects' %}
-        {% include 'main/three_section_tabs.html' %}
-    {% endwith %}
+    {% if not readonly or version %}
+        {% if project.is_assignment or project.assignment %}
+            {% with active='assignments' %}
+                {% include 'main/three_section_tabs.html' %}
+            {% endwith %}
+        {% else %}
+            {% with active='projects' %}
+                {% include 'main/three_section_tabs.html' %}
+            {% endwith %}
+        {% endif %}
+    {% endif %}
     <div class="tab-content">
         <div role="tabpanel">
             <div class="row mt-2">
@@ -64,9 +72,15 @@
                     <nav aria-label="breadcrumb">
                       <ol class="breadcrumb bg-light mb-0">
                         <li class="breadcrumb-item" aria-current="page">
-                            <a href="{% url 'project-list' request.course.pk %}">
-                                Back to all projects
-                            </a>
+                            {% if version %}
+                                <a href="{% url 'project-revisions' request.course.pk project.id %}">
+                                    Back to {{project.title}} revisions
+                                </a>
+                            {% else %}{% if not readonly %}
+                                <a href="{% url 'project-list' request.course.pk %}">
+                                    Back to all projects
+                                </a>
+                            {% endif %}{% endif %}
                         </li>
                       </ol>
                     </nav>

--- a/mediathread/templates/projects/project_readonly.html
+++ b/mediathread/templates/projects/project_readonly.html
@@ -1,14 +1,12 @@
 {% extends "base_new.html" %}
 
 {% block title %}
-    {% if project.title %}{{project.title}}{% else %}New Composition{% endif %}
+    {{project.title}}
 {% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="{{STATIC_URL}}js/select2/select2.css" media="screen" />
     <link rel="stylesheet" href="{{STATIC_URL}}css/project.css"  media="screen" />
     <link rel="stylesheet" href="{{STATIC_URL}}css/project.print.css"  media="print" />
-    <link rel="stylesheet" href="{{STATIC_URL}}js/lib/sherdjs/lib/tinymce/plugins/citation/css/citation.css" />
 
     <!--All the annotation css -->
     {% include "djangosherd/annotator_resources_css.html" %}
@@ -21,28 +19,21 @@
 {% block js %}
     <!--All the annotation javascript -->
     {% include "djangosherd/annotator_resources.html" %}
-
-    <script src="{{STATIC_URL}}jquery/js/jquery-ui-timepicker-addon.js" type="text/javascript"></script>
 {% endblock %}
 
 {% block uncompressable_js %}
     {% include "djangosherd/player_resources.html" %}
     <!-- required project functionality -->
     <script type="text/javascript" src="{{STATIC_URL}}js/select2/select2.min.js"></script>
-    <script type="text/javascript" src="{{STATIC_URL}}js/lib/sherdjs/lib/tinymce/tinymce.min.js"></script>
-    <script type="text/javascript" src="{{STATIC_URL}}js/app/tinymce_init.js"></script>
-
-    <!--  Generic Functionality -->
-    <script type="text/javascript" src="{{STATIC_URL}}jquery/js/masonry.pkgd.min.js"></script>
 
     <script type="text/javascript">
         jQuery(document).ready(function () {
             panelManager.init({
                 'container': 'project-workspace',
-                {% if show_feedback %}
-                    'url': MediaThread.urls['project-feedback']({{project.id}})
+                {% if public_url %}
+                    'url': '{{ public_url }}'
                 {% else %}
-                    'url': MediaThread.urls['project-view']({{project.id}})
+                    'url': MediaThread.urls['project-readonly']({{project.id}}, {{version}})
                 {% endif %}
             });
         });
@@ -50,24 +41,34 @@
 {% endblock %}
 
 {% block content %}
-    {% with active='projects' %}
-        {% include 'main/three_section_tabs.html' %}
-    {% endwith %}
+    {% if version %}
+        {% if project.is_assignment or project.assignment %}
+            {% with active='assignments' %}
+                {% include 'main/three_section_tabs.html' %}
+            {% endwith %}
+        {% else %}
+            {% with active='projects' %}
+                {% include 'main/three_section_tabs.html' %}
+            {% endwith %}
+        {% endif %}
+    {% endif %}
     <div class="tab-content">
         <div role="tabpanel">
+            {% if version %}
             <div class="row mt-2">
                 <div class="col-md-auto">
                     <nav aria-label="breadcrumb">
                       <ol class="breadcrumb bg-light mb-0">
                         <li class="breadcrumb-item" aria-current="page">
-                            <a href="{% url 'project-list' request.course.pk %}">
-                                Back to all projects
+                            <a href="{% url 'project-revisions' request.course.pk project.id %}">
+                                Back to {{project.title}} revisions
                             </a>
                         </li>
                       </ol>
                     </nav>
                 </div>
             </div>
+            {% endif %}
             <div id="project-workspace" class="row">
                 <div id="project-container" class="col-md-12">
                 </div>

--- a/mediathread/templates/projects/version_list.html
+++ b/mediathread/templates/projects/version_list.html
@@ -1,0 +1,58 @@
+{% extends "base_new.html" %}
+{% load static %}
+
+{% block title %}
+Projects
+{% endblock %}
+
+{% block css %}
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.min.css' %}">
+    <link rel="stylesheet" href="{% static 'js/lib/tablesorter/theme.default.custom.css' %}">
+{% endblock %}
+
+{% block content %}
+<div>
+    {% if project.is_assignment or project.assignment %}
+        {% with active='assignments' %}
+            {% include 'main/three_section_tabs.html' %}
+        {% endwith %}
+    {% else %}
+        {% with active='projects' %}
+            {% include 'main/three_section_tabs.html' %}
+        {% endwith %}
+    {% endif %}
+    <div class="tab-content">
+        <div role="tabpanel">
+            <div class="row mt-2">
+                <div class="col-md-auto">
+                    <nav aria-label="breadcrumb">
+                      <ol class="breadcrumb bg-light mb-0">
+                        <li class="breadcrumb-item" aria-current="page">
+                            <a href="{% url 'project-workspace' request.course.pk project.id %}">
+                                Back to {{project.title}}
+                            </a>
+                        </li>
+                      </ol>
+                    </nav>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <h1 class="page-title">Revisions</h1>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-auto">
+                    <ul class="list-group">
+                        {% for v in versions %}
+                        <li class="list-group-item">
+                            <a href="{% url 'project-view-readonly' project.id v.version_number %}">{{v.modified}}</strong> by {{v.author}}</a> 
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/mediathread/templates/projects/version_list.html
+++ b/mediathread/templates/projects/version_list.html
@@ -29,7 +29,7 @@ Projects
                       <ol class="breadcrumb bg-light mb-0">
                         <li class="breadcrumb-item" aria-current="page">
                             <a href="{% url 'project-workspace' request.course.pk project.id %}">
-                                Back to {{project.title}}
+                                Back to {{project.title}} view
                             </a>
                         </li>
                       </ol>
@@ -38,7 +38,7 @@ Projects
             </div>
             <div class="row">
                 <div class="col">
-                    <h1 class="page-title">Revisions</h1>
+                    <h1 class="page-title">Revisions for {{project.title}}</h1>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
Remove template fetches and ajax calls for revisions in favor of navigating to a vanilla list view of versions.