### PR TITLE
Panopto Ingester: Strip spaces

### DIFF
--- a/mediathread/main/tasks.py
+++ b/mediathread/main/tasks.py
@@ -54,6 +54,7 @@ class PanoptoIngester(object):
         return imported
 
     def get_course(self, session, course_string):
+        course_string = course_string.strip()
         d = CanvasTemplate.to_dict(course_string)
         s = WindTemplate.to_string(d)
         try:

--- a/mediathread/main/tests/test_tasks.py
+++ b/mediathread/main/tests/test_tasks.py
@@ -149,7 +149,7 @@ class PanoptoIngesterTest(MediathreadTestMixin, TestCase):
 
     def test_get_course(self):
         session = {'Id': 1, 'Name': 'session1'}
-        course_string = 'SOCWT7100_099_2020_3'
+        course_string = ' SOCWT7100_099_2020_3'
         self.assertIsNone(self.ingester.get_course(session, course_string))
 
         msgs = [m.message for m in get_messages(self.request)]


### PR DESCRIPTION
Add some resilience to the metadata parsing code by stripping spaces.

Note: this was applied as a hot fix in the production environment.