### PR TITLE
Update expiration time for private assets to 8 hours.

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -1351,7 +1351,7 @@ class S3SignView(SignS3View):
     private = True
     root = 'private/'
     acl = None
-    expiration_time = 3600
+    expiration_time = 3600 * 8  # 8 hours
     max_file_size = 10000000  # 10mb
 
     def get_bucket(self):


### PR DESCRIPTION
There are cases in the composition assignment where the items are loaded
dynamically, so if you leave a page open for a long time it's possible
to fail the asset fetch due to expired URLs. I'm increasing this limit
to 8 hours to reduce those scenarios.