### PR TITLE
Remove @babel/eslint-parser

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from "eslint/config";
 import react from "eslint-plugin-react";
 import globals from "globals";
-import babelParser from "@babel/eslint-parser";
 import pluginCypress from 'eslint-plugin-cypress';
 
 export default defineConfig([
@@ -20,22 +19,21 @@ export default defineConfig([
         },
 
         languageOptions: {
-            globals: {
-                ...globals.browser,
-                ...globals.node,
-                ...globals.jquery,
-                Backbone: true,
-                _: true,
-            },
-
-            parser: babelParser,
-            ecmaVersion: 6,
-            sourceType: "module",
+            ecmaVersion: 'latest',
+            sourceType: 'module',
 
             parserOptions: {
                 ecmaFeatures: {
                     jsx: true,
                 },
+            },
+
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...globals.jquery,
+                Backbone: 'readonly',
+                _: 'readonly',
             },
         },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "devDependencies": {
         "@babel/cli": "^7.7.4",
         "@babel/core": "^7.7.4",
-        "@babel/eslint-parser": "^7.15.8",
         "@babel/preset-env": "^7.9.6",
         "@babel/preset-react": "^7.7.4",
         "@babel/runtime": "^7.12.5",
@@ -306,25 +305,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.5.tgz",
-      "integrity": "sha512-fcdRcWahONYo+JRnJg1/AekOacGvKx12Gu0qXJXFi2WBqQA1i7+O5PaxRB7kxE/Op94dExnCiiar6T09pvdHpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -3720,16 +3700,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
     },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
@@ -7213,16 +7183,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
-    "@babel/eslint-parser": "^7.15.8",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.7.4",
     "@babel/runtime": "^7.12.5",


### PR DESCRIPTION
This package is not needed, and removing it makes eslint upgrades easier.