### PR TITLE
List old discussions on the assignments page

### DIFF
--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -23,6 +23,7 @@ from mediathread.api import CourseResource
 from mediathread.api import UserResource
 from mediathread.assetmgr.api import AssetResource
 from mediathread.assetmgr.models import Asset
+from mediathread.discussions.utils import get_course_discussions
 from mediathread.discussions.views import threaded_comment_json
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
 from mediathread.main.course_details import allow_public_compositions, \
@@ -822,6 +823,7 @@ class AssignmentListView(ProjectListView):
         ctx = super().get_context_data(**kwargs)
         ctx['status'] = self.request.GET.get('status', 'all')
         ctx['title'] = self.request.GET.get('title', '')
+        ctx['discussions'] = get_course_discussions(self.request.course)
         return ctx
 
     def filter_by_status(self, qs):

--- a/mediathread/templates/projects/assignment_list.html
+++ b/mediathread/templates/projects/assignment_list.html
@@ -1,5 +1,5 @@
 {% extends "base_new.html" %}
-{% load coursetags static %}
+{% load coursetags static comments %}
 
 {% block title %}
 Assignments
@@ -100,6 +100,22 @@ Assignments
                     </div>
                 </div>
             </div>
+            {% endif %}
+
+            {% if discussions|length > 0 %}
+                <h3 class="mt-5">Past Discussions</h3>
+                <p><i>Discussion created prior to August 2020 were available outside the assignment context.</i></p>
+                <ul>
+                {% for disc in discussions %}
+                    <li>
+                        <a href="/discussion/{{disc.id}}/">
+                            {% firstof disc.title disc.content_object.title "Untitled" %}</a>
+                            {% get_comment_count for disc.content_object as comment_count%}
+                            ({{comment_count}})
+                        </a>
+                    </li>
+                {% endfor %}
+                </ul>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Discussions created before mid-August 2020 were available outside the assignment context. List these for reference underneath the assignments table.

<img width="673" alt="Screen Shot 2020-09-05 at 6 51 14 PM" src="https://user-images.githubusercontent.com/141369/92314676-00ca7080-efa9-11ea-8091-7fedb90853d9.png">
