### PR TITLE
Use django's require_GET/POST decorators instead of djangohelpers

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -24,9 +24,9 @@ from django.utils.decorators import method_decorator
 from django.utils.encoding import smart_bytes
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import DetailView
 from django.views.generic.base import View, TemplateView
-from djangohelpers.lib import allow_http
 import hmac
 import json
 from mediathread.api import UserResource, TagResource
@@ -436,7 +436,7 @@ class AssetUpdateView(View):
 
 
 @login_required
-@allow_http("GET", "POST")
+@require_http_methods(["GET", "POST"])
 @ajax_required
 def asset_delete(request, asset_id):
     in_course_or_404(request.user.username, request.course)
@@ -453,7 +453,7 @@ def asset_delete(request, asset_id):
 
 
 @login_required
-@allow_http("POST")
+@require_POST
 def annotation_create(request, asset_id):
     """
     delegate to djangosherd view and redirect back to asset workspace
@@ -486,7 +486,7 @@ def annotation_create(request, asset_id):
 
 
 @login_required
-@allow_http("POST")
+@require_POST
 @ajax_required
 def annotation_create_global(request, asset_id):
     asset = get_object_or_404(Asset, pk=asset_id, course=request.course)
@@ -504,7 +504,7 @@ def annotation_create_global(request, asset_id):
 
 
 @login_required
-@allow_http("POST")
+@require_POST
 def annotation_save(request, asset_id, annot_id):
     try:
         # Verify annotation exists
@@ -527,7 +527,7 @@ def annotation_save(request, asset_id, annot_id):
 
 
 @login_required
-@allow_http("POST")
+@require_POST
 def annotation_delete(request, asset_id, annot_id):
     try:
         # Verify annotation exists

--- a/mediathread/discussions/views.py
+++ b/mediathread/discussions/views.py
@@ -10,10 +10,11 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.encoding import smart_text
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
 from django.views.generic.base import View
 import django_comments
 from django_comments.models import COMMENT_MAX_LENGTH
-from djangohelpers.lib import rendered_with, allow_http
+from djangohelpers.lib import rendered_with
 import json
 from mediathread.api import UserResource
 from mediathread.assetmgr.api import AssetResource
@@ -210,7 +211,7 @@ class DiscussionView(LoggedInCourseMixin, View):
                                 content_type='application/json')
 
 
-@allow_http("POST")
+@require_POST
 @login_required
 @rendered_with('comments/posted.html')
 def comment_save(request, comment_id, next_url=None):

--- a/mediathread/djangosherd/views.py
+++ b/mediathread/djangosherd/views.py
@@ -4,8 +4,8 @@ from json import JSONDecodeError
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseForbidden, \
     HttpResponseRedirect
+from django.views.decorators.http import require_POST
 from django.shortcuts import get_object_or_404
-from djangohelpers.lib import allow_http
 
 from mediathread.djangosherd.models import Asset, SherdNote, NULL_FIELDS
 from mediathread.projects.models import ProjectNote, Project
@@ -25,7 +25,7 @@ def is_clipping(data):
 
 
 @login_required
-@allow_http("POST")
+@require_POST
 def create_annotation(request):
     asset = get_object_or_404(Asset,
                               pk=request.POST['annotation-context_pk'])

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -25,11 +25,11 @@ from django.utils.encoding import smart_bytes, smart_text
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView, View
 from django.views.generic.edit import FormView, UpdateView
 from django.views.generic.list import ListView
-from djangohelpers.lib import allow_http
 import hmac
 import json
 from lti_auth.models import LTICourseContext
@@ -190,7 +190,7 @@ class CourseManageSourcesView(LoggedInFacultyMixin, TemplateView):
             reverse('course-manage-sources', args=[request.course.pk]))
 
 
-@allow_http("POST")
+@require_POST
 @ajax_required
 def set_user_setting(request, user_name):
     user = get_object_or_404(User, username=user_name)

--- a/mediathread/taxonomy/views.py
+++ b/mediathread/taxonomy/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
-from djangohelpers.lib import allow_http, rendered_with
+from django.views.decorators.http import require_GET
+from djangohelpers.lib import rendered_with
 from mediathread.mixins import attach_course_request, faculty_only
 from mediathread.taxonomy.models import VocabularyForm, Vocabulary, TermForm, \
     Term, TermRelationship
@@ -7,7 +8,7 @@ from mediathread.taxonomy.models import VocabularyForm, Vocabulary, TermForm, \
 
 @login_required
 @attach_course_request
-@allow_http("GET")
+@require_GET
 @rendered_with('taxonomy/taxonomy.html')
 @faculty_only
 def taxonomy_workspace(request):


### PR DESCRIPTION
djangohelpers is our custom library that may not be completely up to
date with Django's stuff. This has the potential to cause strange
problems, which may be the cause of the missing Response object messing
up some of our error logging in Sentry ticket MEDIATHREAD-87.

The 'NoneType object has no attribute status_code' error is actually
getting triggered from at least two different scenarios:
Annotation creation and also LTI connection (`/course/lti/create/`).

We can just use Django's decorators in place of allow_http().

https://docs.djangoproject.com/en/3.2/topics/http/decorators/#allowed-http-methods