### PR TITLE
Remove annotation title from Insert in Text button title

### DIFF
--- a/mediathread/templates/clientside/collection_assets.mustache
+++ b/mediathread/templates/clientside/collection_assets.mustache
@@ -156,7 +156,7 @@
                                                     <div>
                                                         {{#citable}}
                                                             <button class="btn btn-sm btn-warning materialCitation clickableCitation d-inline"
-                                                                title="{{#metadata.title}}{{{metadata.title}}}{{/metadata.title}}{{^metadata.title}}-Untitled-{{/metadata.title}}"
+                                                                title="-Untitled-"
                                                                 name="{{url}}" data-type="{{metadata.primary_type}}" data-range="{{range1}}">
                                                                 Insert in Text
                                                             </button>


### PR DESCRIPTION
This is breaking the template if the title has quotes in it.