### PR TITLE
Disable double-click to zoom when drawing - MEDT-3622

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -892,6 +892,7 @@ export default class AssetDetail extends React.Component {
 
         this.draw = new Draw({
             source: this.selectionSource,
+            stopClick: true,
             type: 'Polygon'
         });
 


### PR DESCRIPTION
This is done by adding `stopClick: true` to the openlayers Draw object:

https://github.com/openlayers/openlayers/issues/3610#issuecomment-677850828