### PR TITLE
Update title spacing - MEDT-3707

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -4129,6 +4129,10 @@ ul.section-tabs>li>a.active {
     height: 480px;
 }
 
+.asset-detail h2.asset-detail-title {
+    padding: .5em 0 .25em 0;
+}
+
 .course-collection .card-title, .course-collection .card-text {
     white-space: nowrap;
     overflow: hidden;

--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -687,8 +687,8 @@ export default class AssetDetail extends React.Component {
 
         return (
             <div className="tab-content asset-detail">
-                <div className="row">
-                    <h2 className="col-md-7">
+                <div className="d-flex justify-content-between align-items-center flex-wrap">
+                    <h2 className="col-md-7 asset-detail-title">
                         {this.props.asset.title}
                     </h2>
 


### PR DESCRIPTION
I made the changes in the ticket - is this the intended effect, to have the tabs on the left now?

<img width="753" alt="Screen Shot 2020-08-18 at 11 58 51 AM" src="https://user-images.githubusercontent.com/59292/90536644-54842f80-e14a-11ea-8b6f-d73921670e17.png">
