### PR TITLE
Improve grid view - MEDT-3705

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -4228,4 +4228,5 @@ input#annotationFilter {
 ul.selection-spinner {
     margin-bottom: 0;
     padding-bottom: 0;
+    padding-right: 0;
 }

--- a/media/js/src/AnnotationScroller.jsx
+++ b/media/js/src/AnnotationScroller.jsx
@@ -51,73 +51,68 @@ export default class AnnotationScroller extends React.Component {
         const courseUrl = getCourseUrl();
 
         let activeLink = getAssetUrl(this.props.asset.id);
-        let activeTitle = 'Original Item';
+        const plural = this.props.asset.annotations.length === 1 ? '' : 's';
+        let activeTitle = 'Original Item ' +
+            `(${this.props.asset.annotations.length} selection${plural})`;
         if (selectedAnnotation) {
             activeLink = `${courseUrl}react/asset/` +
                   selectedAnnotation.asset_id +
                 '/annotations/' + selectedAnnotation.id + '/';
-            activeTitle = selectedAnnotation.title;
+            const pageInfo =
+                `(${this.state.currentAnnotation + 1} of ` +
+                  `${this.props.asset.annotations.length}) `;
+            activeTitle = pageInfo + selectedAnnotation.title;
         }
 
-        const showSelectionCount = this.props.asset.annotations &&
-              this.props.asset.annotations.length > 0 &&
-              this.state.currentAnnotation > -1;
-
         return (
-            <div>
-                <nav aria-label="Annotation navigation">
-                    <ul className="pagination btn-sm selection-spinner">
-                        <li className={
-                            'page-item ' + (
-                                this.state.currentAnnotation > -1 ?
-                                    '' : 'disabled'
-                            )
-                        }>
-                            <a
-                                className="page-link" href="#"
-                                onClick={this.onPrevClick}
-                                title="Previous Selection"
-                                aria-label="Previous Selection">
-                                <span aria-hidden="true">
-                                    <svg width="1em" height="1em" viewBox="0 0 16 16" className="bi bi-caret-left-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
-                                    </svg>
-                                </span>
-                            </a>
-                        </li>
+            <nav className="mx-1" aria-label="Annotation navigation">
+                <ul className="pagination btn-sm selection-spinner">
+                    <li className={
+                        'page-item ' + (
+                            this.state.currentAnnotation > -1 ?
+                                '' : 'disabled'
+                        )
+                    }>
+                        <a
+                            className="page-link" href="#"
+                            onClick={this.onPrevClick}
+                            title="Previous Selection"
+                            aria-label="Previous Selection">
+                            <span aria-hidden="true">
+                                <svg width="1em" height="1em" viewBox="0 0 16 16" className="bi bi-caret-left-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
+                                </svg>
+                            </span>
+                        </a>
+                    </li>
 
-                        <li className="page-item w-100 text-center">
-                            <a className="page-link" href={activeLink}>
-                                {activeTitle}
-                            </a>
-                        </li>
+                    <li className="page-item w-100 text-center text-nowrap text-truncate">
+                        <a className="page-link" href={activeLink}>
+                            {activeTitle}
+                        </a>
+                    </li>
 
-                        <li className={
-                            'page-item ' + (
-                                (this.state.currentAnnotation <
-                                 (this.props.asset.annotations.length - 1)) ?
-                                    '' : 'disabled'
-                            )
-                        }>
-                            <a
-                                className="page-link" href="#"
-                                onClick={this.onNextClick}
-                                title="Next Selection"
-                                aria-label="Next Selection">
-                                <span aria-hidden="true">
-                                    <svg width="1em" height="1em" viewBox="0 0 16 16" className="bi bi-caret-right-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                                    </svg>
-                                </span>
-                            </a>
-                        </li>
-                    </ul>
-                    <div className={'text-center ' + (showSelectionCount ? '' : 'invisible')}>
-                        Selection {this.state.currentAnnotation + 1} of&nbsp;
-                        {this.props.asset.annotations.length}
-                    </div>
-                </nav>
-            </div>
+                    <li className={
+                        'page-item ' + (
+                            (this.state.currentAnnotation <
+                             (this.props.asset.annotations.length - 1)) ?
+                                '' : 'disabled'
+                        )
+                    }>
+                        <a
+                            className="page-link" href="#"
+                            onClick={this.onNextClick}
+                            title="Next Selection"
+                            aria-label="Next Selection">
+                            <span aria-hidden="true">
+                                <svg width="1em" height="1em" viewBox="0 0 16 16" className="bi bi-caret-right-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+                                </svg>
+                            </span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
         );
     }
 }

--- a/media/js/src/GridAsset.jsx
+++ b/media/js/src/GridAsset.jsx
@@ -17,7 +17,9 @@ import Asset from './Asset';
 import {
     capitalizeFirstLetter, handleBrokenImage, getAssetUrl
 } from './utils';
-import {objectProportioned, displaySelection} from './openlayersUtils';
+import {
+    objectProportioned, displaySelection, resetMap
+} from './openlayersUtils';
 
 export default class GridAsset extends React.Component {
     constructor(props) {
@@ -28,8 +30,9 @@ export default class GridAsset extends React.Component {
             thumbnailUrl: '/media/img/thumb_video.png'
         };
 
+        this.selectionSource = new VectorSource();
         this.selectionLayer = new VectorLayer({
-            source: new VectorSource()
+            source: this.selectionSource
         });
 
         this.asset = new Asset(this.props.asset);
@@ -45,9 +48,19 @@ export default class GridAsset extends React.Component {
         this.setState({selectedAnnotation: a});
 
         if (type === 'image') {
-            this.map.removeLayer(this.selectionLayer);
-            const newLayer = displaySelection(a, this.map);
-            this.selectionLayer = newLayer;
+            if (this.selectionLayer) {
+                this.map.removeLayer(this.selectionLayer);
+            }
+
+            if (a) {
+                const newLayer = displaySelection(a, this.map);
+                this.selectionLayer = newLayer;
+            } else {
+                resetMap(
+                    this.map,
+                    this.selectionSource,
+                    this.asset.getImage());
+            }
         }
     }
     render() {
@@ -69,8 +82,8 @@ export default class GridAsset extends React.Component {
         const assetUrl = getAssetUrl(this.props.asset.id);
 
         return (
-            <div className="col-sm-4">
-                <h5 className="text-nowrap text-truncate">
+            <div className="col-sm-4 border-right border-white mb-2">
+                <h5 className="text-nowrap text-truncate pr-2">
                     <a
                         onClick={(e) => this.props.enterAssetDetailView(e, this.props.asset)}
                         href={assetUrl}


### PR DESCRIPTION
![Screenshot_2020-08-11_18-40-16](https://user-images.githubusercontent.com/59292/89955954-265e9700-dc02-11ea-8989-d76fca68df69.png)


I'm putting the "(1 of 2)" text before the title, because the CSS ellipsis functionality isn't advanced enough to determine available space, and append a string after the ellipsis. If we put this info at the end, it won't be visible to the user, unless we put this info in a separate element and do some sort of flexbox solution, which is definitely possible. But this works for now:

![Screenshot_2020-08-11_18-41-15](https://user-images.githubusercontent.com/59292/89956157-98cf7700-dc02-11ea-93e4-ae384d69d8d6.png)
