### PR TITLE
Restore Selection Assignment View Options

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -3352,11 +3352,6 @@ div#asset-view-details  a.edit-item {
     padding: 3px 8px 2px 4px;
 }
 
-div#asset-view-details .filter-selections {
-    margin: -8px 0 0 0;
-    padding: 3px 8px 2px 4px;
-}
-
 div#asset-header table {
     width: 100%;
 }

--- a/media/css/project.css
+++ b/media/css/project.css
@@ -416,16 +416,19 @@ form[name="sequence-assignment-edit"] input[type=radio] {
     display: none;
 }
 
-.selection-assignment .filter-selections {
-    display: none;
-}
-
 .selection-assignment .selected-item .gallery-item {
     margin-top: 30px;
     float: none;
 }
 
 .clipstrip-display {
+    display: none;
+}
+
+.selection-assignment .clipstrip-display {
+    display: block;
+}
+.selection-assignment #clipStripLayer_focus {
     display: none;
 }
 

--- a/media/js/app/assetmgr/asset.js
+++ b/media/js/app/assetmgr/asset.js
@@ -249,6 +249,7 @@
 
         ///Groupby('author')
         ///Groupby('tag')
+        ///Groupby('term')
         //  - get, group
         //  - replace/hide-show Layer, group-by color
         //  - decorate
@@ -306,6 +307,23 @@
                     } else {
                         //127 ensures that None is last
                         return [String.fromCharCode(127) + 'No Tags'];
+                    }
+                };
+                break;
+            case 'term':
+                this.layers[grouping].color_by = function(ann) {
+                    if (ann.vocabulary.length) {
+                        var terms = [];
+                        for (var i = 0; i < ann.vocabulary.length; i++) {
+                            var vterms = ann.vocabulary[i].terms;
+                            for (var j = 0; j < vterms.length; j++) {
+                                terms.push(vterms[j].display_name);
+                            }
+                        }
+                        return terms;
+                    } else {
+                        //127 ensures that None is last
+                        return [String.fromCharCode(127) + 'No Terms'];
                     }
                 };
                 break;

