### PR TITLE
Revert the webpack 5.0 and webpack-cli updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "jest": "^26.0.1",
     "jsdom": "^16.0.1",
     "start-server-and-test": "^1.11.0",
-    "webpack": "^5.0.0",
-    "webpack-cli": "^4.0.0"
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.12"
   },
   "dependencies": {
     "get-youtube-id": "^1.0.1",


### PR DESCRIPTION
This upgrade broke the webpack dev flow. We'll need to take a look at how Nick handled the upgraded in Locus Tempus and make the same changes here.