### PR TITLE
Extended support for recommended source thumbnails

### DIFF
--- a/mediathread/templates/dashboard/class_manage_sources.html
+++ b/mediathread/templates/dashboard/class_manage_sources.html
@@ -45,9 +45,15 @@
                         <tr>
                             <td class="thumb">
                                 {% if suggested.thumb_url %}
-                                    <a href="{{suggested.url}}">
-                                        <img src="{{STATIC_URL}}{{suggested.thumb_url}}" alt="thumbnail image" />
-                                    </a>
+                                    {% if request.path|slice:":5" == '/test' %}
+                                        <a href="{{suggested.url}}">
+                                            {% if suggested.thumb_url|slice:":4" == "http" %}
+                                                <img src="{{suggested.thumb_url}}" alt="thumbnail image" />
+                                            {% else %}
+                                                <img src="{{STATIC_URL}}{{suggested.thumb_url}}" alt="thumbnail image" />
+                                            {% endif %}
+                                        </a>
+                                    {% endif %}
                                 {% endif %}
                             </td>
                             <td>

--- a/mediathread/templates/main/rec_sources.html
+++ b/mediathread/templates/main/rec_sources.html
@@ -12,8 +12,13 @@
                     {% if collection.thumb_url %}
                         <div class="source_thumb">
                             <a href="/explore/redirect/{{collection.id}}/">
-                                <img src="{{STATIC_URL}}{{collection.thumb_url}}" alt="{{collection.title}} icon"
-                                    class="collection-link" />
+                                {% if collection.thumb_url|slice:":4" == "http" %}
+                                    <img src="{{collection.thumb_url}}" alt="{{collection.title}} icon"
+                                        class="collection-link" />
+                                {% else %}
+                                    <img src="{{STATIC_URL}}{{collection.thumb_url}}" alt="{{collection.title}} icon"
+                                        class="collection-link" />
+                                {% endif %}
                                 <span class="sr-only">{{collection.title}} icon</span>
                             </a>
                         </div>


### PR DESCRIPTION
We've preferred to have control over the "recommended source" thumbnails to ensure the look/feel is correct. By allowing faculty to add their own sources, we need to also support external images.