### PR TITLE
Contact form: make course and category optional

### DIFF
--- a/mediathread/main/forms.py
+++ b/mediathread/main/forms.py
@@ -16,11 +16,11 @@ class ContactUsForm(forms.Form):
     name = forms.CharField(required=True, max_length=512)
     email = forms.EmailField(required=True)
     username = forms.CharField(required=False, max_length=512)
-    course = forms.CharField(required=True, max_length=512)
+    course = forms.CharField(required=False, max_length=512)
 
     issue_date = forms.DateTimeField(required=False)
 
-    category = forms.CharField(required=True, max_length=512)
+    category = forms.CharField(required=False, max_length=512)
 
     description = forms.CharField(widget=forms.Textarea, required=True)
 


### PR DESCRIPTION
These are usually pre-filled in anyways, but there's no reason they should be required for a contact request. I've also made some updates to our contact form template which is in the mediathread_deploy_specific git repo.