### PR TITLE
Update sentry JS to current version, to fix loading

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -21,8 +21,8 @@
 
         {% if not debug %}
         <script
-            src="https://browser.sentry-cdn.com/5.9.1/bundle.min.js"
-            integrity="sha384-/x1aHz0nKRd6zVUazsV6CbQvjJvr6zQL2CHbQZf3yoLkezyEtZUpqUNnOLW9Nt3v"
+            src="https://browser.sentry-cdn.com/5.23.0/bundle.min.js"
+            integrity="sha384-5yYHk2XjpqhbWfLwJrxsdolnhl+HfgEnD1UhVzAs6Kd2fx+ZoD0wBFjd65mWgZOG"
             crossorigin="anonymous"></script>
         <script>
         Sentry.init({

--- a/mediathread/templates/base_new.html
+++ b/mediathread/templates/base_new.html
@@ -30,10 +30,9 @@ A new base.html without the course context overwritten in the template.
 
         {% if not debug %}
             <script
-                src="https://browser.sentry-cdn.com/5.9.1/bundle.min.js"
-                integrity="sha384-/x1aHz0nKRd6zVUazsV6CbQvjJvr6zQL2CHbQZf3yoLkezyEtZUpqUNnOLW9Nt3v"
+                src="https://browser.sentry-cdn.com/5.23.0/bundle.min.js"
+                integrity="sha384-5yYHk2XjpqhbWfLwJrxsdolnhl+HfgEnD1UhVzAs6Kd2fx+ZoD0wBFjd65mWgZOG"
                 crossorigin="anonymous"></script>
-            <script>
             Sentry.init({
                 dsn: 'https://a22770cb4ac744bbaf2b1ec76281e7ed@sentry.io/102468',
                 whitelistUrls: [/mediathread\.stage\.ctl\.columbia\.edu/]


### PR DESCRIPTION
Currently on production there's an error:

    Failed to find a valid digest in the 'integrity' attribute for resource
    'https://browser.sentry-cdn.com/5.9.1/bundle.min.js' with computed
    SHA-256 integrity '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='. The
    resource has been blocked.
    (index):37 Uncaught ReferenceError: Sentry is not defined
        at (index):37

This should fix that.