### PR TITLE
Fix pdf annotation positioning on collection - METH-3910

### DIFF
--- a/media/js/pdf/utils.js
+++ b/media/js/pdf/utils.js
@@ -23,10 +23,10 @@
  * Canvas or SVG expects:: top-left point x/y, then width/height.
  */
 const convertPointsToXYWH = function(x1, y1, x2, y2, scale=1) {
-    x1 = x1 * scale;
-    y1 = y1 * scale;
-    x2 = x2 * scale;
-    y2 = y2 * scale;
+    x1 *= scale;
+    y1 *= scale;
+    x2 *= scale;
+    y2 *= scale;
 
     return [
         Math.min(x1, x2), Math.min(y1, y2),


### PR DESCRIPTION
* Scroll to correct page number when flipping through annotations
* Fix annotation position as window is resized.
    
There are more issues I've seen with certain a more complex PDF I'm
testing with - a 300 page book where some of the pages are different
aspect ratios. I'll be handling those bugs separately