### PR TITLE
Fix bug where migrating a discussion project lacks ThreadedComments

### DIFF
--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -136,9 +136,38 @@ class SherdNoteFactory(DjangoModelFactory):
     author = factory.SubFactory(UserFactory)
 
 
+class CollaborationPolicyRecordFactory(DjangoModelFactory):
+    class Meta:
+        model = CollaborationPolicyRecord
+
+    policy_name = 'PolicyName'
+
+
+class CollaborationFactory(DjangoModelFactory):
+    class Meta:
+        model = Collaboration
+
+    user = factory.SubFactory(UserFactory)
+    group = factory.SubFactory(GroupFactory)
+    policy_record = factory.SubFactory(CollaborationPolicyRecordFactory)
+
+
+class ThreadedCommentFactory(DjangoModelFactory):
+    class Meta:
+        model = ThreadedComment
+
+    title = 'Comment Title'
+    comment = 'comment content'
+    site = factory.LazyAttribute(
+        lambda _: Site.objects.all().first())
+    content_type = factory.LazyAttribute(
+        lambda _: ContentType.objects.get_for_model(ThreadedComment))
+
+
 class ProjectFactory(DjangoModelFactory):
     class Meta:
         model = Project
+
     course = factory.SubFactory(CourseFactory)
     title = factory.Sequence(lambda n: 'Project %d' % n)
     author = factory.SubFactory(UserFactory)
@@ -162,18 +191,6 @@ class ProjectFactory(DjangoModelFactory):
     def participants(self, create, extracted, **kwargs):
         if create:
             self.participants.add(self.author)
-
-
-class CollaborationFactory(DjangoModelFactory):
-    class Meta:
-        model = Collaboration
-    user = factory.SubFactory(UserFactory)
-    group = factory.SubFactory(GroupFactory)
-
-
-class CollaborationPolicyRecordFactory(DjangoModelFactory):
-    class Meta:
-        model = CollaborationPolicyRecord
 
 
 class AssignmentItemFactory(DjangoModelFactory):

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -159,6 +159,8 @@ class Collaboration(models.Model):
                 CollaborationPolicyRecord.objects.get_or_create(
                     policy_name=policy_name)
 
+        self.save()
+
     def __str__(self):
         return u'%s %r <%s %s> [%s]' % (self.title, self.pk, self.content_type,
                                         self.object_pk, self.slug)


### PR DESCRIPTION
* Made a test to reproduce discussion project migration bug
* project.course_discussion() should not be None after migrating a discussion project.