### PR TITLE
Consolidate prefetch_related calls

### DIFF
--- a/mediathread/projects/models.py
+++ b/mediathread/projects/models.py
@@ -541,8 +541,7 @@ class Project(models.Model):
         if not collaboration:
             return visible
 
-        children = collaboration.get_children_for_object(
-            self, author).prefetch_related('content_object__author')
+        children = collaboration.get_children_for_object(self, author)
 
         viewer_response = None
         if viewer and not viewer.is_anonymous:

--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -128,8 +128,11 @@ class Collaboration(models.Model):
         if author and not author.is_anonymous:
             queryset = queryset.filter(Q(user=author) | Q(group__user=author))
 
-        return queryset.prefetch_related(
-            'content_object', 'policy_record', 'user')
+        return queryset.select_related(
+            'user', 'policy_record'
+        ).prefetch_related(
+            'content_object',
+            'content_object__author')
 
     def get_top_ancestor(self):  # i.e. domain
         result = self


### PR DESCRIPTION
To make sure the second one isn't overriding the first.

Also, use select_related where available, for the ForeignKey fields, to
avoid extra queries.