### PR TITLE
Add role="img" to div containing asset canvas

### DIFF
--- a/media/js/src/assetDetail/AssetDetail.jsx
+++ b/media/js/src/assetDetail/AssetDetail.jsx
@@ -802,6 +802,7 @@ export default class AssetDetail extends React.Component {
                     <div
                         id={`map-${this.props.asset.id}`}
                         className="ol-map"
+                        role="img"
                         aria-live="polite"
                         aria-label={'Image for ' + label}></div>
                 </React.Fragment>


### PR DESCRIPTION
This is a band-aid solution for #5160.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role

The preferred solution would still be adding the aria-label directly to the `<canvas>` element. There was some discussion on that in this OpenLayers thread: https://github.com/openlayers/openlayers/issues/12485