### PR TITLE
Fix bug where we're not getting Course Connected emails

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1686,7 +1686,7 @@ class LTICourseCreateTest(TestCase):
             self.assertEquals(mail.outbox[0].from_email,
                               settings.SERVER_EMAIL)
             self.assertEquals(mail.outbox[0].to,
-                              [settings.SERVER_EMAIL])
+                              [settings.CONTACT_US_EMAIL])
 
             self.assertEqual(mail.outbox[1].subject,
                              'Mediathread Course Connected')

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -1258,7 +1258,7 @@ class LTICourseCreate(LoggedInMixin, View):
         send_template_email(
             'Mediathread Course Connected',
             'main/notify_lti_course_connect.txt',
-            data, settings.SERVER_EMAIL)
+            data, settings.CONTACT_US_EMAIL)
 
     def thank_faculty(self, course):
         send_template_email(


### PR DESCRIPTION
Susan made a change separating out server sending email, and this call got
lost in the fray. SERVER_EMAIL is not monitored and goes nowhere.