### PR TITLE
Tags: Remove the "no options" message in react-select

### DIFF
--- a/media/js/src/forms/SelectionForm.jsx
+++ b/media/js/src/forms/SelectionForm.jsx
@@ -167,6 +167,7 @@ export default class SelectionForm extends React.Component {
                         onChange={this.handleTagsChange}
                         isMulti
                         defaultValue={selectedTags}
+                        noOptionsMessage={({inputValue}) => !inputValue ? "" : "No tags found"}
                         options={tagsOptions} />
                 </Form.Group>
 


### PR DESCRIPTION
Per request from our team, the "no options" message is a bit weird. When no tags exist, remove this message, otherwise indicate, "no tags found"