--- a/media/js/lib/sherdjs/src/video/annotators/clipstrip.js
+++ b/media/js/lib/sherdjs/src/video/annotators/clipstrip.js
@@ -35,6 +35,12 @@ if (!Sherd.Video.Annotators.ClipStrip) {
 
         Sherd.Video.Base.apply(this, arguments); //inherit off video.js - base.js
 
+        jQuery(window).resize(function() {
+            if (self.components.hasOwnProperty('timestrip')) {
+                self.microformat._resize();
+            }
+        });
+
         this.attachView = function (view) {
             this.targetview = view;
 
@@ -167,10 +173,16 @@ if (!Sherd.Video.Annotators.ClipStrip) {
         };
 
         this.microformat._resize = function () {
+            self.components.timestrip = self.targetview.media.timestrip();
+
+            jQuery('#clipStrip').css('width', self.components.timestrip.w + 'px');
+            jQuery('#clipStripTrack').css('width', self.components.timestrip.trackWidth + 'px');
+            jQuery('.clipStripLayer').css('width', self.components.timestrip.trackWidth + 'px');
+
             var left = self.microformat._timeToPixels(self.components.starttime, self.components.duration, self.components.timestrip.trackWidth);
-            
+
             var endtime = self.components.endtime > self.components.duration ? self.components.duration : self.components.endtime;
-            
+
             var right = self.microformat._timeToPixels(endtime, self.components.duration, self.components.timestrip.trackWidth);
             var width = right - left;
             if (width < 0) {
@@ -192,16 +204,16 @@ if (!Sherd.Video.Annotators.ClipStrip) {
                     for (var annotationName in layer._anns) {
                         if (layer._anns.hasOwnProperty(annotationName)) {
                             var annotation = layer._anns[annotationName];
-                            
+
                             endtime = annotation.endtime > self.components.duration ? self.components.duration : annotation.endtime;
-        
+
                             left = self.microformat._timeToPixels(annotation.starttime, self.components.duration, self.components.timestrip.trackWidth);
                             right = self.microformat._timeToPixels(endtime, self.components.duration, self.components.timestrip.trackWidth);
                             width = (right - left);
                             if (width < 0) {
                                 width = 0;
                             }
-        
+
                             jQuery("#" + annotation.htmlID).css("left", left);
                             jQuery("#" + annotation.htmlID).css("width", width);
                         }

--- a/media/js/lib/sherdjs/src/video/views/flowplayer.js
+++ b/media/js/lib/sherdjs/src/video/views/flowplayer.js
@@ -326,7 +326,7 @@ if (!Sherd.Video.Flowplayer && Sherd.Video.Base) {
             // The clipstrip is calibrated to the flowplayer scrubber
             // Visually, it looks a little "short", but trust, it tags along
             // with the circle shaped thumb properly.
-            var w = self.components.width;
+            var w = jQuery('#' + self.components.playerID).width();
             return {
                 w: w,
                 trackX: 2,

--- a/media/js/lib/sherdjs/src/video/views/vimeo.js
+++ b/media/js/lib/sherdjs/src/video/views/vimeo.js
@@ -301,7 +301,7 @@ if (!Sherd.Video.Vimeo) {
         };
 
         this.media.timestrip = function () {
-            var w = self.components.width;
+            var w = jQuery('#' + self.components.playerID).width();
             return {
                 w: w,
                 trackX: 96,

--- a/media/js/lib/sherdjs/src/video/views/youtube.js
+++ b/media/js/lib/sherdjs/src/video/views/youtube.js
@@ -409,7 +409,7 @@ if (!Sherd.Video.YouTube) {
         };
 
         this.media.timestrip = function () {
-            var w = document.getElementById(self.playerID).width;
+            var w = jQuery('#' + self.components.playerID).width();
             return {
                 w: w,
                 trackX: 3,

--- a/mediathread/templates/clientside/asset_view_details.mustache
+++ b/mediathread/templates/clientside/asset_view_details.mustache
@@ -17,22 +17,27 @@
 
     {{#asset-current}}
         <div class="btn-group float-right">
-            <button type="button" class="btn btn-default btn-sm dropdown-toggle filter-selections"
+            <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle filter-selections"
                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <img src="{{#staticUrl}}{{/staticUrl}}img/icons/meth_view.png" /> View <span class="caret"></span>
+                View Options <span class="caret"></span>
             </button>
             <div id="annotation-filter-menu" class="dropdown-menu dropdown-menu-right">
                 <form name="annotation-list-filter">
                     <div class="annotation-filter-groupby">
-                        <div><b>Group selections by</b></div>
+                        <div class="mb-1"><b>Group selections by</b></div>
                         <div class="radio">
-                            <label>
-                                <input type="radio" name="groupby" value="author" />author
+                            <label class="mb-0">
+                                <input type="radio" name="groupby" value="author" /> author
                             </label>
                         </div>
                         <div class="radio">
-                            <label>
-                                <input type="radio" name="groupby" value="tag" />tag
+                            <label class="mb-0">
+                                <input type="radio" name="groupby" value="tag" /> tag
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label class="mb-0">
+                                <input type="radio" name="groupby" value="term" /> term
                             </label>
                         </div>
                         <hr />

--- a/mediathread/templates/projects/selection_assignment_view.html
+++ b/mediathread/templates/projects/selection_assignment_view.html
@@ -191,7 +191,7 @@
                                   </div>
                                   <div class="modal-body">
                                     <form method="post" class="project-response-form"
-                                        action="{% url 'project-save' my_response.id %}">
+                                        action="{% url 'project-save' request.course.id my_response.id %}">
                                         {% csrf_token %}
                                         <div>Please review assignment instructions before submitting. Instructions may specify:</div>
                                         <ul class="pl-0">


### PR DESCRIPTION
* Show the GroupBy and Display All Selections that were hidden
* Add Group By Term
* Make the Clipstrip resize to the width of the player
* Fix various clipstrip bugs

(This is a short-term fix until we can get functionality into the new, reactive detail view)