### PR TITLE
Downgrade react-bootstrap to ~1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "lodash": "^4.17.15",
         "ol": "~6.11.0",
         "react": "~17.0.2",
-        "react-bootstrap": "^2.0.2",
+        "react-bootstrap": "~1.6.4",
         "react-data-table-component": "^7.0.0",
         "react-dom": "~17.0.2",
         "react-pdf": "^5.3.0",
@@ -2810,47 +2810,23 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.0.tgz",
-      "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2"
-      },
+    "node_modules/@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
+        "react": ">=16.3.2"
       }
     },
     "node_modules/@restart/hooks": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.5.tgz",
-      "integrity": "sha512-tLGtY0aHeIfT7aPwUkvQuhIy3+q3w4iqmUzFLPlOAf/vNUacLaBt1j/S//jv/dQhenRh8jvswyMojCwmLvJw8A==",
+      "version": "0.3.27",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.27.tgz",
+      "integrity": "sha512-s984xV/EapUIfkjlf8wz9weP2O9TNKR96C68FfMEy2bE69+H4cNv3RD4Mf97lW7Htt7PjZrYTjSC8f3SB9VCXw==",
       "dependencies": {
         "dequal": "^2.0.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@restart/ui": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.0.1.tgz",
-      "integrity": "sha512-hLAqltcAjQYtjGuHBHKyPpR3ScTxzdkSYNvniwBfN7rUDbYiHu/UZiI1hvV2idJeUvktRnz29l7W9BnNLHrG6Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
-        "@types/warning": "^3.0.0",
-        "dequal": "^2.0.2",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/@sideway/address": {
@@ -10184,13 +10160,13 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.1.2.tgz",
-      "integrity": "sha512-E7PR13cVsEW70gw08BWplENwn6PHTshskOsQygZqyc65jQlsnr9MsmuW/lgzAN2OiMBnc0KaNpuZ/FohL7dchw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.4.tgz",
+      "integrity": "sha512-z3BhBD4bEZuLP8VrYqAD7OT7axdcSkkyvWBWnS2U/4MhyabUihrUyucPWkan7aMI1XIHbmH4LCpEtzWGfx/yfA==",
       "dependencies": {
         "@babel/runtime": "^7.14.0",
-        "@restart/hooks": "^0.4.5",
-        "@restart/ui": "^1.0.1",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.26",
         "@types/invariant": "^2.2.33",
         "@types/prop-types": "^15.7.3",
         "@types/react": ">=16.14.8",
@@ -10201,13 +10177,14 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
+        "react-overlays": "^5.1.1",
         "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       },
       "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-data-table-component": {
@@ -10249,6 +10226,25 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-overlays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.1.1.tgz",
+      "integrity": "sha512-eCN2s2/+GVZzpnId4XVWtvDPYYBD2EtOGP74hE+8yDskPzFy9+pV1H3ZZihxuRdEbQzzacySaaDkR7xE0ydl4Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.8.6",
+        "@restart/hooks": "^0.3.26",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-pdf": {
       "version": "5.7.0",
@@ -14183,37 +14179,18 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
-    "@react-aria/ssr": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.0.tgz",
-      "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
-      "requires": {
-        "@babel/runtime": "^7.6.2"
-      }
+    "@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
+      "requires": {}
     },
     "@restart/hooks": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.5.tgz",
-      "integrity": "sha512-tLGtY0aHeIfT7aPwUkvQuhIy3+q3w4iqmUzFLPlOAf/vNUacLaBt1j/S//jv/dQhenRh8jvswyMojCwmLvJw8A==",
+      "version": "0.3.27",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.27.tgz",
+      "integrity": "sha512-s984xV/EapUIfkjlf8wz9weP2O9TNKR96C68FfMEy2bE69+H4cNv3RD4Mf97lW7Htt7PjZrYTjSC8f3SB9VCXw==",
       "requires": {
         "dequal": "^2.0.2"
-      }
-    },
-    "@restart/ui": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.0.1.tgz",
-      "integrity": "sha512-hLAqltcAjQYtjGuHBHKyPpR3ScTxzdkSYNvniwBfN7rUDbYiHu/UZiI1hvV2idJeUvktRnz29l7W9BnNLHrG6Q==",
-      "requires": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
-        "@types/warning": "^3.0.0",
-        "dequal": "^2.0.2",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
       }
     },
     "@sideway/address": {
@@ -19775,13 +19752,13 @@
       }
     },
     "react-bootstrap": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.1.2.tgz",
-      "integrity": "sha512-E7PR13cVsEW70gw08BWplENwn6PHTshskOsQygZqyc65jQlsnr9MsmuW/lgzAN2OiMBnc0KaNpuZ/FohL7dchw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.4.tgz",
+      "integrity": "sha512-z3BhBD4bEZuLP8VrYqAD7OT7axdcSkkyvWBWnS2U/4MhyabUihrUyucPWkan7aMI1XIHbmH4LCpEtzWGfx/yfA==",
       "requires": {
         "@babel/runtime": "^7.14.0",
-        "@restart/hooks": "^0.4.5",
-        "@restart/ui": "^1.0.1",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.26",
         "@types/invariant": "^2.2.33",
         "@types/prop-types": "^15.7.3",
         "@types/react": ">=16.14.8",
@@ -19792,6 +19769,7 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
+        "react-overlays": "^5.1.1",
         "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
@@ -19829,6 +19807,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-overlays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.1.1.tgz",
+      "integrity": "sha512-eCN2s2/+GVZzpnId4XVWtvDPYYBD2EtOGP74hE+8yDskPzFy9+pV1H3ZZihxuRdEbQzzacySaaDkR7xE0ydl4Q==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.8.6",
+        "@restart/hooks": "^0.3.26",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      }
     },
     "react-pdf": {
       "version": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.15",
     "ol": "~6.11.0",
     "react": "~17.0.2",
-    "react-bootstrap": "^2.0.2",
+    "react-bootstrap": "~1.6.4",
     "react-data-table-component": "^7.0.0",
     "react-dom": "~17.0.2",
     "react-pdf": "^5.3.0",


### PR DESCRIPTION
Version 2.x of this package is meant for Bootstrap 5. Mediathread is
still on Bootstrap 4. This resolves the weird icon in the validation
alert - MET-3976.