### PR TITLE
Add axe-core configuration

### DIFF
--- a/cypress/e2e/1.course/course.cy.js
+++ b/cypress/e2e/1.course/course.cy.js
@@ -3,5 +3,6 @@ describe('Course Navigation', () => {
         cy.login('instructor_one', 'test');
         cy.visit('/course/1/');
         cy.url().should('match', /course\/1\/$/);
+        cy.checkPageA11y();
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -60,3 +60,42 @@ Cypress.Commands.add('getIframeBody', () => {
     // https://on.cypress.io/wrap
         .then(cy.wrap);
 });
+
+// Lifted this pattern from https://github.com/jonoliver/cypress-axe-demo
+
+const severityIndicators = {
+    minor: '⚪️',
+    moderate: '🟡',
+    serious: '🟠',
+    critical: '🔴',
+};
+
+function callback(violations) {
+    violations.forEach(violation => {
+        const nodes =
+            Cypress.$(violation.nodes.map(node => node.target).join(','));
+
+        Cypress.log({
+            name: `${severityIndicators[violation.impact]} A11Y`,
+            consoleProps: () => violation,
+            $el: nodes,
+            message: `[${violation.help}](${violation.helpUrl})`
+        });
+
+        violation.nodes.forEach(({ target }) => {
+            Cypress.log({
+                name: '🔧',
+                consoleProps: () => violation,
+                $el: Cypress.$(target.join(',')),
+                message: target
+            });
+        });
+    });
+}
+
+Cypress.Commands.add('checkPageA11y', () => {
+    cy.injectAxe();
+
+    const ctx = {runOnly: {type: 'tag', values: ['wcag2a']}};
+    cy.checkA11y('html', ctx, callback, true);
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,5 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+import 'cypress-axe';

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,11 @@
         "@babel/preset-env": "^7.9.6",
         "@babel/preset-react": "^7.7.4",
         "@babel/runtime": "^7.12.5",
+        "axe-core": "^4.1.4",
         "babel-jest": "^28.0.1",
         "babel-loader": "^8.0.6",
         "cypress": "10.3.0",
+        "cypress-axe": "^1.0.0",
         "eslint": "~8.19.0",
         "eslint-plugin-cypress": "^2.11.1",
         "eslint-plugin-react": "^7.20.0",
@@ -3715,6 +3717,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axe-core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -4659,6 +4670,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
+      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -14979,6 +15003,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "dev": true
+    },
     "axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -15782,6 +15812,13 @@
           }
         }
       }
+    },
+    "cypress-axe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
+      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
+      "dev": true,
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/ccnmtl/mediathread/issues"
   },
   "devDependencies": {
+    "axe-core": "^4.1.4",
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.9.6",
@@ -36,6 +37,7 @@
     "@babel/eslint-parser": "^7.15.8",
     "babel-loader": "^8.0.6",
     "cypress": "10.3.0",
+    "cypress-axe": "^1.0.0",
     "eslint": "~8.19.0",
     "eslint-plugin-cypress": "^2.11.1",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
This PR adds basic axe-core functionality. For the moment, the tests are designed to succeed even if there are accessibility errors.

Note: the final "true" parameter in the call to cy.checkA11y allows the check to always pass.

```
    const ctx = {runOnly: {type: 'tag', values: ['wcag2a']}};
    cy.checkA11y('html', ctx, callback, true);
```