### PR TITLE
Fix dev mode build process for webpack 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9546,7 +9546,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -13908,8 +13907,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cypress:ffopen": "cypress open --browser firefox",
     "cypress:ffhead": "cypress run --browser firefox",
     "cypress:test": "start-server-and-test 'make integrationserver' http-get://localhost:8000 cypress:ffhead",
-    "dev": "webpack -d --watch",
+    "dev": "webpack --mode development --watch",
     "eslint": "eslint media/js/src media/js/src/*.jsx media/js/src/**/*.jsx *.js",
     "build": "webpack"
   },


### PR DESCRIPTION
It looks like webpack changed the -d option. Use --mode development
explicitly, instead.