### PR TITLE
Introduce django-lti - INFRA-2583

### DIFF
--- a/lti_auth/urls.py
+++ b/lti_auth/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from lti_auth.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
     LTICourseEnableView
+from lti_tool.views import jwks, OIDCLoginInitView
 
 
 urlpatterns = [
@@ -10,4 +11,9 @@ urlpatterns = [
     path('landing/<slug:context>/',
          LTILandingPage.as_view(), {}, 'lti-landing-page'),
     path('', LTIRoutingView.as_view(), {}, 'lti-login'),
+
+    # django-lti
+    path('.well-known/jwks.json', jwks, name='jwks'),
+    path('init/<uuid:registration_uuid>/',
+         OIDCLoginInitView.as_view(), name='oidc_init'),
 ]

--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -67,6 +67,7 @@ MIDDLEWARE += [  # noqa
     'corsheaders.middleware.CorsMiddleware',
     'mediathread.main.middleware.MethCourseManagerMiddleware',
     'django_user_agents.middleware.UserAgentMiddleware',
+    'lti_tool.middleware.LtiLaunchMiddleware',
 ]
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
@@ -95,6 +96,7 @@ INSTALLED_APPS += [  # noqa
     'corsheaders',
     'reversion',
     'lti_auth',
+    'lti_tool',
     'bootstrap3',
     'bootstrap4',
     'django_extensions',

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,12 @@ oauth==1.0.1
 oauth2==1.9.0.post1
 oauthlib==3.2.2
 pylti==0.7.0
+
+pyjwt==2.10.1  # pylti1p3
+jwcrypto==1.5.6  # pylti1p3
+PyLTI1p3==2.0.0  # django-lti
+django-lti==0.7.0
+
 nameparser==1.1.0
 django-bootstrap3==24.3
 django-bootstrap4==24.4


### PR DESCRIPTION
For LTI 1.3 compatibility.

An "LTI registration" object can be created in the lti_tool section of Django admin. This enables the view to be linked to from Canvas.

Here are some of the configuration options which must be filled in when creating an LTI registration within the Django admin:
* Client ID: The ID of the Developer Key created in Canvas
* Auth URL: `https://<canvas hostname>/api/lti/authorize_redirect`
* Access token URL: `https://<canvas hostname>/login/oauth2/auth`
* Keyset URL: `https://<canvas hostname>/api/lti/security/jwks`

I am not 100% certain on the accuracy of all of these values yet. I am still investigating the integration steps. It seems many different integration methods are possible.