### PR TITLE
pdf.js viewer css: use absolute paths for URLs

### DIFF
--- a/media/css/pdfjs/viewer.css
+++ b/media/css/pdfjs/viewer.css
@@ -688,8 +688,8 @@
   overflow: visible;
   border: var(--page-border);
   background-clip: content-box;
-  -o-border-image: url(images/shadow.png) 9 9 repeat;
-     border-image: url(images/shadow.png) 9 9 repeat;
+  -o-border-image: url(/media/css/pdfjs/images/shadow.png) 9 9 repeat;
+     border-image: url(/media/css/pdfjs/images/shadow.png) 9 9 repeat;
   background-color: rgba(255, 255, 255, 1);
 }
 
@@ -773,7 +773,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  background: url("images/loading-icon.gif") center no-repeat;
+  background: url("/media/css/pdfjs/images/loading-icon.gif") center no-repeat;
 }
 .pdfViewer .page .loadingIcon.notVisible {
   background: none;
@@ -849,43 +849,43 @@
   --overlay-button-bg-color: rgba(12, 12, 13, 0.1);
   --overlay-button-hover-bg-color: rgba(12, 12, 13, 0.3);
 
-  --loading-icon: url(images/loading.svg);
-  --treeitem-expanded-icon: url(images/treeitem-expanded.svg);
-  --treeitem-collapsed-icon: url(images/treeitem-collapsed.svg);
-  --toolbarButton-menuArrow-icon: url(images/toolbarButton-menuArrow.svg);
-  --toolbarButton-sidebarToggle-icon: url(images/toolbarButton-sidebarToggle.svg);
-  --toolbarButton-secondaryToolbarToggle-icon: url(images/toolbarButton-secondaryToolbarToggle.svg);
-  --toolbarButton-pageUp-icon: url(images/toolbarButton-pageUp.svg);
-  --toolbarButton-pageDown-icon: url(images/toolbarButton-pageDown.svg);
-  --toolbarButton-zoomOut-icon: url(images/toolbarButton-zoomOut.svg);
-  --toolbarButton-zoomIn-icon: url(images/toolbarButton-zoomIn.svg);
-  --toolbarButton-presentationMode-icon: url(images/toolbarButton-presentationMode.svg);
-  --toolbarButton-print-icon: url(images/toolbarButton-print.svg);
-  --toolbarButton-openFile-icon: url(images/toolbarButton-openFile.svg);
-  --toolbarButton-download-icon: url(images/toolbarButton-download.svg);
-  --toolbarButton-bookmark-icon: url(images/toolbarButton-bookmark.svg);
-  --toolbarButton-viewThumbnail-icon: url(images/toolbarButton-viewThumbnail.svg);
-  --toolbarButton-viewOutline-icon: url(images/toolbarButton-viewOutline.svg);
-  --toolbarButton-viewAttachments-icon: url(images/toolbarButton-viewAttachments.svg);
-  --toolbarButton-viewLayers-icon: url(images/toolbarButton-viewLayers.svg);
-  --toolbarButton-currentOutlineItem-icon: url(images/toolbarButton-currentOutlineItem.svg);
-  --toolbarButton-search-icon: url(images/toolbarButton-search.svg);
-  --findbarButton-previous-icon: url(images/findbarButton-previous.svg);
-  --findbarButton-next-icon: url(images/findbarButton-next.svg);
-  --secondaryToolbarButton-firstPage-icon: url(images/secondaryToolbarButton-firstPage.svg);
-  --secondaryToolbarButton-lastPage-icon: url(images/secondaryToolbarButton-lastPage.svg);
-  --secondaryToolbarButton-rotateCcw-icon: url(images/secondaryToolbarButton-rotateCcw.svg);
-  --secondaryToolbarButton-rotateCw-icon: url(images/secondaryToolbarButton-rotateCw.svg);
-  --secondaryToolbarButton-selectTool-icon: url(images/secondaryToolbarButton-selectTool.svg);
-  --secondaryToolbarButton-handTool-icon: url(images/secondaryToolbarButton-handTool.svg);
-  --secondaryToolbarButton-scrollPage-icon: url(images/secondaryToolbarButton-scrollPage.svg);
-  --secondaryToolbarButton-scrollVertical-icon: url(images/secondaryToolbarButton-scrollVertical.svg);
-  --secondaryToolbarButton-scrollHorizontal-icon: url(images/secondaryToolbarButton-scrollHorizontal.svg);
-  --secondaryToolbarButton-scrollWrapped-icon: url(images/secondaryToolbarButton-scrollWrapped.svg);
-  --secondaryToolbarButton-spreadNone-icon: url(images/secondaryToolbarButton-spreadNone.svg);
-  --secondaryToolbarButton-spreadOdd-icon: url(images/secondaryToolbarButton-spreadOdd.svg);
-  --secondaryToolbarButton-spreadEven-icon: url(images/secondaryToolbarButton-spreadEven.svg);
-  --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
+  --loading-icon: url(/media/css/pdfjs/images/loading.svg);
+  --treeitem-expanded-icon: url(/media/css/pdfjs/images/treeitem-expanded.svg);
+  --treeitem-collapsed-icon: url(/media/css/pdfjs/images/treeitem-collapsed.svg);
+  --toolbarButton-menuArrow-icon: url(/media/css/pdfjs/images/toolbarButton-menuArrow.svg);
+  --toolbarButton-sidebarToggle-icon: url(/media/css/pdfjs/images/toolbarButton-sidebarToggle.svg);
+  --toolbarButton-secondaryToolbarToggle-icon: url(/media/css/pdfjs/images/toolbarButton-secondaryToolbarToggle.svg);
+  --toolbarButton-pageUp-icon: url(/media/css/pdfjs/images/toolbarButton-pageUp.svg);
+  --toolbarButton-pageDown-icon: url(/media/css/pdfjs/images/toolbarButton-pageDown.svg);
+  --toolbarButton-zoomOut-icon: url(/media/css/pdfjs/images/toolbarButton-zoomOut.svg);
+  --toolbarButton-zoomIn-icon: url(/media/css/pdfjs/images/toolbarButton-zoomIn.svg);
+  --toolbarButton-presentationMode-icon: url(/media/css/pdfjs/images/toolbarButton-presentationMode.svg);
+  --toolbarButton-print-icon: url(/media/css/pdfjs/images/toolbarButton-print.svg);
+  --toolbarButton-openFile-icon: url(/media/css/pdfjs/images/toolbarButton-openFile.svg);
+  --toolbarButton-download-icon: url(/media/css/pdfjs/images/toolbarButton-download.svg);
+  --toolbarButton-bookmark-icon: url(/media/css/pdfjs/images/toolbarButton-bookmark.svg);
+  --toolbarButton-viewThumbnail-icon: url(/media/css/pdfjs/images/toolbarButton-viewThumbnail.svg);
+  --toolbarButton-viewOutline-icon: url(/media/css/pdfjs/images/toolbarButton-viewOutline.svg);
+  --toolbarButton-viewAttachments-icon: url(/media/css/pdfjs/images/toolbarButton-viewAttachments.svg);
+  --toolbarButton-viewLayers-icon: url(/media/css/pdfjs/images/toolbarButton-viewLayers.svg);
+  --toolbarButton-currentOutlineItem-icon: url(/media/css/pdfjs/images/toolbarButton-currentOutlineItem.svg);
+  --toolbarButton-search-icon: url(/media/css/pdfjs/images/toolbarButton-search.svg);
+  --findbarButton-previous-icon: url(/media/css/pdfjs/images/findbarButton-previous.svg);
+  --findbarButton-next-icon: url(/media/css/pdfjs/images/findbarButton-next.svg);
+  --secondaryToolbarButton-firstPage-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-firstPage.svg);
+  --secondaryToolbarButton-lastPage-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-lastPage.svg);
+  --secondaryToolbarButton-rotateCcw-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-rotateCcw.svg);
+  --secondaryToolbarButton-rotateCw-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-rotateCw.svg);
+  --secondaryToolbarButton-selectTool-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-selectTool.svg);
+  --secondaryToolbarButton-handTool-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-handTool.svg);
+  --secondaryToolbarButton-scrollPage-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-scrollPage.svg);
+  --secondaryToolbarButton-scrollVertical-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-scrollVertical.svg);
+  --secondaryToolbarButton-scrollHorizontal-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-scrollHorizontal.svg);
+  --secondaryToolbarButton-scrollWrapped-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-scrollWrapped.svg);
+  --secondaryToolbarButton-spreadNone-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-spreadNone.svg);
+  --secondaryToolbarButton-spreadOdd-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-spreadOdd.svg);
+  --secondaryToolbarButton-spreadEven-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-spreadEven.svg);
+  --secondaryToolbarButton-documentProperties-icon: url(/media/css/pdfjs/images/secondaryToolbarButton-documentProperties.svg);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -931,7 +931,7 @@
     /* This image is used in <input> elements, which unfortunately means that
      * the `mask-image` approach used with all of the other images doesn't work
      * here; hence why we still have two versions of this particular image. */
-    --loading-icon: url(images/loading-dark.svg);
+    --loading-icon: url(/media/css/pdfjs/images/loading-dark.svg);
   }
 }
 


### PR DESCRIPTION
This resolves the Safari icon loading issue.