### PR TITLE
Refactor LTICourseSelector to allow broken data

### DIFF
--- a/mediathread/main/tests/test_views.py
+++ b/mediathread/main/tests/test_views.py
@@ -1648,6 +1648,22 @@ class LTICourseSelectorTest(MediathreadTestMixin, TestCase):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context['course'], self.sample_course)
 
+    def test_get_without_course(self):
+        ctx = LTICourseContextFactory(
+            group=self.sample_course.group,
+            faculty_group=self.sample_course.faculty_group)
+
+        self.sample_course.delete()
+        ctx.refresh_from_db()
+
+        url = reverse('lti-course-select', args=[ctx.lms_course_context])
+
+        self.client.login(
+            username=self.instructor_one.username, password='test')
+        response = self.client.get(url, follow=True)
+        self.assertEquals(response.status_code, 200)
+        self.assertTrue('course' not in response.context)
+
 
 class LTICourseCreateTest(TestCase):
 

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -1232,16 +1232,22 @@ Faculty: {} <{}>
 class LTICourseSelector(LoggedInMixin, View):
 
     def get(self, request, context):
-        try:
-            messages.add_message(
-                request, messages.INFO,
-                'Reminder: please log out of Mediathread '
-                'after you log out of Courseworks.')
+        messages.add_message(
+            request, messages.INFO,
+            'Reminder: please log out of Mediathread '
+            'after you log out of Courseworks.')
 
+        url = '/'
+        try:
             ctx = LTICourseContext.objects.get(lms_course_context=context)
-            url = reverse('course_detail', args=[ctx.group.course.id])
         except LTICourseContext.DoesNotExist:
-            url = '/'
+            pass
+
+        try:
+            url = reverse('course_detail', args=[ctx.group.course.pk])
+        except Group.course.RelatedObjectDoesNotExist:
+            # Don't fail when we don't find a course
+            pass
 
         return HttpResponseRedirect(url)
 


### PR DESCRIPTION
Don't completely fail when there is no Course object associated with a given LTICourseContext.

Similarly, this is a refactor breaking out too much code going on in a single `try` statement.