### PR TITLE
Fix bug where PDF view wasn't visible in the mini-collection

### DIFF
--- a/media/js/app/assetmgr/collection.js
+++ b/media/js/app/assetmgr/collection.js
@@ -695,6 +695,7 @@ CollectionList.prototype.assetPostUpdate = function($elt, the_records) {
             const containerEl = document.getElementById(
                 'pdf-container-' + asset.id);
             if (!containerEl) {
+                console.error('collection error: No pdf DOM element found!');
                 return;
             }
 

--- a/media/js/lib/sherdjs/src/pdf/views/pdf.js
+++ b/media/js/lib/sherdjs/src/pdf/views/pdf.js
@@ -170,7 +170,7 @@ const PdfJS = function() {
                 );
 
                 const selector = self.wrapperID ?
-                    '#' + self.wrapperID : '.sherd-pdfjs-view';
+                      '#' + self.wrapperID : '.sherd-pdfjs-view';
 
                 if (annotation) {
                     // Append <svg> element next to the <canvas>

--- a/media/js/pdf/utils.js
+++ b/media/js/pdf/utils.js
@@ -51,7 +51,8 @@ const renderPage = function(page, canvas, width, height, annotation=null) {
     // canvas container's width and use that to constrain the PDF
     // view.
     if (!width || typeof width !== 'number') {
-        width = jQuery(canvas).closest('.sherd-pdfjs-view').width();
+        width = jQuery(canvas).closest(
+            '.sherd-pdfjs-view,.pdf-container').width();
     }
 
     // Get unmodified viewport for reference


### PR DESCRIPTION
The annotation and main asset views have different selectors here, and
the width for the main annotation was gettings set to 0.