### PR TITLE
:arrow_up: editdistance 0.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ lazy-object-proxy==1.9.0
 wrapt==1.15.0
 unicodecsv==0.14.1
 
-editdistance==0.6.0
+editdistance==0.6.2
 
 pylint==2.17.0
 


### PR DESCRIPTION
This fixes a compile error on python 3.11.3 which I have in my dev environment:

```
      gcc -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -fexceptions -g -grecord-gcc-switche
s -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-
strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SO
URCE -fPIC -fwrapv -O2 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FO
RTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwin
d-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -fexceptions -g -grecord
-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstac
k-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protecti
on -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I./editdistance -I/home/nik/src/d/mediathread/ve/include -I/usr/incl
ude/python3.11 -c editdistance/bycython.cpp -o build/temp.linux-x86_64-cpython-311/editdistance/bycython.o
      editdistance/bycython.cpp:216:12: fatal error: longintrepr.h: No such file or directory             
        216 |   #include "longintrepr.h"                                                                  
            |            ^~~~~~~~~~~~~~~                                                                  
      compilation terminated.                                                                             
      error: command '/usr/bin/gcc' failed with exit code 1  
      [end of output]
```