### PR TITLE
Downgrade django-celery-results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -140,7 +140,7 @@ amqp==2.6.1
 amqplib==1.0.2
 kombu==4.6.11 # pyup: <5.0.0
 celery==4.4.7 # pyup: <5.0.0
-django-celery-results==2.2.0
+django-celery-results==1.2.1
 # memcached
 pylibmc==1.6.1; sys_platform == 'linux'
 requests-file==1.5.1


### PR DESCRIPTION
The 2.0 version requires celery 5 or above.