### PR TITLE
Add fix for discussion assignment comment body

### DIFF
--- a/mediathread/factories.py
+++ b/mediathread/factories.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 import factory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyText
 import json
 from mediathread.assetmgr.models import (
     Asset, Source, ExternalCollection,
@@ -171,6 +172,8 @@ class ProjectFactory(DjangoModelFactory):
 
     course = factory.SubFactory(CourseFactory)
     title = factory.Sequence(lambda n: 'Project %d' % n)
+    body = ''
+    summary = FuzzyText()
     author = factory.SubFactory(UserFactory)
     project_type = 'composition'
 

--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -148,8 +148,12 @@ class ProjectManager(models.Manager):
         Returns the new Project.
         """
         new_project = Project.objects.create(
-            title=project.title, project_type=project.project_type,
-            course=course, author=user,
+            title=project.title,
+            project_type=project.project_type,
+            course=course,
+            author=user,
+            body=project.body,
+            summary=project.summary,
             response_view_policy=project.response_view_policy)
 
         collaboration_context = Collaboration.objects.get_for_object(course)

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -86,6 +86,7 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         self.discussion_assignment = ProjectFactory.create(
             course=self.sample_course,
             author=self.instructor_one,
+            body='Discussion Assignment Body',
             policy=PUBLISH_WHOLE_CLASS[0],
             project_type='discussion-assignment'
         )
@@ -195,6 +196,8 @@ class ProjectTest(MediathreadTestMixin, TestCase):
                                                   self.alt_instructor)
 
         self.assertEquals(new_project.title, self.assignment.title)
+        self.assertEquals(new_project.summary, self.assignment.summary)
+        self.assertEquals(new_project.body, self.assignment.body)
         self.assertEquals(new_project.author, self.alt_instructor)
         self.assertEquals(new_project.course, self.alt_course)
         self.assertEquals(new_project.description(), 'Composition Assignment')
@@ -213,6 +216,12 @@ class ProjectTest(MediathreadTestMixin, TestCase):
             self.alt_instructor)
 
         self.assertEqual(new_project.title, self.discussion_assignment.title)
+        self.assertEqual(
+            new_project.summary,
+            self.discussion_assignment.summary)
+        self.assertEqual(
+            new_project.body,
+            self.discussion_assignment.body)
         self.assertEqual(new_project.author, self.alt_instructor)
         self.assertEqual(new_project.course, self.alt_course)
         self.assertEqual(
@@ -224,6 +233,11 @@ class ProjectTest(MediathreadTestMixin, TestCase):
         self.assertIsNotNone(new_discussion)
         self.assertEqual(discussion.title, new_discussion.title)
         self.assertEqual(discussion.comment, new_discussion.comment)
+
+        # Assert that the original discussion's body text made it through
+        # to the ThreadedComment's comment attribute.
+        self.assertEqual(discussion.comment, self.discussion_assignment.body)
+
         self.assertEqual(discussion.user, self.instructor_one)
         self.assertEqual(new_discussion.user, self.alt_instructor)
 


### PR DESCRIPTION
The body text wasn't coming through from the Project on migration. Make this fix and update tests accordingly.