### PR TITLE
Use timezone-naive datetime objects when calculating nonce

### DIFF
--- a/mediathread/assetmgr/views.py
+++ b/mediathread/assetmgr/views.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.encoding import smart_bytes
 from django.utils import timezone
+from django.utils.timezone import make_naive
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_http_methods, require_POST
@@ -616,7 +617,7 @@ class RedirectToUploaderView(LoggedInCourseMixin, View):
         url = reverse('course_detail', args=[self.request.course.id])
         redirect_back = '{}?msg=upload'.format(request.build_absolute_uri(url))
 
-        nonce = '%smthc' % timezone.now().isoformat()
+        nonce = '%smthc' % make_naive(timezone.now()).isoformat()
 
         digest = hmac.new(
             smart_bytes(special[exc.url]),
@@ -974,7 +975,7 @@ class AssetEmbedListView(LoggedInCourseMixin, RestrictedMaterialsMixin,
                            kwargs={'course_id': self.request.course.id,
                                    'annot_id': selection.id})
 
-        nonce = '%smthc' % timezone.now().isoformat()
+        nonce = '%smthc' % make_naive(timezone.now()).isoformat()
         digest = hmac.new(
             smart_bytes(secret),
             smart_bytes(

--- a/mediathread/main/views.py
+++ b/mediathread/main/views.py
@@ -24,6 +24,7 @@ from django.utils.encoding import smart_bytes, smart_text
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils import timezone
+from django.utils.timezone import make_naive
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
@@ -504,7 +505,7 @@ class CourseDeleteMaterialsView(LoggedInSuperuserMixin, FormView):
 
     def delete_uploaded_media(self, url, secret, asset):
         redirect_to = asset.get_metadata('wardenclyffe-id')[0]
-        nonce = '%smthc' % timezone.now().isoformat()
+        nonce = '%smthc' % make_naive(timezone.now()).isoformat()
         digest = hmac.new(
             smart_bytes(secret),
             smart_bytes('{}:{}:{}'.format(
@@ -595,7 +596,7 @@ class CourseConvertMaterialsView(LoggedInSuperuserMixin, TemplateView):
 
     def convert_media(self, user, course, url, secret, asset, folder):
         redirect_to = asset.get_metadata('wardenclyffe-id')[0]
-        nonce = '%smthc' % timezone.now().isoformat()
+        nonce = '%smthc' % make_naive(timezone.now()).isoformat()
         digest = hmac.new(
             smart_bytes(secret),
             smart_bytes('{}:{}:{}'.format(


### PR DESCRIPTION
ctlsettings change introduced USE_TZ = True, causing timezone.now() to return timezone-aware datetimes, which have a '+' character in their string, which may be affecting things in our request.GET connection with wardenclyffe. This change reverts back to naive datetime for the nonce.