### PR TITLE
PDF annotation improvements in sherd.js

### DIFF
--- a/media/js/app/assetmgr/collection.js
+++ b/media/js/app/assetmgr/collection.js
@@ -477,6 +477,9 @@ CollectionList.prototype.createAssetThumbs = function(assets) {
             case 'fsiviewer':
                 view = new Sherd.Image.FSIViewer();
                 break;
+            case 'pdf':
+                view = new Sherd.Pdf.PdfJS();
+                break;
             }
             djangosherd.thumbs.push(view);
 
@@ -701,7 +704,7 @@ CollectionList.prototype.assetPostUpdate = function($elt, the_records) {
             const loadingTask = pdfjsLib.getDocument(asset.pdf);
             loadingTask.promise.then(function(pdf) {
                 pdf.getPage(1).then(function(page) {
-                    renderPage(page, canvasEl, 192);
+                    renderPage(page, canvasEl, null, 192);
                 });
             });
         }

--- a/media/js/lib/sherdjs/src/pdf/views/pdf.js
+++ b/media/js/lib/sherdjs/src/pdf/views/pdf.js
@@ -156,8 +156,11 @@ const PdfJS = function() {
         self.pdfLoadingTask.promise.then(function(pdf) {
             pdf.getPage(pageNumber).then(function(page) {
                 window.myPage = page;
-                const [renderTask, scale] =
-                      renderPage(page, canvasEl, presentation.height());
+                const [renderTask, scale, offsetX, offsetY] = renderPage(
+                    page, canvasEl,
+                    presentation.width(), presentation.height(),
+                    annotation
+                );
 
                 const selector = self.wrapperID ?
                     '#' + self.wrapperID : '.sherd-pdfjs-view';
@@ -174,7 +177,7 @@ const PdfJS = function() {
                 );
 
                 self.svgDraw.rect(width, height)
-                    .move(x, y)
+                    .move(x - offsetX, y - offsetY)
                     .stroke({color: '#22f', width: 2})
                     .fill('none');
             });


### PR DESCRIPTION
* Constrain pdf view on width as well as height.
* Add an annotation-aware mode for renderPage(). Currently this reads
  the annotation geometry and does some scaling based on that, putting
  the annotation at roughly the top-left portion of the view. Next steps
  here are to perfect this and center it.