### PR TITLE
Fix page count error on asset refresh

### DIFF
--- a/media/js/src/CollectionTab.jsx
+++ b/media/js/src/CollectionTab.jsx
@@ -183,9 +183,7 @@ export default class CollectionTab extends React.Component {
                     d.active_tags, d.active_vocabulary
                 );
 
-                if (me.filterRef && me.filterRef.current) {
-                    me.filterRef.current.updatePageCount(d.asset_count);
-                }
+                me.updatePageCount(d.asset_count);
             }, function(e) {
                 console.error('asset get error!', e);
             });


### PR DESCRIPTION
The updatePageCount() method should be called on the class instance, not
the dom element.