### PR TITLE
Separate support email from sending mechanism

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,6 +17,6 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior should be reported by sending an email to [ccnmt-mediathread@columbia.edu](mailto:ccnmtl-mediathread@columbia.edu)
+Instances of abusive, harassing, or otherwise unacceptable behavior should be reported by sending an email to [ctl-mediathread@columbia.edu](mailto:ctl-mediathread@columbia.edu)
 
 This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ residing in the directory [ requirements/src/ ] including Django
 (http://www.djangoproject.com/) which is BSD-licensed.
 
     Copyright (C) 2010 Columbia Center for New Media Teaching and Learning
-    ccnmtl@columbia.edu
+    ctl-mediathread@columbia.edu
 
     Authors: 
     Schuyler Duveen sky@columbia.edu

--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -542,7 +542,7 @@ class ContactUsViewTest(TestCase):
             self.assertEquals(mail.outbox[0].from_email,
                               settings.SERVER_EMAIL)
             self.assertEquals(mail.outbox[0].to,
-                              [settings.SERVER_EMAIL])
+                              [settings.CONTACT_US_EMAIL])
 
             self.assertEqual(mail.outbox[1].subject,
                              'Mediathread Contact Us Request')
@@ -573,7 +573,7 @@ class ContactUsViewTest(TestCase):
             self.assertEquals(mail.outbox[0].from_email,
                               settings.SERVER_EMAIL)
             self.assertEquals(mail.outbox[0].to,
-                              [settings.SERVER_EMAIL])
+                              [settings.CONTACT_US_EMAIL])
 
             self.assertEqual(mail.outbox[1].subject,
                              'Mediathread Contact Us Request')
@@ -1425,7 +1425,7 @@ class AffilActivateViewTest(LoggedInUserTestMixin, TestCase):
             settings.SERVER_EMAIL)
         self.assertEquals(
             mail.outbox[0].to,
-            [settings.SERVER_EMAIL])
+            [settings.CONTACT_US_EMAIL])
         self.assertIn(
             'Course Title: {}'.format('English for Cats'),
             mail.outbox[0].body)

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -407,7 +407,7 @@ class ContactUsView(FormView):
 
         # send to server email instead
         send_mail('Mediathread Support Request', form_data['description'],
-                  settings.SERVER_EMAIL, (settings.SERVER_EMAIL,))
+                  settings.SERVER_EMAIL, (settings.CONTACT_US_EMAIL,))
 
         # send a follow-up to the user requesting help
         support_email = getattr(settings, 'SUPPORT_DESTINATION', None)
@@ -1038,7 +1038,7 @@ If you are new to Mediathread, a CTL learning designer or your
 department specialist will check in with you in the coming days to
 make sure all is going well. If you have any pressing questions in the
 meantime, please feel free to contact us at
-ccnmtl-mediathread@ccnmtl.columbia.edu.
+ctl-mediathread@columbia.edu.
 
 Thanks,
 The Mediathread Team
@@ -1084,7 +1084,7 @@ Faculty: {} <{}>
             subject,
             body,
             settings.SERVER_EMAIL,
-            [settings.SERVER_EMAIL])
+            [settings.CONTACT_US_EMAIL])
 
     def create_course(self, form, affil):
         """Creates a Course for this form.

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -83,7 +83,8 @@ INSTALLED_APPS += [  # noqa
 ]
 
 THUMBNAIL_SUBDIR = "thumbs"
-SERVER_EMAIL = "mediathread@example.com"
+SERVER_EMAIL = "mediathread-noreply@example.com"
+CONTACT_US_EMAIL = "mediathread-support@example.com"
 
 DATE_FORMAT = DATETIME_FORMAT = "g:i a, m/d/y"
 LOGOUT_REDIRECT_URL = LOGIN_REDIRECT_URL = '/'

--- a/mediathread/templates/main/lti_course_connect.txt
+++ b/mediathread/templates/main/lti_course_connect.txt
@@ -8,7 +8,7 @@ For an overview of Mediathread, please visit our About page (https://mediathread
 
 CTL learning designers Andrew Corpuz (abc2188@columbia.edu) or Michael Tarnow (mit2114@columbia.edu) can help you conceptualize and set up assignments in Mediathread.
 
-Please email us at ccnmtl-mediathread@columbia.edu to request a consultation.
+Please email us at ctl-mediathread@columbia.edu to request a consultation.
 
 Mediathread is designed and maintained here at the CTL, and we are always eager to receive ideas from the Columbia community – please let us know how it goes! We hope you have a successful semester using Mediathread.
 


### PR DESCRIPTION
Our infrastructure now sends from one verified email address (`SERVER_EMAIL`) to a support alias.
* Adding a `CONTACT_US_EMAIL` setting to identify the support alias and substituting that for `SERVER_EMAIL` where appropriate.
* Updating the static ccnmtl email references to `ctl-mediathread`.