### PR TITLE
Sentry: add missing <script> tag

### DIFF
--- a/mediathread/templates/base_new.html
+++ b/mediathread/templates/base_new.html
@@ -33,6 +33,7 @@ A new base.html without the course context overwritten in the template.
                 src="https://browser.sentry-cdn.com/5.23.0/bundle.min.js"
                 integrity="sha384-5yYHk2XjpqhbWfLwJrxsdolnhl+HfgEnD1UhVzAs6Kd2fx+ZoD0wBFjd65mWgZOG"
                 crossorigin="anonymous"></script>
+            <script>
             Sentry.init({
                 dsn: 'https://a22770cb4ac744bbaf2b1ec76281e7ed@sentry.io/102468',
                 whitelistUrls: [/mediathread\.stage\.ctl\.columbia\.edu/]


### PR DESCRIPTION
This fixes a problem where the Sentry init code is displayed at the top of the page.