### PR TITLE
Allow additional AWS credential methods

### DIFF
--- a/mediathread/settings_docker.py
+++ b/mediathread/settings_docker.py
@@ -20,8 +20,8 @@ DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
 
 AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
-AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
-AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
+AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', None)
+AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', None)
 AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
 AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
 


### PR DESCRIPTION
Setting keys to `None` value defaults the boto3 library to search for [environment based credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) (~/.aws/credentials file, IAM roles, etc...). 

An empty string is treated as an actual value, and therefore always invalid when used.