### PR TITLE
Hide unnecessary pdf.js tools - MEDT-3947

### DIFF
--- a/mediathread/templates/assetmgr/pdfjs_viewer.html
+++ b/mediathread/templates/assetmgr/pdfjs_viewer.html
@@ -71,13 +71,13 @@ window.PDFViewerApplication.baseUrl = window.ASSET_URL;
               <button id="viewThumbnail" class="toolbarButton toggled" title="Show Thumbnails" tabindex="2" data-l10n-id="thumbs">
                  <span data-l10n-id="thumbs_label">Thumbnails</span>
               </button>
-              <button id="viewOutline" class="toolbarButton" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3" data-l10n-id="document_outline">
+              <button style="display: none;" id="viewOutline" class="toolbarButton" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3" data-l10n-id="document_outline">
                  <span data-l10n-id="document_outline_label">Document Outline</span>
               </button>
-              <button id="viewAttachments" class="toolbarButton" title="Show Attachments" tabindex="4" data-l10n-id="attachments">
+              <button style="display: none;" id="viewAttachments" class="toolbarButton" title="Show Attachments" tabindex="4" data-l10n-id="attachments">
                  <span data-l10n-id="attachments_label">Attachments</span>
               </button>
-              <button id="viewLayers" class="toolbarButton" title="Show Layers (double-click to reset all layers to the default state)" tabindex="5" data-l10n-id="layers">
+              <button style="display: none;" id="viewLayers" class="toolbarButton" title="Show Layers (double-click to reset all layers to the default state)" tabindex="5" data-l10n-id="layers">
                  <span data-l10n-id="layers_label">Layers</span>
               </button>
             </div>
@@ -140,7 +140,7 @@ window.PDFViewerApplication.baseUrl = window.ASSET_URL;
 
         <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
           <div id="secondaryToolbarButtonContainer">
-            <button id="secondaryPresentationMode" class="secondaryToolbarButton presentationMode visibleLargeView" title="Switch to Presentation Mode" tabindex="51" data-l10n-id="presentation_mode">
+            <button style="display: none;" id="secondaryPresentationMode" class="secondaryToolbarButton presentationMode visibleLargeView" title="Switch to Presentation Mode" tabindex="51" data-l10n-id="presentation_mode">
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
@@ -242,7 +242,7 @@ window.PDFViewerApplication.baseUrl = window.ASSET_URL;
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">
-                <button id="presentationMode" class="toolbarButton presentationMode hiddenLargeView" title="Switch to Presentation Mode" tabindex="31" data-l10n-id="presentation_mode">
+                <button style="display: none;" id="presentationMode" class="toolbarButton presentationMode hiddenLargeView" title="Switch to Presentation Mode" tabindex="31" data-l10n-id="presentation_mode">
                   <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
                 </button>
 


### PR DESCRIPTION
I'm hiding these with CSS instead of removing the DOM elements - because
removing the dom elements causes JS errors with viewer.js. These
elements are still expected to be present for the viewer.