### PR TITLE
Composition assignment: put back "create selection" in the collection

### DIFF
--- a/cypress/integration/4.quickedit/create.and.edit.selection.js
+++ b/cypress/integration/4.quickedit/create.and.edit.selection.js
@@ -63,5 +63,40 @@ describe('Instructor creates a selection', () => {
         cy.log('verify new selection is visible');
         cy.get('div.ajaxloader').should('not.be.visible');
         cy.get('button.btn-link').contains('Rename Selection');
+
+        cy.log('create a new selection');
+        cy.log('click the +/create button next to the asset');
+        cy.get('#record-2').find('.create-annotation')
+            .click({ force: true });
+
+        cy.log('verify the create form is visible');
+        cy.get('#annotation-current').should('exist');
+        cy.contains('Title').should('exist');
+        cy.contains('Tag').should('exist');
+        cy.contains('Notes').should('exist');
+        cy.get('[name="Cancel"]').should('exist');
+        cy.get('[name="Save"]').should('exist');
+        cy.get('input[name="annotation-title"]').type('Test Selection');
+        cy.get('#edit-annotation-form .select2-input')
+            .type('abc{enter}');
+        cy.get('#edit-annotation-form textarea[name="annotation-body"]')
+            .type('Here are my new notes');
+        cy.get('#annotation-body input[name="Save"]').click({ force: true });
+        cy.get('#annotation-current').should('not.be.visible');
+
+        cy.log('verify new selection is visible');
+        cy.get('div.ajaxloader').should('not.be.visible');
+        cy.get('.quick-edit').should('not.be.visible');
+        cy.get('.collection-materials').should('be.visible');
+        cy.get('button.btn-link').contains('Test Selection')
+            .should('be.visible');
+        cy.get('button.btn-link').contains('Test Selection').first().click();
+        cy.get('.collapse.show').within(() => {
+            cy.get('button.materialCitation').contains('Insert in Text');
+            cy.get('.metadata-value').contains('One, Instructor');
+
+            cy.log('edit the new selection is visible');
+            cy.get('button').contains('Edit').click();
+        });
     });
 });

--- a/mediathread/templates/clientside/collection_assets.mustache
+++ b/mediathread/templates/clientside/collection_assets.mustache
@@ -93,8 +93,13 @@
                     </a>
                 </h5>
                 <hr />
-                <h6>Selections</h6>
-
+                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                    <h6 class="m-0 mt-1">Selections</h6>
+                    <a class="btn btn-sm btn-link collection-choice create-annotation p-0" href="{{id}}"
+                        title="Create selection on this item" class="create_annotation_icon">   
+                        Create Selection
+                    </a>
+                </div>
                 <div id="record-{{id}}-metadata" class="record-metadata">
                 {{^annotation_count}}
                     <p class="text-muted">None</p>


### PR DESCRIPTION
The "create selection" action is now a quieter link to both offer the functionality and deemphasize it.