### PR TITLE
Revert "Bump django-compressor from 2.4.1 to 3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ django-courseaffils==2.2.5
 django-statsd-mozilla==0.4.0
 sentry-sdk==1.5.0
 django-appconf==1.0.5
-django-compressor==3.1
+django-compressor==2.4.1
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-smoketest==1.1.2


### PR DESCRIPTION
Reverts ccnmtl/mediathread#4267