### PR TITLE
Restrict PDFViewerDetailView permissions - METH-404

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -1334,6 +1334,20 @@ class PDFViewerDetailView(LoggedInCourseMixin, DetailView):
     template_name = 'assetmgr/pdfjs_viewer.html'
     model = Asset
 
+    def dispatch(self, request, *args, **kwargs):
+        r = super().dispatch(request, *args, **kwargs)
+
+        if request.user.is_superuser or \
+           request.course.is_faculty(request.user):
+            return r
+
+        if not course_details.all_items_are_visible(request.course) and \
+           not request.course.is_faculty(self.object.author) and \
+           self.object.author != request.user:
+            return HttpResponseForbidden('You can\'t view this asset.')
+
+        return r
+
 
 class S3SignView(SignS3View):
     private = True


### PR DESCRIPTION
The PDFViewerDetailView is the iframe that displays the PDF Asset, not
the SherdNotes, so it didn't really make sense to add in the
RestrictedMaterialsMixin which deals with collections of assets and
their annotations.