### PR TITLE
:arrow_up: django-celery-results 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -140,7 +140,7 @@ amqp==2.6.1
 amqplib==1.0.2
 kombu==4.6.11 # pyup: <5.0.0
 celery==4.4.7 # pyup: <5.0.0
-django-celery-results==2.0.0
+django-celery-results<2.1.0
 # memcached
 pylibmc==1.6.1; sys_platform == 'linux'
 requests-file==1.5.1


### PR DESCRIPTION
Okay, more research here. The version beginning 2.1.0 version requires celery 5 as stated in the pipdeptree output. Upgrading to 2.0.0 to ensure we're not using the insecure versions < 2.