### PR TITLE
Specify @babel/runtime in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/ccnmtl/mediathread/issues"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.12.5",
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.9.6",


### PR DESCRIPTION
I'm seeing errors compiling locally. If not specified, the @babel/runtime version defaults to a lesser version that is incompatible with webpack 5.