### PR TITLE
Display the full image in the detail view - MEDT-3595

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -861,7 +861,6 @@ export default class AssetDetail extends React.Component {
         }
 
         if (this.type === 'image') {
-            const thumbnail = this.asset.getThumbnail();
             const img = this.asset.getImage();
 
             const extent = objectProportioned(img.width, img.height);

--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -882,7 +882,7 @@ export default class AssetDetail extends React.Component {
                 layers: [
                     new ImageLayer({
                         source: new Static({
-                            url: thumbnail,
+                            url: img.url,
                             projection: projection,
                             imageExtent: extent
                         })


### PR DESCRIPTION
This should resolve a bug where the image thumbnail was displayed in the detail view rather than the full image.