### PR TITLE
Allow tags to contain spaces - MEDT-3767

### DIFF
--- a/media/js/src/assetDetail/CreateSelection.jsx
+++ b/media/js/src/assetDetail/CreateSelection.jsx
@@ -17,17 +17,13 @@ export default class CreateSelection extends SelectionForm {
         // components.
         const rawTags = this.tagsRef.current.state.value;
 
-        // Tags are handled as a space-separated CharField, while
+        // Tags are handled as a comma-separated CharField, while
         // Terms are handled with primary keys.
         let tags = '';
         if (rawTags) {
             rawTags.forEach(function(tag) {
-                tags += tag.value + ' ';
+                tags += tag.value + ',';
             });
-        }
-
-        if (tags.length) {
-            tags = tags.slice(0, -1);
         }
 
         let terms = null;

--- a/media/js/src/forms/EditSelectionForm.jsx
+++ b/media/js/src/forms/EditSelectionForm.jsx
@@ -18,17 +18,13 @@ export default class EditSelectionForm extends SelectionForm {
         // components.
         const rawTags = this.tagsRef.current.state.value;
 
-        // Tags are handled as a space-separated CharField, while
+        // Tags are handled as a comma-separated CharField, while
         // Terms are handled with primary keys.
         let tags = '';
         if (rawTags) {
             rawTags.forEach(function(tag) {
-                tags += tag.value + ' ';
+                tags += tag.value + ',';
             });
-        }
-
-        if (tags.length) {
-            tags = tags.slice(0, -1);
         }
 
         let terms = null;


### PR DESCRIPTION
My confusion here was due to some misleading documentation in
django-tagging:
https://django-tagging.readthedocs.io/en/develop/#field-types

This states that TagField is a space-separated CharField. In fact, it's
comma-separated:

    (Pdb) p note.tags
    'my tag,green,black'

Either this documentation is out of date, or Mediathread is doing
something special with tags.