### PR TITLE
Embed view: don't compress js

### DIFF
--- a/mediathread/templates/assetmgr/asset_embed_view.html
+++ b/mediathread/templates/assetmgr/asset_embed_view.html
@@ -43,15 +43,11 @@
         <div class="clipstrip-display" style="display: none"></div>
     </div>
 
-    {% compress js %}
-        <script type="text/javascript" src='{% static "js/app/analytics.js" %}'></script>
-        <!--All the annotation javascript -->
-        {% include "djangosherd/annotator_resources.html" %}
-    {% endcompress %}
+    <script type="text/javascript" src='{% static "js/app/analytics.js" %}'></script>
 
-    {% block uncompressable_js %}
-        {% include "djangosherd/player_resources.html" %}
-    {% endblock %}
+    <!--All the annotation javascript -->
+    {% include "djangosherd/annotator_resources.html" %}
+    {% include "djangosherd/player_resources.html" %}
 
     <script type="text/javascript">
         jQuery(document).ready(function () {


### PR DESCRIPTION
All views except this one, we include javascript with `block js` instead
of `compress js`, so do that here too. This template doesn't inherit
from base_new.html, so just include the js resources as is.
    
This may fix the LTI embed issue.
