### PR TITLE
Add panel fetch error if panel load ajax call fails

### DIFF
--- a/media/js/app/panel.js
+++ b/media/js/app/panel.js
@@ -52,6 +52,9 @@
                     ).then(function() {
                         self.loadContent();
                     });
+                },
+                error: function(e) {
+                    console.error('Error fetching panel data:', e);
                 }
             });
         };


### PR DESCRIPTION
I just worked through a bug where it's possible for the course to not be
set when loading the project workspace. You can work around this bug by
going to course select, selecting your course, and going back to the
project view.

I haven't resolved the bug yet, but adding an error here will help with
debugging, as it was pretty confusing to see what was going on with no
errors and a blank page.