### PR TITLE
Fix bug where tags and terms are not saving

### DIFF
--- a/media/js/src/assetDetail/CreateSelection.jsx
+++ b/media/js/src/assetDetail/CreateSelection.jsx
@@ -15,7 +15,7 @@ export default class CreateSelection extends SelectionForm {
     onCreateSelection(e) {
         // Get the tags and terms values from the react-select
         // components.
-        const rawTags = this.tagsRef.current.state.value;
+        const rawTags = this.tagsRef.current.state.selectValue;
 
         // Tags are handled as a comma-separated CharField, while
         // Terms are handled with primary keys.
@@ -28,7 +28,7 @@ export default class CreateSelection extends SelectionForm {
 
         let terms = null;
         if (this.termsRef && this.termsRef.current) {
-            const rawTerms = this.termsRef.current.state.value;
+            const rawTerms = this.termsRef.current.state.selectValue;
 
             terms = [];
             if (rawTerms) {

--- a/media/js/src/forms/EditSelectionForm.jsx
+++ b/media/js/src/forms/EditSelectionForm.jsx
@@ -16,7 +16,7 @@ export default class EditSelectionForm extends SelectionForm {
     onSaveSelection(e) {
         // Get the tags and terms values from the react-select
         // components.
-        const rawTags = this.tagsRef.current.state.value;
+        const rawTags = this.tagsRef.current.state.selectValue;
 
         // Tags are handled as a comma-separated CharField, while
         // Terms are handled with primary keys.
@@ -29,7 +29,7 @@ export default class EditSelectionForm extends SelectionForm {
 
         let terms = null;
         if (this.termsRef && this.termsRef.current) {
-            const rawTerms = this.termsRef.current.state.value;
+            const rawTerms = this.termsRef.current.state.selectValue;
 
             terms = [];
             if (rawTerms) {


### PR DESCRIPTION
The `.value` reference no longer appears to be valid. Replacing with `.selectValue`.