### PR TITLE
nav link active now back to blue with important tag

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -26,7 +26,7 @@ a, a.page-link {
 }
 
 .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {
-    color: #0056b3;
+    color: #0056b3 !important;
 }
 
 .page-item.active .page-link {


### PR DESCRIPTION
* Added !important to nav link active so that the active tab is always blue.