### PR TITLE
audio upload template was not showing up. This fixes it.

### DIFF
--- a/mediathread/templates/main/collection_add.html
+++ b/mediathread/templates/main/collection_add.html
@@ -89,6 +89,7 @@
                                                                    </select>
                                                                </div>
                                                            {% endif %}
+                                                           <input type="hidden" name="audio" value="mp4"></input>
                                                            <div class="col-auto my-1">
                                                                <button type="submit" class="btn btn-secondary upload_button video" value="mp4">Upload Audio</button>
                                                            </div>


### PR DESCRIPTION
In add to collection the audio option was leading the user to a video uploader instead of audio. This fixes that bug.