### PR TITLE
Discussions form: exclude a form that has the "response" class

### DIFF
--- a/media/js/app/discussion/discussionpanel.js
+++ b/media/js/app/discussion/discussionpanel.js
@@ -11,7 +11,7 @@ var DiscussionPanelHandler = function(el, $parent, panel, space_owner) {
     self.panel = panel;
     self.$parentContainer = $parent;
     self.space_owner = space_owner;
-    self.form = self.$el.find('form.threaded_comments_form')[0];
+    self.form = self.$el.find('form.threaded_comments_form:not(.response)')[0];
     self.max_comment_length = 20000;
 
     djangosherd.storage.json_update(panel.context);


### PR DESCRIPTION
When testing this between development and production, I noticed this particular discussion on production is initiated with two slightly different "threaded_comments_form" forms present on the page. One of them has the "response" class added - and this is getting selected as the DiscussionPanel's self.form in the front-end code, breaking the response.

![Screenshot_2022-10-25_11-23-27](https://user-images.githubusercontent.com/59292/197815649-da98c45c-a481-4cc8-9c2b-feaa16069e5c.png)


This should fix the issue, but I'm curious how this is happening in the first place.