### PR TITLE
Adjust python compatibility in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ FORUM: https://groups.google.com/group/mediathread
 
 REQUIREMENTS
 ------------
-* Python 3.6
+* Python >=3.6, <=3.9
 * Postgres (or MySQL)
 * Flowplayer installation for your site (See below for detailed instructions)
 * Flickr API Key if you want to bookmark from FLICKR


### PR DESCRIPTION
My dev environment currently uses python 3.9, and works well with Mediathread.

I thought we could state this in the readme now that we have some new groups using Mediathread.