### PR TITLE
LTI config: add contextmembership.readonly scope

### DIFF
--- a/lti_auth/views.py
+++ b/lti_auth/views.py
@@ -163,7 +163,12 @@ class LTI1p3JSONConfigView(View):
             'target_link_uri': target_link_uri,
             'scopes': [
                 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
-                'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly'
+
+                'https://purl.imsglobal.org/',
+                'spec/lti-ags/scope/result.readonly',
+
+                'https://purl.imsglobal.org/'
+                'spec/lti-nrps/scope/contextmembership.readonly',
             ],
             'extensions': [
                 {


### PR DESCRIPTION
This should allow Mediathread to access course and user data through LTI: https://canvas.instructure.com/doc/api/names_and_role.html