### PR TITLE
TimecodeEditor: hardcode max input value

### DIFF
--- a/media/js/src/TimecodeEditor.jsx
+++ b/media/js/src/TimecodeEditor.jsx
@@ -18,13 +18,15 @@ export default class TimecodeEditor extends React.Component {
         if (this.props.timecode) {
             timecode = formatTimecode(this.props.timecode, true);
         }
+
         return (
             <div className="jux-timecode-editor">
                 <input
                     required
                     id="juxTimecode"
                     ref={this.spinnerRef}
-                    min={this.props.min}
+                    min={formatTimecode(this.props.min)}
+                    max="99:00:00"
                     defaultValue={timecode} />
             </div>
         );

--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -861,7 +861,7 @@ export default class AssetDetail extends React.Component {
                                                         Stop
                                                     </button>
                                                     <TimecodeEditor
-                                                        min={0}
+                                                        min={1}
                                                         onChange={this.onEndTimeUpdate}
                                                         timecode={this.state.selectionEndTime}
                                                     />


### PR DESCRIPTION
In this TimecodeEditor, we don't have direct access to the media's duration. Because some accessibility tools require a `max` attribute if we're using a `min` value, just hardcode this to 99 hours.