### PR TITLE
Student assignment list view: Fix inconsistent response filter

### DIFF
--- a/mediathread/projects/templatetags/user_projects.py
+++ b/mediathread/projects/templatetags/user_projects.py
@@ -104,5 +104,5 @@ def date_format_change(date):
 
 
 @register.simple_tag
-def show_discussion_response(status, comments):
-    return status != 'no-response' or comments[0] == 0
+def show_discussion_response(status, comment_count):
+    return status != 'no-response' or comment_count == 0

--- a/mediathread/projects/templatetags/user_projects.py
+++ b/mediathread/projects/templatetags/user_projects.py
@@ -101,3 +101,8 @@ def date_format_change(date):
     newFormat = ''.join(newDate.split())
 
     return re.sub(r'(?<=[,])(?=[^\s])', r' ', newFormat)
+
+
+@register.simple_tag
+def show_discussion_response(status, comments):
+    return status != 'no-response' or comments[0] == 0

--- a/mediathread/templates/projects/assignment_table_student.html
+++ b/mediathread/templates/projects/assignment_table_student.html
@@ -38,6 +38,8 @@
         {% for object in object_list %}
             {% if object.is_discussion_assignment %}
                 {% comment_count object request.user as comments %}
+                {% show_discussion_response status comments as show_response %}
+                {% if show_response %}
                  <tr>
                     <td>
                         {% if object.due_date %}
@@ -94,6 +96,7 @@
                     <td>
                     </td>
                 </tr>
+                {% endif %}
             {% else %}
                 {% my_assignment_responses object request.user as responses %}
 

--- a/mediathread/templates/projects/assignment_table_student.html
+++ b/mediathread/templates/projects/assignment_table_student.html
@@ -38,7 +38,7 @@
         {% for object in object_list %}
             {% if object.is_discussion_assignment %}
                 {% comment_count object request.user as comments %}
-                {% show_discussion_response status comments as show_response %}
+                {% show_discussion_response status comments.0 as show_response %}
                 {% if show_response %}
                  <tr>
                     <td>


### PR DESCRIPTION
A discussion assignment "response" is modeled quite differently than a composition, sequence or selection response. The simple filter query being completed server side for "no response yet", doesn't work for discussion assignment. To work around this, implement a simple client-side filter that checks for status and comment count.