### PR TITLE
Exclude PDF from juxtapose assignment

### DIFF
--- a/media/js/app/assetmgr/collectionwidget.js
+++ b/media/js/app/assetmgr/collectionwidget.js
@@ -80,8 +80,10 @@ CollectionWidget.prototype.mapSignals = function() {
             self.onSave(event, params);
         });
 
-    jQuery(window).on('collection.open', {'self': this},
-        function(event, params) {
+    jQuery(window).on(
+        'collection.open', {
+            'self': this
+        }, function(event, params) {
             self.$quickEditView.hide();
             self.$el.show();
             self.open('gallery', params);
@@ -682,7 +684,10 @@ CollectionWidget.prototype.baseUrl = function() {
 };
 
 CollectionWidget.prototype.isValidFilter = function(filter) {
-    var filters = ['tag', 'modified', 'search_text', 'media_type'];
+    var filters = [
+        'tag', 'modified', 'search_text',
+        'media_type', 'primary_type'
+    ];
     return filters.indexOf(filter) > -1 || filter.startsWith('vocabulary-');
 };
 

--- a/mediathread/mixins.py
+++ b/mediathread/mixins.py
@@ -125,6 +125,13 @@ class RestrictedMaterialsMixin(object):
         if request.GET.getlist('primary_type[]'):
             filtered_types = request.GET.getlist('primary_type[]')
             visible_notes = visible_notes.exclude_primary_types(filtered_types)
+        elif request.GET.get('primary_type'):
+            # If primary_type is passed in as a string, use that
+            # instead of the list.
+
+            filtered_type = request.GET.get('primary_type')
+            visible_notes = visible_notes.exclude_primary_types(
+                [filtered_type])
 
         search_text = request.GET.get('search_text', '').strip().lower()
         if len(search_text) > 0:

--- a/mediathread/templates/clientside/collectionwidget.mustache
+++ b/mediathread/templates/clientside/collectionwidget.mustache
@@ -40,7 +40,6 @@
                             <li><a class="switcher-choice filterbymedia" href="audio">audio</a></li>
                             <li><a class="switcher-choice filterbymedia" href="image">image</a></li>
                             <li><a class="switcher-choice filterbymedia" href="video">video</a></li>
-                            <li><a class="switcher-choice filterbymedia" href="pdf">pdf</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This comprises of two changes:
* Remove PDF option from collectionwidget's mustache template
* Allow the primary_type API param to be parsed as a single string
  as well as an array