### PR TITLE
Update browser extension requirements

### DIFF
--- a/mediathread/templates/main/collection_add.html
+++ b/mediathread/templates/main/collection_add.html
@@ -15,7 +15,12 @@
                        <div class="card-body">
                            <h5 class="card-title text-center">Import Media</h5>
                            <p class="card-text">
-                               Install Mediathread’s Google Chrome extension to import video, audio, and images into this course from various sites across the web. You must be using Chrome to install this extension.
+                               Install Mediathread’s Google Chrome
+                               extension to import video, audio, and
+                               images into this course from various
+                               sites across the web. You must be using
+                               a browser in the <a href="https://en.wikipedia.org/wiki/Chromium_(web_browser)#Browsers_based_on_Chromium">Chrome family</a>
+                               to install this extension.
                            </p>
                            <div class="arrowContent">
                                {% if request.user_agent.browser.family == 'Chrome' or request.user_agent.browser.family == 'Chromium' %}


### PR DESCRIPTION
The extension actually works with any browser based on Chromium (I use
it in Brave):
https://en.wikipedia.org/wiki/Chromium_(web_browser)#Browsers_based_on_Chromium

So, I don't want users of other browsers to feel left out here. I think
"a browser in the Chrome family" is succint enough, and still makes it
obvious for less technical users that they just need to use Chrome.

Changing this line:

    You must be using Chrome to install this extension.

to:

    You must be using a browser in the Chrome family to install this
    extension.