### PR TITLE
Add django-debug-toolbar in development mode

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -212,9 +212,11 @@ LTI_TOOL_CONFIGURATION = {
 
 LTI_EXTRA_PARAMETERS = ['custom_course_context']
 
-if 'test' in sys.argv or \
-   'jenkins' in sys.argv or \
-   'integrationserver' in sys.argv:
+TESTING = ('test' in sys.argv or 'jenkins' in sys.argv or
+           'integrationserver' in sys.argv)
+DEVELOPMENT = 'runserver' in sys.argv
+
+if TESTING:
     ENVIRONMENT = 'testing'
     DEBUG = True
     TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa
@@ -247,6 +249,16 @@ if 'test' in sys.argv or \
 else:
     SESSION_COOKIE_SAMESITE = 'None'
     DCS_SESSION_COOKIE_SAMESITE = 'None'
+
+if DEVELOPMENT:
+    INSTALLED_APPS = [
+        *INSTALLED_APPS,
+        'debug_toolbar',
+    ]
+    MIDDLEWARE = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+        *MIDDLEWARE,
+    ]
 
 CSRF_COOKIE_SAMESITE = 'None'
 

--- a/mediathread/urls.py
+++ b/mediathread/urls.py
@@ -1,6 +1,7 @@
 import os.path
 
 import courseaffils
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.views import (
     PasswordChangeView, PasswordChangeDoneView,
@@ -45,6 +46,7 @@ from mediathread.projects.views import (
 from mediathread.taxonomy.api import TermResource, VocabularyResource
 from registration.backends.default.views import RegistrationView
 from tastypie.api import Api
+from debug_toolbar.toolbar import debug_toolbar_urls
 
 
 tastypie_api = Api('')
@@ -285,3 +287,8 @@ urlpatterns = [
     path('s/<slug:context_slug>/<slug:obj_type>/<int:obj_id>/',
          ProjectPublicView.as_view(), name='collaboration-obj-view'),
 ]
+
+if settings.DEVELOPMENT:
+    urlpatterns = [
+        *urlpatterns,
+    ] + debug_toolbar_urls()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pbr>=0.11
 
 six==1.17.0
 sqlparse==0.5.0  # django-debug-toolbar
+django-debug-toolbar==4.4.6
 python-mimeparse==2.0.0  # tastypie
 python-dateutil==2.9.0  # tastypie
 defusedxml==0.7.1  # tastypie


### PR DESCRIPTION
This can be helpful for debugging slow pages. We used to include this in ccnmtlsettings but now I think we only need in on a per-application basis.