### PR TITLE
Disable JS compression

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -295,7 +295,6 @@
         })();
     </script>
 
-    {% compress js %}
         <script type="text/javascript" src='{% static "js/lib/json2.js" %}'></script>
         <script type="text/javascript" src='{% static "js/app/util.js" %}'></script>
         <script type="text/javascript" src='{% static "js/app/ajaxDelete.js" %}'></script>
@@ -355,7 +354,6 @@
         </script>
 
         {% block js %}{% endblock %}
-    {% endcompress %}
 
     {% if not debug %}
         <script>

--- a/mediathread/templates/base_new.html
+++ b/mediathread/templates/base_new.html
@@ -195,7 +195,6 @@ A new base.html without the course context overwritten in the template.
             })();
             </script>
 
-            {% compress js %}
             <script src='{% static "js/lib/json2.js" %}'></script>
             <script src='{% static "js/app/util.js" %}'></script>
             <script src='{% static "js/app/ajaxDelete.js" %}'></script>
@@ -250,7 +249,6 @@ A new base.html without the course context overwritten in the template.
             </script>
 
             {% block js %}{% endblock %}
-    {% endcompress %}
 
     {% if not debug %}
         <script>


### PR DESCRIPTION
The JS compressor creates failing code when some files are modules and
others aren't.