### PR TITLE
Small citation window redesign

### DIFF
--- a/media/css/project.css
+++ b/media/css/project.css
@@ -71,6 +71,29 @@ body.mce-content-body {
 
 div.mce_editorwindow {
     min-width: 324px;
+    margin-top: 5px;
+}
+
+div.mce_editorwindow .asset-object {
+    background-color: white;
+    border: 0;
+}
+
+div.mce_editorwindow .mce_top {
+    background-color: #343a40;
+}
+
+div.mce_editorwindow .mce_editorwindow_closebtn {
+    float: right;
+    margin: 5px;
+}
+
+div.mce_editorwindow .mce_content {
+    clear: both;
+}
+
+div.mce_editorwindow .mce_editorwindow_closebtn:hover {
+  background-image: none;
 }
 
 .defaultSkin table.mceLayout {
@@ -87,6 +110,11 @@ div.mce_editorwindow {
 .main-view.asset-view-published {
     margin-top: 83px;
 }
+
+.main-view.asset-view-published .videoclipbox {
+    border-top: 40px solid #343a40;
+}
+
 .main-view.collection-materials {
     margin-top: 62px;
 }
@@ -188,7 +216,6 @@ div.save-publish-status li {
     font-size: 1.5rem;
     margin-bottom: 1rem;
 }
-
 
 /* ---- Selection & Sequence Assignments ------- */
 /* Selection Assignment */

--- a/media/js/app/projects/projectpanel.js
+++ b/media/js/app/projects/projectpanel.js
@@ -403,6 +403,7 @@ ProjectPanelHandler.prototype.preview = function(showPreview) {
         jQuery(self.essaySpace).hide();
 
         self.$el.find('div.asset-view-published').hide();
+        self.$el.find('.videoclipbox').hide();
         self.$el.find('.project-editbutton').addClass('active');
         self.$el.find('.project-previewbutton').removeClass('active');
 

--- a/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
+++ b/media/js/lib/sherdjs/lib/tinymce/plugins/citation/plugin.min.js
@@ -175,28 +175,24 @@
                                 var ann_href = String(a_tag.href);
                                 var dom = DOM.create(
                                     'div', {},
-                                    '<a href="' + ann_href + '">' +
-                                        'View Selection</a>' +
                                         '<div class="asset-object">' +
                                         '<div class="assetbox" ' +
                                         'style="width: 322px; display:none;"><div class="asset-display"></div>' +
-                                        '<div class="clipstrip-display"></div>' +
+                                        '<div class="clipstrip-display" style="display: none"></div>' +
                                         '</div></div>');
-                                self.opener_listener = DomQuery(dom.firstChild)
-                                    .on('click', function(evt) {
-                                        evt.preventDefault();
-                                        var cv = new CitationView();
-                                        cv.init({
-                                            autoplay:true,
-                                            targets:{
-                                                asset:self.asset_target
-                                            }});
-                                        self.citation = cv.openCitation(a_tag);
-                                    });
-                                self.current_opener = dom.firstChild;
+
                                 //target should be the thing that has display:none
                                 self.asset_target = dom.lastChild.firstChild;
                                 return dom;
+                            },
+                            onOpen: function(a_tag) {
+                                var cv = new CitationView();
+                                cv.init({
+                                    autoplay:true,
+                                    targets:{
+                                        asset: self.asset_target
+                                    }});
+                                self.citation = cv.openCitation(a_tag);
                             }
                         });
                     }

--- a/media/js/lib/sherdjs/lib/tinymce/plugins/editorwindow/css/editorwindow.css
+++ b/media/js/lib/sherdjs/lib/tinymce/plugins/editorwindow/css/editorwindow.css
@@ -13,42 +13,10 @@ div.mce_editorwindow
   height:auto;
   /*end init defaults*/
 
-  background-color:#EDEDED;
-  border:1px solid #555555;
-  padding:0.5em 1em 0.5em 0.5em;
+  background-color: white;
+  border: 1px solid rgba(0,0,0,0.2);
+  background-color: white;
+
+  padding:0 1em 0 0 0;
 
  }
-/*
-a.mce_editorwindow_closebtn
-{ 
-  float:right;
-  border:1px solid red;
-  background-color:#FFC0C0;
-  color:red;
-  padding:2px;
-  margin-left:10px;
- }
-*/
-a.mce_editorwindow_closebtn
-{ 
-    display:block;
-  float:right;
-  /*IE7 with float:right makes the parent div width:100% and looks bad
-    so we float it left instead.  not perfect, but looks ok.
-   */
-    *float:left;
-  background-image:url(cornerx.png);
-  margin-left:10px;
-    *margin-right:10px;
-    *margin-left:0px;
-  width:16px;
-  height:16px;
-  color:transparent;
-  /*for IE 6-8 not supporting transparent text:*/
-    overflow:hidden;
-    line-height:48px;
- }
-a.mce_editorwindow_closebtn:hover
-{ 
-  background-image:url(cornerx_red.png);
-}

--- a/media/js/lib/sherdjs/lib/tinymce/plugins/editorwindow/plugin.min.js
+++ b/media/js/lib/sherdjs/lib/tinymce/plugins/editorwindow/plugin.min.js
@@ -137,21 +137,23 @@
                 'class': 'mce_editorwindow',
                 'id': id
             });
+            var classes =
+                'btn btn-sm btn-outline-light mce_editorwindow_closebtn';
             this._addAll(
                 win,
                 [
                     'div',
-                    {id: id + '_top'},
+                    {id: id + '_top', 'class': 'mce_top'},
                     ['a',
                      {
                          id: id + '_close',
-                         'class': 'mce_editorwindow_closebtn',
+                         'class': classes,
                          tabindex: '-1',
                          href: '#'
                      },
-                     'x'
+                     'Close'
                     ],
-                    ['div', {id: id + '_content'}]
+                    ['div', {id: id + '_content', 'class': 'mce_content'}]
                 ]);
             //a little much?  but that's where the key events are :-(
             //any changes should also update removal in _closeWindow
@@ -173,6 +175,8 @@
             DOM.get(id + '_content').appendChild(this.opened.content(parent));
 
             this._positionWindow(ed,currentElt,parent);
+
+            this.opened.onOpen(parent)
 
             DomQuery('#' + id + '_close').on('click', function(evt) {
                 evt.preventDefault();

--- a/mediathread/templates/clientside/project_response.mustache
+++ b/mediathread/templates/clientside/project_response.mustache
@@ -62,7 +62,6 @@
                                             Revisions
                                         </a>
                                     {{/context.can_edit}}
-
                                     <a class="project-export btn btn-outline-secondary btn-sm" href="/project/export/msword/{{context.project.id}}/">
                                         Export to Word
                                     </a>


### PR DESCRIPTION
These changes adjust the behavior for the small citation window that pops up within the edit views in composition, composition assignment response and discussion spaces.

* Eliminate the "View Selection" link and show the selection immediately
* Restyle to be in line with the overall new design
* Add the slate border to the top of the large citation window
* Hide videoclipbox on edit

<img width="495" alt="Screen Shot 2020-08-10 at 5 15 12 PM" src="https://user-images.githubusercontent.com/141369/89956487-46428a80-dc03-11ea-81e0-05c79b1243b4.png">
