### PR TITLE
Video selections: allow autoplay

### DIFF
--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -421,6 +421,14 @@ CitationView.prototype.displayCitation = function (anchor, ann_obj, id) {
                 ((ann_obj.metadata && ann_obj.metadata.title) ?
                         '' + ann_obj.metadata.title + ''
                         : '');
+            if (ann_obj.annotation.startCode) {
+                var duration = new Date(ann_obj.annotation.duration * 1000)
+                    .toISOString().substr(11, 8);
+                targets.annotation_title.innerHTML += 
+                    '<br />' + ann_obj.annotation.startCode + ' - ' +
+                     ann_obj.annotation.endCode +
+                    ' (' + duration + ')';
+            }
         }
     }
 

--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -132,7 +132,7 @@ if (!Sherd.Video.Vimeo) {
                 'width="' + obj.options.width + '" ' +
                 'height="' + obj.options.height + '" ' +
                 'autoplay="' + autoplay + '" ' +
-                '></iframe>' +
+                'allow="autoplay"></iframe>' +
                 '</div>';
 
             return {

--- a/media/js/lib/sherdjs/src/video/views/youtube.js
+++ b/media/js/lib/sherdjs/src/video/views/youtube.js
@@ -93,6 +93,7 @@ if (!Sherd.Video.YouTube) {
                     'width="' + obj.options.width + '" ' +
                     'height="' + obj.options.height + '" ' +
                     'allowfullscreen="true" ' +
+                    'allow="autoplay" ' +
                     'frameborder="0" ' +
                     'id="' + self.playerID + '" />' +
                     '</div>'

--- a/mediathread/assetmgr/api.py
+++ b/mediathread/assetmgr/api.py
@@ -61,9 +61,9 @@ class AssetResource(ModelResource):
 
         if hasattr(self, 'request') and hasattr(self.request, 'course'):
             bundle.data['local_url'] = reverse(
-                'asset-view', kwargs={
+                'react_asset_detail', kwargs={
                     'course_pk': bundle.obj.course.pk,
-                    'asset_id': bundle.obj.pk,
+                    'pk': bundle.obj.pk,
                 })
         else:
             bundle.data['local_url'] = bundle.obj.get_absolute_url()


### PR DESCRIPTION
Add `allow="autoplay"` to the rendered Vimeo & YouTube iframes. This also tweaks the UI a bit to add range and duration underneath the displayed video.