### PR TITLE
don't display the clipstrip div

### DIFF
--- a/mediathread/templates/assetmgr/asset_embed_view.html
+++ b/mediathread/templates/assetmgr/asset_embed_view.html
@@ -40,7 +40,7 @@
         <div class="asset-display">
             <img class="item-poster" src="{{thumb_url}}" alt_text="Item poster" />
         </div>
-        <div class="clipstrip-display"></div>
+        <div class="clipstrip-display" style="display: none"></div>
     </div>
 
     {% compress js %}


### PR DESCRIPTION
* I noticed a little bit of a stutter that could be the reason for issue MEDT-1447. Not displaying  the clipstrip div seems to make it more stable.