### PR TITLE
use python 3.8 for testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
         node-version: [16.x]
     services:
       postgres:


### PR DESCRIPTION
mediathread-staging is now on python 3.8, and prod will be soon.