### PR TITLE
Prefetch participants in collaboration children query

### DIFF
--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -129,10 +129,11 @@ class Collaboration(models.Model):
             queryset = queryset.filter(Q(user=author) | Q(group__user=author))
 
         return queryset.select_related(
-            'user', 'policy_record'
+            'user', 'group', 'policy_record'
         ).prefetch_related(
             'content_object',
-            'content_object__author')
+            'content_object__author',
+            'content_object__participants')
 
     def get_top_ancestor(self):  # i.e. domain
         result = self


### PR DESCRIPTION
Using django-debug-toolbar, I found that this reduces the amount of SQL queries in this scenario from ~399 to ~150. We'll see if it has an effect on production.