### PR TITLE
Hide pdf.js annotation layer

### DIFF
--- a/media/css/mediathread_new.css
+++ b/media/css/mediathread_new.css
@@ -4127,6 +4127,10 @@ ul.section-tabs>li>a.active {
     height: 100%;
 }
 
+.react-pdf-page-container .annotationLayer {
+    display: none;
+}
+
 .sherd-pdfjs-view {
     position: relative;
     text-align: left;


### PR DESCRIPTION
This element is unused for our purposes, and is actually the source of
the "tall item" bug in the collection with certain PDFs.