### PR TITLE
Only populate timecode in API for video type

### DIFF
--- a/mediathread/djangosherd/api.py
+++ b/mediathread/djangosherd/api.py
@@ -60,9 +60,12 @@ class SherdNoteResource(ModelResource):
                 'body': bundle.obj.body.strip() if bundle.obj.body else '',
                 'primary_type': bundle.obj.asset.primary.label,
                 'modified': modified,
-                'timecode': bundle.obj.range_as_timecode(),
                 'title': bundle.obj.title
             }
+
+            if bundle.obj.asset.media_type() == 'video':
+                bundle.data['metadata']['timecode'] = \
+                    bundle.obj.range_as_timecode()
 
             editable = (bundle.request.user.id ==
                         getattr(bundle.obj, 'author_id', -1))


### PR DESCRIPTION
We already have a similar check in `assetmgr/views.py`, line 1043.
This fixes the timecode display issue in the mini collection.

It turns out the global annotation changes weren't actually necessary
for this, but I'm still happy I did that as that will make other work
more straightforward.