### PR TITLE
github: test on node 14.x as well

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
     services:
       postgres:
         image: postgres:10


### PR DESCRIPTION
This is the current LTS release of node, we're just not using it on production yet. https://nodejs.org/en/