### PR TITLE
Disable file_overwrite for private files

### DIFF
--- a/mediathread/assetmgr/custom_storage.py
+++ b/mediathread/assetmgr/custom_storage.py
@@ -5,6 +5,7 @@ from storages.backends.s3boto3 import S3Boto3Storage
 class S3PrivateStorage(S3Boto3Storage):
     default_acl = 'private'
     location = 'private'
+    file_overwrite = False
 
     def __init__(self):
         super(S3PrivateStorage, self).__init__()


### PR DESCRIPTION
This will cause a file with a duplicate name to have characters added to
it automatically, to not overwrite the old one.

* https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html