### PR TITLE
Remove leading slash in static paths to fix crash

### DIFF
--- a/mediathread/templates/main/collection_add.html
+++ b/mediathread/templates/main/collection_add.html
@@ -356,11 +356,11 @@
     </script>
 
     <!-- Media import form -->
-    <script src="{% static '/js/lib/get-youtube-id/index.js' %}"></script>
+    <script src="{% static 'js/lib/get-youtube-id/index.js' %}"></script>
     <script type="module">
     import {
         isYouTubeURL, isImgUrl, getMediaType, refreshImportForm
-    } from "{% static '/js/utils.js' %}";
+    } from "{% static 'js/utils.js' %}";
 
     jQuery(document).ready(function() {
         // In media import form, listen for image URL.


### PR DESCRIPTION
I've never run into this before - I can't believe something like this crashes the view. Very annoying that only happens in prod, so the tests don't catch it.

https://stackoverflow.com/a/43552427/173630