### PR TITLE
Composition collection: simplify pagination - MEDT-3757

### DIFF
--- a/mediathread/templates/clientside/collection.mustache
+++ b/mediathread/templates/clientside/collection.mustache
@@ -82,41 +82,6 @@
         </div>  {{! end filter widget }}
         <div class="clearfix"></div>
 
-        {{#paginator}}
-            {{#numPages}}
-                <ul class="pagination nav justify-content-end btn-sm" style="padding: 0px;">
-                    <li class="page-item {{^hasPrev}}disabled{{/hasPrev}}">
-                        <a class="page-link" data-page-number="1" href="#" aria-label="First">
-                            First
-                        </a>
-                    </li>
-                    <li class="page-item {{^hasPrev}}disabled{{/hasPrev}}">
-                        <a class="page-link"
-                            href="#" data-page-number="{{prevPage}}" aria-label="Previous">
-                            Previous
-                        </a>
-                    </li>
-                    <li class="page-item active">
-                        <div class="page-link">
-                            {{currentPage}} of {{numPages}}<span class="sr-only">(current)</span>
-                        </div>
-                    </li>
-                    <li class="page-item {{^hasNext}}disabled{{/hasNext}}">
-                        <a class="page-link "
-                            data-page-number="{{nextPage}}" href="#" aria-label="Next">
-                            Next
-                        </a>
-                    </li>
-                    <li class="page-item {{^hasNext}}disabled{{/hasNext}}">
-                        <a class="page-link"
-                            data-page-number="{{numPages}}" href="#" aria-label="Last">
-                            Last
-                        </a>
-                    </li>
-                </ul>
-            {{/numPages}}
-        {{/paginator}}
-
         <div class="collection-assets annotation-embedding">
             <div id="asset_table" class="asset-table"></div>
         </div>
@@ -125,11 +90,6 @@
             {{#numPages}}
                 <ul class="pagination nav justify-content-end btn-sm mt-2" style="padding: 0px;">
                     <li class="page-item {{^hasPrev}}disabled{{/hasPrev}}">
-                        <a class="page-link" data-page-number="1" href="#" aria-label="First">
-                            First
-                        </a>
-                    </li>
-                    <li class="page-item {{^hasPrev}}disabled{{/hasPrev}}">
                         <a class="page-link"
                             href="#" data-page-number="{{prevPage}}" aria-label="Previous">
                             Previous
@@ -144,12 +104,6 @@
                         <a class="page-link "
                             data-page-number="{{nextPage}}" href="#" aria-label="Next">
                             Next
-                        </a>
-                    </li>
-                    <li class="page-item {{^hasNext}}disabled{{/hasNext}}">
-                        <a class="page-link"
-                            data-page-number="{{numPages}}" href="#" aria-label="Last">
-                            Last
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
1. Remove the pagination at the top of the collection, keeping it at the bottom of the list.
2. Remove "First" and "Last"