### PR TITLE
Redirect from old collection to new collection

### DIFF
--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -258,7 +258,8 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         response = self.client.get('/asset/most_recent/', {}, follow=True)
         self.assertEquals(response.status_code, 200)
 
-        url = '/asset/%s/' % asset1.id
+        url = '/course/%s/react/asset/%s/' % \
+            (self.sample_course.id, asset1.id)
         self.assertEquals(response.redirect_chain, [(url, 302)])
 
     def test_asset_delete(self):

--- a/mediathread/assetmgr/urls.py
+++ b/mediathread/assetmgr/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 from mediathread.assetmgr.views import (
     AssetWorkspaceView, AssetReferenceView, ManageExternalCollectionView,
     AssetEmbedView, AssetEmbedListView, ScalarExportView,
-    most_recent, annotation_create, annotation_create_global,
+    MostRecentView, annotation_create, annotation_create_global,
     annotation_save, annotation_delete, asset_delete, final_cut_pro_xml,
     AnnotationCopyView, ManageIngestView
 )
@@ -28,7 +28,7 @@ urlpatterns = [
          {}, 'asset-references'),
 
     # Goto the most recently created asset by user
-    path('most_recent/', most_recent, name='asset-most-recent'),
+    path('most_recent/', MostRecentView.as_view(), name='asset-most-recent'),
 
     path('<int:asset_id>/', AssetWorkspaceView.as_view(),
          {}, 'asset-view'),


### PR DESCRIPTION
If the user is attempting to access the non-ajax collection, asset or annotation views, send them over to the new view.

This also refactors the "most recent asset" view...which I think was used with the bookmarklet to navigate to the collection and show the last thing collected. @nikolas - is the extension still using this?