### PR TITLE
Prepend CORS middleware

### DIFF
--- a/mediathread/settings_shared.py
+++ b/mediathread/settings_shared.py
@@ -61,10 +61,12 @@ TEMPLATES = [
     },
 ]
 
+MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
+] + MIDDLEWARE  # noqa
 
 MIDDLEWARE += [  # noqa
     'django.middleware.csrf.CsrfViewMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'mediathread.main.middleware.MethCourseManagerMiddleware',
     'django_user_agents.middleware.UserAgentMiddleware',
     'lti_tool.middleware.LtiLaunchMiddleware',


### PR DESCRIPTION
This should go before ctlsettings' CommonMiddleware, according to the docs.
https://pypi.org/project/django-cors-headers/