### PR TITLE
Remove prefetch_related on collaboration call

### DIFF
--- a/structuredcollaboration/models.py
+++ b/structuredcollaboration/models.py
@@ -128,13 +128,7 @@ class Collaboration(models.Model):
         if author and not author.is_anonymous:
             queryset = queryset.filter(Q(user=author) | Q(group__user=author))
 
-        return queryset.select_related(
-            'user', 'group', 'policy_record'
-        ).prefetch_related(
-            'content_object',
-            'content_object__author',
-            'content_object__participants',
-            'content_object__collaboration')
+        return queryset.select_related('user', 'group', 'policy_record')
 
     def get_top_ancestor(self):  # i.e. domain
         result = self


### PR DESCRIPTION
In development mode, removing this prefetch increases both the SQL queries and CPU load, but for some reason allows the page to actually load in the staging environment. So, I want to deploy this to see if it changes anything in production.