### PR TITLE
Shows default image when no thumbnail is available

### DIFF
--- a/media/js/src/Asset.js
+++ b/media/js/src/Asset.js
@@ -59,6 +59,9 @@ export default class Asset {
         if (!this.asset.sources.thumb){
             this.asset.sources.thumb = mediaPrefix + 'img/thumb_image.png';
         }
+        if(this.asset.sources.image.url === 'source url'){
+            this.asset.sources.image.url = mediaPrefix + 'img/thumb_image.png';
+        }
         return this.asset.sources.image ||
             this.asset.sources.thumb;
     }


### PR DESCRIPTION
* The default image thumbnail sometimes wouldn't show up and would cause an error. This makes sure the url is updated to the default image thumbnail in the case where a thumbnail cannot be produced.