### PR TITLE
Fix discussion assignment migration

### DIFF
--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -158,6 +158,7 @@ class ThreadedCommentFactory(DjangoModelFactory):
 
     title = 'Comment Title'
     comment = 'comment content'
+    user = factory.SubFactory(UserFactory)
     site = factory.LazyAttribute(
         lambda _: Site.objects.all().first())
     content_type = factory.LazyAttribute(

--- a/mediathread/projects/views.py
+++ b/mediathread/projects/views.py
@@ -26,8 +26,9 @@ from mediathread.assetmgr.models import Asset
 from mediathread.discussions.utils import get_course_discussions
 from mediathread.discussions.views import threaded_comment_json
 from mediathread.djangosherd.models import SherdNote, DiscussionIndex
-from mediathread.main.course_details import allow_public_compositions, \
-    cached_course_is_faculty, cached_course_collaboration
+from mediathread.main.course_details import (
+    allow_public_compositions, cached_course_is_faculty
+)
 from mediathread.main.models import UserSetting
 from mediathread.mixins import (
     LoggedInCourseMixin, RestrictedMaterialsMixin, AjaxRequiredMixin,
@@ -45,7 +46,6 @@ from mediathread.taxonomy.models import Vocabulary
 from mediathread.util import attach_course_to_request
 from reversion.models import Version
 from structuredcollaboration.models import Collaboration
-from threadedcomments.models import ThreadedComment
 
 
 class ProjectCreateView(LoggedInCourseMixin, JSONResponseMixin,
@@ -425,37 +425,8 @@ class DiscussionAssignmentCreateView(LoggedInFacultyMixin, ProjectCreateView):
         # create a project
         project = self.create_project()
 
-        # get the project's collaboration object
-        project_collab = project.get_collaboration()
-
-        # construct a collaboration for this discussion
-        # the parent will be this project within the course context
-        # all course members can participate in the discussion
-        course_collab = cached_course_collaboration(request.course)
-        disc_collab = Collaboration(_parent=project_collab,
-                                    title=project.title,
-                                    context=course_collab)
-        disc_collab.set_policy('CourseProtected')
-        disc_collab.save()
-
-        # Create a ThreadedComment that will act as the discussion root
-        # It will be tied to the project via the collaboration object
-        # as a generic foreign key
-        new_threaded_comment = ThreadedComment.objects.create(
-            parent=None, title=project.title, comment=project.body,
-            user=request.user, site_id=1, content_object=disc_collab)
-
-        # Conversely, the discussion collaboration will hold the
-        # discussion root in its generic foreign key
-        # this thread can now be accessed via the "course_discussion"
-        # model attribute
-        disc_collab.content_object = new_threaded_comment
-        disc_collab.save()
-
-        DiscussionIndex.update_class_references(
-            new_threaded_comment.comment, new_threaded_comment.user,
-            new_threaded_comment, new_threaded_comment.content_object,
-            new_threaded_comment.user)
+        Project.objects.make_discussion_assignment(
+            project, request.course, request.user)
 
         return HttpResponseRedirect(
                 reverse('project-workspace',


### PR DESCRIPTION
Consolidate the discussion creation view code into a model-level
method: `Project.make_discussion_assignment()`

* Created view test for migrated discussion assignment
* Update the model test as necessary
