### PR TITLE
Use querystring_auth = True and clear object parameters for custom storage

### DIFF
--- a/mediathread/assetmgr/custom_storage.py
+++ b/mediathread/assetmgr/custom_storage.py
@@ -7,7 +7,7 @@ class S3PrivateStorage(S3Boto3Storage):
     location = 'private'
     file_overwrite = False
     querystring_auth = True
-    
+
     # Don't set an ACL - use the bucket settings.
     object_parameters = {}
 

--- a/mediathread/assetmgr/custom_storage.py
+++ b/mediathread/assetmgr/custom_storage.py
@@ -7,6 +7,9 @@ class S3PrivateStorage(S3Boto3Storage):
     location = 'private'
     file_overwrite = False
     querystring_auth = True
+    
+    # Don't set an ACL - use the bucket settings.
+    object_parameters = {}
 
     def __init__(self):
         super(S3PrivateStorage, self).__init__()

--- a/mediathread/assetmgr/custom_storage.py
+++ b/mediathread/assetmgr/custom_storage.py
@@ -6,6 +6,7 @@ class S3PrivateStorage(S3Boto3Storage):
     default_acl = 'private'
     location = 'private'
     file_overwrite = False
+    querystring_auth = True
 
     def __init__(self):
         super(S3PrivateStorage, self).__init__()


### PR DESCRIPTION
querystring_auth is set to False in ccnmtlsettings for our public assets. We need this to be True for private assets.

Also, don't upload items with the `public-read` ACL.