### PR TITLE
Remove node 12 testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     services:
       postgres:
         image: postgres:10


### PR DESCRIPTION
As cypress tests are unstable, I think it will help to only test on a single node version. Node 14 is the current LTS version, so let's use that.