### PR TITLE
Project.faculty_compositions: allow faculty_group to be None

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -339,10 +339,13 @@ class ProjectManager(models.Manager):
         projects = projects.select_related('author')
         return projects.order_by('-modified', 'title')
 
-    def faculty_compositions(self, course, user):
-        qs = Project.objects.filter(
-            course=course,
-            author__in=course.faculty_group.user_set.all())
+    @staticmethod
+    def faculty_compositions(course, user):
+        authors = []
+        if course and course.faculty_group:
+            authors = course.faculty_group.user_set.all()
+
+        qs = Project.objects.filter(course=course, author__in=authors)
         qs = qs.select_related('author')
         qs = qs.filter(project_type=PROJECT_TYPE_COMPOSITION)
 

--- a/mediathread/projects/tests/test_models.py
+++ b/mediathread/projects/tests/test_models.py
@@ -18,6 +18,13 @@ from mediathread.projects.models import (
     PROJECT_TYPE_SEQUENCE_ASSIGNMENT)
 
 
+class ProjectMinimalTest(TestCase):
+    """Test with minimal db setup"""
+    def test_faculty_compositions(self):
+        compositions = Project.objects.faculty_compositions(None, None)
+        self.assertEqual(len(compositions), 0)
+
+
 class ProjectTest(MediathreadTestMixin, TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This code should not fail when this value isn't set. This was uncovered in development testing with a very minimal course and wouldn't necessarily happen in production. I've also added a unit test for this.

Also, this function is essentially a static method that doesn't use `self`, so I've update the function signature.