### PR TITLE
Refactor to fix LTICourseContext bug

### DIFF
--- a/mediathread/main/middleware.py
+++ b/mediathread/main/middleware.py
@@ -7,24 +7,39 @@ from mediathread.main.views import MethCourseListView
 
 
 class MethCourseManagerMiddleware(CourseManagerMiddleware):
+    def set_course(self, course, request):
+        request.session[SESSION_KEY] = course
+        request.course = course
+        self.decorate_request(request, course)
+
     def process_request(self, request):
         # LTI requests need to have the course set explicitly
         # particularly for the collection integration
         # 'context_id' comes through in the LTI POST request
         lti_course_id = request.POST.get('context_id', None)
         if lti_course_id is not None:
+            ctx = None
             try:
                 ctx = LTICourseContext.objects.get(
                     lms_course_context=lti_course_id)
-
-                course = Course.objects.get(group=ctx.group,
-                                            faculty_group=ctx.faculty_group)
-                request.session[SESSION_KEY] = course
-                self.decorate_request(request, course)
-                return None
             except LTICourseContext.DoesNotExist:
-                # the course *should* exist, but don't break if it doesn't
                 pass
+
+            course = None
+            if ctx is not None:
+                # If we have an LTI course context, find and set the
+                # course associated with it.
+                try:
+                    course = Course.objects.get(
+                        group=ctx.group,
+                        faculty_group=ctx.faculty_group)
+                except Course.DoesNotExist:
+                    # The course *should* exist, but don't break if it
+                    # doesn't.
+                    pass
+
+            if course:
+                self.set_course(course, request)
 
         # Don't display the switch course view when making an ajax
         # request that contains the 'course' GET param. Ultimately,


### PR DESCRIPTION
This bug can occur when we find an LTICourseContext and no Course
object associated with it. try/except statements should really only be used
to surround a single line - unexpected exceptions can occur otherwise.