### PR TITLE
Cypress: pin github actions jobs versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run eslint
   cypress:
     name: Cypress run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         firefox: [ 'latest-esr' ]
@@ -53,7 +53,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install -y libmemcached-dev
-      - uses: browser-actions/setup-firefox@latest
+      - uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: ${{ matrix.firefox }}
       - name: Run Integration Tests


### PR DESCRIPTION
In general, I think pinning these version numbers helps track down when exactly things start failing, in case there is ever a version issue in the environments.