### PR TITLE
Fix corner case in adding an external collection

### DIFF
--- a/mediathread/assetmgr/tests/test_views.py
+++ b/mediathread/assetmgr/tests/test_views.py
@@ -184,6 +184,22 @@ class AssetViewTest(MediathreadTestMixin, TestCase):
         ExternalCollection.objects.get(course=self.sample_course,
                                        title='YouTube')
 
+    def test_manage_external_collection_add_custom_corner_case(self):
+        ExternalCollectionFactory(course=self.sample_course, title='YouTube')
+        data = {
+            'title': 'YouTube',
+            'url': 'https://www.youtube.com/',
+            'thumb_url': '/site_media/img/thumbs/youtube.png',
+            'description': 'https://www.youtube.com/'}
+
+        self.client.login(username=self.instructor_one.username,
+                          password='test')
+        self.switch_course(self.client, self.sample_course)
+        self.client.post('/asset/archive/', data)
+
+        ExternalCollection.objects.get(course=self.sample_course,
+                                       title='YouTube')
+
     def test_manage_external_collection_add_suggested(self):
         suggested = SuggestedExternalCollectionFactory()
         data = {'suggested_id': suggested.id}

--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -92,12 +92,12 @@ class ManageExternalCollectionView(
             exc.save()
             msg = '%s has been enabled for your class.' % exc.title
         else:
-            exc = ExternalCollection()
-            exc.title = request.POST.get('title')
+            exc, created = ExternalCollection.objects.get_or_create(
+                title=request.POST.get('title'),
+                course=request.course)
             exc.url = request.POST.get('url')
             exc.thumb_url = request.POST.get('thumb')
             exc.description = request.POST.get('description')
-            exc.course = request.course
             exc.uploader = request.POST.get('uploader', False)
             exc.save()
 


### PR DESCRIPTION
According to Sentry, it is possible for a user to add an external collection that already exists. I'm unable to reproduce this on the site, but was able to add a test that recreated the described condition then put in some guard code.