### PR TITLE
Course vocabulary 

### DIFF
--- a/media/js/src/CollectionListView.jsx
+++ b/media/js/src/CollectionListView.jsx
@@ -82,7 +82,7 @@ export default class CollectionListView extends React.Component {
                 }
             },
             {
-                name: 'Terms',
+                name: 'Course Vocabulary',
                 selector: 'terms',
                 sortable: false,
                 wrap: true,

--- a/media/js/src/assetDetail/ViewItem.jsx
+++ b/media/js/src/assetDetail/ViewItem.jsx
@@ -109,7 +109,7 @@ export default class ViewItem extends React.Component {
         }
 
         let tags = 'There are no tags.';
-        let terms = 'There are no terms.';
+        let terms = 'There are no vocabulary terms.';
         if (this.props.asset && this.props.asset.annotations) {
             const tagsArray = getTags(this.props.asset.annotations);
             if (tagsArray.length > 0) {
@@ -142,7 +142,7 @@ export default class ViewItem extends React.Component {
 
                 <hr />
 
-                <h3>Terms</h3>
+                <h3>Course Vocabulary</h3>
                 <p>
                     {terms}
                 </p>

--- a/media/js/src/assetDetail/ViewSelections.jsx
+++ b/media/js/src/assetDetail/ViewSelections.jsx
@@ -227,12 +227,13 @@ export default class ViewSelections extends React.Component {
                 const terms = [];
                 if (s.vocabulary) {
                     s.vocabulary.forEach(function(vocab) {
-                        vocab.terms.forEach(function(term) {
+                        vocab.terms.forEach(function(term, idx) {
+                            const isNotLast = idx < vocab.terms.length - 1;
                             terms.push(
                                 <React.Fragment key={`termfragment-${reactKey}-${term.id}`}>
                                     <a href="#">
                                         {term.display_name}
-                                    </a>,&nbsp;
+                                    </a>{isNotLast && ', '}
                                 </React.Fragment>
                             );
                         });

--- a/media/js/src/assetDetail/ViewSelections.jsx
+++ b/media/js/src/assetDetail/ViewSelections.jsx
@@ -11,7 +11,8 @@ import find from 'lodash/find';
 
 import EditSelectionForm from '../forms/EditSelectionForm';
 import {
-    groupByAuthor, groupByTerm, groupByTag, formatTimecode, getDuration
+    groupByAuthor, groupByTerm, groupByTag, formatTimecode, getDuration,
+    capitalizeFirstLetter
 } from '../utils';
 
 export default class ViewSelections extends React.Component {
@@ -192,7 +193,7 @@ export default class ViewSelections extends React.Component {
                             s.vocabulary.forEach(function(vocab) {
                                 groupedSelections.push(
                                     <h5 key={'title-' + reactKey}>
-                                        {vocab.display_name}: {groupName}
+                                        {capitalizeFirstLetter(vocab.display_name)}: {groupName}
                                     </h5>);
                             });
                         } else {

--- a/media/js/src/assetDetail/ViewSelections.jsx
+++ b/media/js/src/assetDetail/ViewSelections.jsx
@@ -91,13 +91,14 @@ export default class ViewSelections extends React.Component {
 
                         {s.author.public_name.length > 0 && (
                             <p className="card-text">
-                                Author: {s.author.public_name}
+                                <strong>Author:</strong> {s.author.public_name}
                             </p>
                         )}
 
                         {this.props.type === 'video' && (
                             <>
                                 <p className="card-text">
+                                    <strong>Time code: </strong>
                                     {formatTimecode(s.range1)}
                                     {String.fromCharCode(160)}
                                     {String.fromCharCode(8212)}
@@ -105,20 +106,20 @@ export default class ViewSelections extends React.Component {
                                     {formatTimecode(s.range2)}
                                 </p>
                                 <p className="card-text">
-                                    Duration: <strong>{formatTimecode(getDuration(s.range1, s.range2))}</strong>
+                                    <strong>Duration:</strong> {formatTimecode(getDuration(s.range1, s.range2))}
                                 </p>
                             </>
                         )}
 
                         {tags.length > 0 && (
                             <p className="card-text">
-                                Tags: {tags}
+                                <strong>Tags:</strong> {tags}
                             </p>
                         )}
 
                         {terms.length > 0 && (
                             <p className="card-text">
-                                Terms: {terms}
+                                <strong>Course Vocabulary:</strong> {terms}
                             </p>
                         )}
 
@@ -186,6 +187,20 @@ export default class ViewSelections extends React.Component {
                             <h5 key={'title-' + reactKey}>
                                 {s.author.public_name}
                             </h5>);
+                    } else if (me.state.groupBy === 'term') {
+                        if(groupName != 'No Vocabulary'){
+                            s.vocabulary.forEach(function(vocab) {
+                                groupedSelections.push(
+                                    <h5 key={'title-' + reactKey}>
+                                        {vocab.display_name}: {groupName}
+                                    </h5>);
+                            });
+                        } else {
+                            groupedSelections.push(
+                                <h5 key={'title-' + reactKey}>
+                                    {groupName}
+                                </h5>);
+                        }
                     } else {
                         groupedSelections.push(
                             <h5 key={'title-' + reactKey}>
@@ -330,7 +345,7 @@ export default class ViewSelections extends React.Component {
                                     this.state.groupBy === 'term' ? 'active' : ''
                                 )}
                                 onClick={(e) => this.onSelectGrouping(e, 'term')}>
-                                Group by term
+                                Group by course vocabulary
                             </button>
                         )}
                     </div>

--- a/media/js/src/filters/AssetFilter.jsx
+++ b/media/js/src/filters/AssetFilter.jsx
@@ -216,8 +216,9 @@ export default class AssetFilter extends React.Component {
         const termsOptions = termsToReactSelect(this.props.allTerms);
 
         const termGroupLabel = function(data) {
+
             return (
-                <div className="font-weight-bold">
+                <div className="font-weight-bold h6">
                     <span>{data.label}</span>
                 </div>
             );

--- a/media/js/src/filters/AssetFilter.jsx
+++ b/media/js/src/filters/AssetFilter.jsx
@@ -218,7 +218,7 @@ export default class AssetFilter extends React.Component {
         const termGroupLabel = function(data) {
 
             return (
-                <div className="font-weight-bold h6">
+                <div className="font-weight-bold">
                     <span>{data.label}</span>
                 </div>
             );

--- a/media/js/src/filters/AssetFilter.jsx
+++ b/media/js/src/filters/AssetFilter.jsx
@@ -210,11 +210,12 @@ export default class AssetFilter extends React.Component {
     render() {
         const tagsOptions = tagsToReactSelect(this.props.allTags);
         const termsOptions = termsToReactSelect(this.props.allTerms);
+        console.log('terms option', termsOptions)
 
         const termGroupLabel = function(data) {
             return (
                 <div>
-                    <span>{data.label}</span>
+                    <strong>{data.label}</strong>
                 </div>
             );
         };
@@ -278,7 +279,7 @@ export default class AssetFilter extends React.Component {
 
                         {window.MediaThread && window.MediaThread.current_course_has_vocab && (
                             <div className="form-group col-md-2">
-                                <label htmlFor="react-select-4-input">Term</label>
+                                <label htmlFor="react-select-4-input">Course Vocabulary</label>
                                 <Select
                                     id="term-filter"
                                     menuPortalTarget={document.body}

--- a/media/js/src/filters/AssetFilter.jsx
+++ b/media/js/src/filters/AssetFilter.jsx
@@ -48,6 +48,10 @@ const reactSelectStyles = {
     input: (provided, state) => ({
         ...provided,
         height: '21px'
+    }),
+    option: (provided, state) => ({
+        ...provided,
+        paddingLeft: '20px'
     })
 };
 
@@ -210,12 +214,11 @@ export default class AssetFilter extends React.Component {
     render() {
         const tagsOptions = tagsToReactSelect(this.props.allTags);
         const termsOptions = termsToReactSelect(this.props.allTerms);
-        console.log('terms option', termsOptions)
 
         const termGroupLabel = function(data) {
             return (
-                <div>
-                    <strong>{data.label}</strong>
+                <div className="font-weight-bold">
+                    <span>{data.label}</span>
                 </div>
             );
         };

--- a/media/js/src/forms/SelectionForm.jsx
+++ b/media/js/src/forms/SelectionForm.jsx
@@ -33,6 +33,10 @@ const reactSelectStyles = {
     placeholder: (provided, state) => ({
         ...provided,
         top: '45%'
+    }),
+    option: (provided, state) => ({
+        ...provided,
+        paddingLeft: '20px'
     })
 };
 
@@ -123,6 +127,14 @@ export default class SelectionForm extends React.Component {
             selectedTerms = termsToReactSelectValues(
                 this.props.selection.vocabulary);
         }
+        const termGroupLabel = function(data) {
+
+            return (
+                <div className="font-weight-bold h6">
+                    <span>{data.label}</span>
+                </div>
+            );
+        };
 
         const hasVocab = this.props.terms && this.props.terms.length > 0;
 
@@ -160,7 +172,7 @@ export default class SelectionForm extends React.Component {
 
                 {hasVocab && (
                     <Form.Group>
-                        <label htmlFor="react-select-7-input">Terms</label>
+                        <label htmlFor="react-select-7-input">Course Vocabulary</label>
                         <Select
                             id="newSelectionTerms"
                             ref={this.termsRef}
@@ -170,6 +182,7 @@ export default class SelectionForm extends React.Component {
                             onChange={this.handleTermsChange}
                             isMulti
                             defaultValue={selectedTerms}
+                            formatGroupLabel={termGroupLabel}
                             options={termsOptions} />
                     </Form.Group>
                 )}

--- a/media/js/src/forms/SelectionForm.jsx
+++ b/media/js/src/forms/SelectionForm.jsx
@@ -172,7 +172,8 @@ export default class SelectionForm extends React.Component {
 
                 {hasVocab && (
                     <Form.Group>
-                        <label htmlFor="react-select-7-input">Course Vocabulary</label>
+                        <label htmlFor="react-select-7-input">
+                            Course Vocabulary</label>
                         <Select
                             id="newSelectionTerms"
                             ref={this.termsRef}

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -517,7 +517,7 @@ const groupByTerm = function(selections) {
             });
             if (!foundTerm) {
                 out.push({
-                    termName: 'No Terms',
+                    termName: 'No Vocabulary',
                     termId: 0,
                     selections: [s]
                 });
@@ -529,7 +529,7 @@ const groupByTerm = function(selections) {
 
     const sorted = sortBy(out, [
         function(group) {
-            // Sort the 'No Terms' group to the end.
+            // Sort the 'No Vocabulary' group to the end.
             if (group && group.termId === 0) {
                 return null;
             }
@@ -608,12 +608,20 @@ const termsToReactSelect = function(vocabs) {
             termSet.forEach(function(t) {
                 const data = t;
                 data.vocab_id = term.id;
-
-                termOptions.push({
-                    label: `${t.display_name} (${t.count})`,
-                    value: t.name,
-                    data: data
-                });
+                if(t.count > 0){
+                    termOptions.push({
+                        label: `${t.display_name} (${t.count})`,
+                        value: t.name,
+                        data: data
+                    });
+                }
+                else {
+                    termOptions.push({
+                        label: `${t.display_name}`,
+                        value: t.name,
+                        data: data
+                    });
+                }
             });
         }
 

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -578,7 +578,13 @@ const tagsToReactSelect = function(tags, isCreating=false) {
     }
 
     return tags.map(function(tag) {
-        let label = `${tag.name} (${tag.count})`;
+        let label = '';
+
+        if(tag.count > 0){
+            label = `${tag.name} (${tag.count})`;
+        } else {
+            label = `${tag.name}`;
+        }
         if (isCreating) {
             label = tag.name;
         }

--- a/mediathread/templates/clientside/collection.mustache
+++ b/mediathread/templates/clientside/collection.mustache
@@ -38,7 +38,7 @@
 
                <div class="col-md-5">
                     <div class="switcher-tool">
-                        <label for="switcher-terms">Terms</label><br />
+                        <label for="switcher-terms">Course Vocabulary</label><br />
                         <select class="vocabulary w-100"
                             data-placeholder="Select {{#lower}}{{display_name}}{{/lower}}"
                             multiple="multiple">


### PR DESCRIPTION
The following changes have been made:

*Change the labeling to "Course Vocabulary" above the dropdown for the collection and item detail view.
*Review the styling of the dropdown to make "concepts" more pronounced, and emphasize the hierarchical relationship for the collection and item detail view.
*Remove the (0). Only show counts if > 0 for terms and tags in the collection space.
*Change Group by term > Group by course vocabulary in the item detail space.
*When grouped by vocabulary, update the headers to Concept: Term.
*On the selection detail card change Term to Course Vocabulary and list terms as they are now.

*Polish collection metadata display
