### PR TITLE
Add pdf type to sherdjs config

### DIFF
--- a/media/js/lib/sherdjs/src/configs/djangosherd.js
+++ b/media/js/lib/sherdjs/src/configs/djangosherd.js
@@ -63,6 +63,8 @@ function djangosherd_adaptAsset(asset) {
     } else if ((asset.image_fpx || asset.image_fpxid) && asset.fsiviewer) {
         asset.type = 'fsiviewer';
         asset.thumbable = true;
+    } else if (asset.pdf) {
+        asset.type = 'pdf';        
     } else if (asset.archive) {
         asset.type = "NONE";
     }


### PR DESCRIPTION
This should allow for the PDF type to be set appropriately, but I'm running into some problems testing this as Juxtapose is half broken at the moment.